### PR TITLE
fix: HTTP requests are executed serially instead of in parallel

### DIFF
--- a/src/src/com/tns/Async.java
+++ b/src/src/com/tns/Async.java
@@ -208,7 +208,7 @@ public class Async
 				options.screenWidth = metrics.widthPixels;
 				options.screenHeight = metrics.heightPixels;
 			}
-			new HttpRequestTask(callback, context).execute(options);
+			new HttpRequestTask(callback, context).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, options);
 		}
 
 		static class HttpRequestTask extends AsyncTask<RequestOptions, Void, RequestResult>


### PR DESCRIPTION
When first introduced, AsyncTasks were executed serially on a single background thread. Starting with DONUT, this was changed to a pool of threads allowing multiple tasks to operate in parallel. Starting with HONEYCOMB, tasks are executed on a single thread to avoid common application errors caused by parallel execution.

If you truly want parallel execution, you can invoke executeOnExecutor(java.util.concurrent.Executor, Object[]) with THREAD_POOL_EXECUTOR.