### PR TITLE
refactored: classNameSeparator

### DIFF
--- a/binding-generator/Generator/src/com/tns/bindings/Dump.java
+++ b/binding-generator/Generator/src/com/tns/bindings/Dump.java
@@ -12,6 +12,8 @@ import android.util.Log;
 
 public class Dump
 {
+	public static final char CLASS_NAME_LOCATION_SEPARATOR = '_';
+	
 	private static final String callJsMethodSignatureCtor = "Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/String;Z[Ljava/lang/Object;";
 	private static final String callJsMethodSignatureMethod = "Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/String;[Ljava/lang/Object;";
 	private static final String LCOM_TNS = "Lcom/tns/gen/";
@@ -228,7 +230,7 @@ public class Dump
 		//String methodSignature = org.objectweb.asm.Type.getMethodDescriptor(Object.class.getMethods()[0]);
 		String tnsClassSignature = LCOM_TNS + 
 				classSignature.substring(1, classSignature.length() - 1).replace("$", "_")
-				+ "-" + proxyName + ";";
+				+ CLASS_NAME_LOCATION_SEPARATOR + proxyName + ";";
 		
 		ClassVisitor cv = generateClass(aw, classTo, classSignature, tnsClassSignature);
 		Method[] methods = getSupportedMethods(classTo, methodOverrides);

--- a/binding-generator/Generator/src/com/tns/bindings/ProxyGenerator.java
+++ b/binding-generator/Generator/src/com/tns/bindings/ProxyGenerator.java
@@ -53,7 +53,7 @@ public class ProxyGenerator
 		aw.visitEnd();
 		byte[] generatedBytes = aw.toByteArray();
 		
-		String proxyFileName = classToProxy.getName().replace('$', '_') + "-" + proxyName;
+		String proxyFileName = classToProxy.getName().replace('$', '_') + Dump.CLASS_NAME_LOCATION_SEPARATOR + proxyName;
 		if (proxyThumb != null)
 		{
 			proxyFileName += "-" + proxyThumb;

--- a/src/jni/Constants.h
+++ b/src/jni/Constants.h
@@ -8,6 +8,8 @@ public:
 
 	const static int PRIMITIVE_TYPE_OFFSET = 1;
 
+	const static char CLASS_NAME_LOCATION_SEPARATOR = '_';
+
 private:
 	Constants() {}
 };

--- a/src/jni/MetadataNode.cpp
+++ b/src/jni/MetadataNode.cpp
@@ -734,7 +734,7 @@ void MetadataNode::InterfaceConstructorCallback(const v8::FunctionCallbackInfo<v
 	SetInstanceMetadata(info.GetIsolate(), implementationObject, node);
 
 	//@@@ Refactor
-	auto fullName = className + "-" + extendNameAndLocation;
+	auto fullName = className + Constants::CLASS_NAME_LOCATION_SEPARATOR + extendNameAndLocation;
 	thiz->SetHiddenValue(ConvertToV8String("implClassName"), ConvertToV8String(fullName));
 	//
 
@@ -1073,7 +1073,7 @@ void MetadataNode::ExtendCallMethodHandler(const v8::FunctionCallbackInfo<v8::Va
 	DEBUG_WRITE("ExtendsCallMethodHandler: called with %s", ConvertToString(extendName).c_str());
 
 	auto extendNameAndLocation = extendLocation + ConvertToString(extendName);
-	auto fullClassName = node->m_name + '-' + extendNameAndLocation; //ConvertToString(extendName);
+	auto fullClassName = node->m_name + Constants::CLASS_NAME_LOCATION_SEPARATOR + extendNameAndLocation; //ConvertToString(extendName);
 	auto fullExtendedName = TNS_PREFIX + fullClassName;
 	DEBUG_WRITE("ExtendsCallMethodHandler: extend full name %s", fullClassName.c_str());
 
@@ -1162,8 +1162,8 @@ bool MetadataNode::GetExtendLocation(string& extendLocation)
 			}
 
 			string srcFileName = ConvertToString(scriptName);
-			std::replace(srcFileName.begin(), srcFileName.end(), '/', '-');
-			std::replace(srcFileName.begin(), srcFileName.end(), '.', '-');
+			std::replace(srcFileName.begin(), srcFileName.end(), '/', '_');
+			std::replace(srcFileName.begin(), srcFileName.end(), '.', '_');
 			int lineNumber = frame->GetLineNumber();
 			if (lineNumber < 0)
 			{
@@ -1186,7 +1186,7 @@ bool MetadataNode::GetExtendLocation(string& extendLocation)
 			}
 
 
-			extendLocationStream << "f" << srcFileName.c_str() << "-l" << lineNumber << "-c" << column << "--";
+			extendLocationStream << "f" << srcFileName.c_str() << "_l" << lineNumber << "_c" << column << "__";
 			//DEBUG_WRITE("EXTEND_LOCATION %s", extendLocationStream.str().c_str());
 		}
 	}

