### PR TITLE
JNI apparently caches stuff in a local reference table; it can only s…

### DIFF
--- a/src/jni/ArgConverter.cpp
+++ b/src/jni/ArgConverter.cpp
@@ -238,6 +238,7 @@ std::string ArgConverter::jstringToString(jstring value)
 	const char* chars = env.GetStringUTFChars(value, &f);
 	string s(chars);
 	env.ReleaseStringUTFChars(value, chars);
+	env.DeleteLocalRef(value);
 
 	return s;
 }
@@ -251,6 +252,7 @@ Handle<String> ArgConverter::jcharToV8String(jchar value)
 	const char* resP = env.GetStringUTFChars(str, &bol);
 	auto v8String = ConvertToV8String(resP, 1);
 	env.ReleaseStringUTFChars(str, resP);
+	env.DeleteLocalRef(str);
 	return v8String;
 }
 
@@ -268,7 +270,7 @@ Local<String> ArgConverter::jstringToV8String(jstring value)
 	jbyte *data = env.GetByteArrayElements(arr, nullptr);
 	auto v8String = ConvertToV8String((const char *)data, length);
 	env.ReleaseByteArrayElements(arr, data, JNI_ABORT);
-
+	env.DeleteLocalRef(arr);
 	return v8String;
 }
 

--- a/src/jni/ArrayElementAccessor.cpp
+++ b/src/jni/ArrayElementAccessor.cpp
@@ -56,6 +56,7 @@ Handle<Value> ArrayElementAccessor::GetArrayElement(const Handle<Object>& array,
 		const char* singleChar = env.GetStringUTFChars(s, &isCopy);
 		value = CheckForArrayAccessException(env, elementSignature, singleChar);
 		env.ReleaseStringUTFChars(s, singleChar);
+		env.DeleteLocalRef(s);
 	}
 	else if (elementSignature == "S")
 	{
@@ -133,6 +134,7 @@ void ArrayElementAccessor::SetArrayElement(const Handle<Object>& array, uint32_t
 		const char* singleChar = env.GetStringUTFChars(s, &isCopy);
 		jchar charElementValue = *singleChar;
 		env.ReleaseStringUTFChars(s, singleChar);
+		env.DeleteLocalRef(s);
 		jcharArray charArr = reinterpret_cast<jcharArray>(arr);
 		env.SetCharArrayRegion(charArr, index, 1, &charElementValue);
 	}

--- a/src/jni/ExceptionUtil.cpp
+++ b/src/jni/ExceptionUtil.cpp
@@ -89,6 +89,7 @@ void ExceptionUtil::GetExceptionMessage(JEnv& env, jthrowable exception, string&
 		}
 
 		env.ReleaseStringUTFChars(msg, msgStr);
+		env.DeleteLocalRef(msg);
 	}
 
 	for (jsize i = 0; i < framesLength; i++)
@@ -102,6 +103,7 @@ void ExceptionUtil::GetExceptionMessage(JEnv& env, jthrowable exception, string&
 		errMsg.append(msgStr);
 
 		env.ReleaseStringUTFChars(msg, msgStr);
+		env.DeleteLocalRef(msg);
 	}
 
 	if (nullptr != (jobjectArray) frames)

--- a/src/jni/FieldAccessor.cpp
+++ b/src/jni/FieldAccessor.cpp
@@ -110,6 +110,7 @@ Handle<Value> FieldAccessor::GetJavaField(const Handle<Object>& target, FieldCal
 				jboolean bol = true;
 				const char* resP = env.GetStringUTFChars(str, &bol);
 				env.ReleaseStringUTFChars(str, resP);
+				env.DeleteLocalRef(str);
 				fieldResult = handleScope.Escape(ConvertToV8String(resP, 1));
 				break;
 			}

--- a/src/jni/JEnv.cpp
+++ b/src/jni/JEnv.cpp
@@ -393,6 +393,9 @@ void JEnv::ReleaseStringUTFChars(jstring str, const char* utf)
 	m_env->ReleaseStringUTFChars(str, utf);
 }
 
+void JEnv::DeleteLocalRef(jstring str) {
+	m_env->DeleteLocalRef(str);
+}
 
 jint JEnv::Throw(jthrowable obj)
 {

--- a/src/jni/JsArgConverter.cpp
+++ b/src/jni/JsArgConverter.cpp
@@ -417,6 +417,7 @@ bool JsArgConverter::ConvertJavaScriptArray(JEnv& env, const Handle<Array>& jsAr
 				const char* singleChar = env.GetStringUTFChars(s, nullptr);
 				jchar value = *singleChar;
 				env.ReleaseStringUTFChars(s, singleChar);
+				env.DeleteLocalRef(s);
 				env.SetCharArrayRegion((jcharArray)arr, i, 1, &value);
 			}
 			break;

--- a/src/jni/NativeScriptRuntime.cpp
+++ b/src/jni/NativeScriptRuntime.cpp
@@ -312,6 +312,7 @@ void NativeScriptRuntime::CallJavaMethod(const Handle<Object>& caller, const str
 			jboolean bol = true;
 			const char* resP = env.GetStringUTFChars(str, &bol);
 			env.ReleaseStringUTFChars(str, resP);
+			env.DeleteLocalRef(str);
 			args.GetReturnValue().Set(ConvertToV8String(resP, 1));
 			break;
 		}
@@ -871,6 +872,7 @@ vector<string> NativeScriptRuntime::GetTypeMetadata(const string& name, int inde
 		const char *pc = env.GetStringUTFChars(s, nullptr);
 		result.push_back(string(pc));
 		env.ReleaseStringUTFChars(s, pc);
+		env.DeleteLocalRef(s);
 	}
 
 	return result;

--- a/src/jni/com_tns_Platform.cpp
+++ b/src/jni/com_tns_Platform.cpp
@@ -203,6 +203,7 @@ extern "C" void Java_com_tns_Platform_runNativeScript(JNIEnv *_env, jobject obj,
 	auto cmd = ConvertToV8String(code);
 
 	env.ReleaseStringUTFChars(appCode, code);
+	env.DeleteLocalRef(appCode);
 
 	DEBUG_WRITE("Compiling script");
 


### PR DESCRIPTION
…upports 512 items.   Doing some work in a loop that references a several variables can cause this table to exceed and then the app will crash with the following error:

JNI ERROR (app bug): local reference table overflow (max=512)
JNI local reference table (0xb9987968) dump:
Failed adding to JNI local ref table (has 512 entries)