--- a/src/jni/NativeScriptRuntime.cpp
+++ b/src/jni/NativeScriptRuntime.cpp
@@ -565,7 +565,7 @@ jobject NativeScriptRuntime::CreateJavaInstance(int objectID, const std::string&
 int NativeScriptRuntime::GetCachedConstructorId(JEnv& env, const FunctionCallbackInfo<Value>& args, const string& name, const string& className, jobjectArray javaArgs, const Handle<Object>& implementationObject)
 {
 	int ctorId = -1;
-	string fullClassName = className + '-' + name;
+	string fullClassName = className + Constants::CLASS_NAME_LOCATION_SEPARATOR + name;
 	string encodedCtorArgs = MethodCache::EncodeSignature(fullClassName, "<init>", args, false);
 	auto itFound = s_constructorCache.find(encodedCtorArgs);
 

--- a/src/src/com/tns/DexFactory.java
+++ b/src/src/com/tns/DexFactory.java
@@ -27,6 +27,7 @@ import android.util.Log;
 public class DexFactory
 {
 	private static final String SECONDARY_DEX_FOLDER_NAME = "code_cache" + File.separator + "secondary-dexes";
+	private static final char CLASS_NAME_LOCATION_SEPARATOR = '_';
 
 	private String dexPath;
 	private String odexPath;
@@ -75,7 +76,7 @@ public class DexFactory
 			return NativeScriptActivity.class;
 		}
 		
-		String fullClassName = className.replace("$", "_") + "-" + name;
+		String fullClassName = className.replace("$", "_") + CLASS_NAME_LOCATION_SEPARATOR + name;
 		Class<?> existingClass = this.injectedDexClasses.get(fullClassName); 
 		if(existingClass != null)
 		{
@@ -83,7 +84,7 @@ public class DexFactory
 		}
 
 		String classToProxy = this.getClassToProxyName(className);
-		String dexFilePath = classToProxy + "-" + name;
+		String dexFilePath = classToProxy + CLASS_NAME_LOCATION_SEPARATOR + name;
 		File dexFile = this.getDexFile(dexFilePath);
 		
 		if (dexFile == null)
@@ -136,6 +137,7 @@ public class DexFactory
 	public Class<?> findClass(String className) throws ClassNotFoundException
 	{
 		String canonicalName = className.replace('/', '.');
+		Log.d("TNS_NATIVE", canonicalName);
 		Class<?> existingClass = this.injectedDexClasses.get(canonicalName);
 		if(existingClass != null)
 		{

--- a/test-app/assets/app/tests/tests.js
+++ b/test-app/assets/app/tests/tests.js
@@ -394,7 +394,7 @@ describe("Tests ", function () {
 		var button1 = new MyButton();
 		var button1Label = button1.toString();
 		
-		expect(button1Label.indexOf("com.tns.tests.Button1-")).not.toEqual(-1);
+		expect(button1Label.indexOf("com.tns.tests.Button1_")).not.toEqual(-1);
 		expect(button1Label.indexOf("MyButton")).not.toEqual(-1);
 		expect(button1Label.indexOf("success")).not.toEqual(-1);
 		

--- a/test-app/assets/app/tests/testsForTypescript.js
+++ b/test-app/assets/app/tests/testsForTypescript.js
@@ -112,8 +112,9 @@ describe("Tests typescript", function () {
 		
 	    var button = new MyButton2();
 	    var button1Label = button.superToString();
-	  	expect(button1Label.indexOf("com.tns.tests.Button1-")).not.toEqual(-1);
-	  	expect(button1Label.indexOf("-MyButton2")).not.toEqual(-1);
+	    
+	  	expect(button1Label.indexOf("com.tns.tests.Button1_")).not.toEqual(-1);
+	  	expect(button1Label.indexOf("_MyButton2")).not.toEqual(-1);
 	});
 	
 	it("When_creating_a_pure_typescript_inheritance_chain_it_should_work", function () {
@@ -289,8 +290,8 @@ describe("Tests typescript", function () {
 	      
 	    var button = new MyButton5();
 	    var button1Label = button.toString();
-	  	expect(button1Label.indexOf("com.tns.tests.Button1-")).not.toEqual(-1);
-		expect(button1Label.indexOf("-MyButton5")).not.toEqual(-1);
+	  	expect(button1Label.indexOf("com.tns.tests.Button1_")).not.toEqual(-1);
+		expect(button1Label.indexOf("_MyButton5")).not.toEqual(-1);
 	});
 	
 	it("When_extending_an_already_extended_object_it_should_throw_an_error", function () {


### PR DESCRIPTION
CLASS_NAME_LOCATION_SEPARATOR is now a constant in binding generator (in Dump.java)… and runtime (in Constants.h).
We do this because of java class naming conventions and to sync with future feature for AOT created classes for specific js user code.

changed tests so they can work with the new changes