### PR TITLE
use byte array temp buffer for copying the image data from the response

### DIFF
--- a/src/src/com/tns/Async.java
+++ b/src/src/com/tns/Async.java
@@ -111,7 +111,9 @@ public class Async
 			    }
 			}
 			
+			public ByteArrayOutputStream raw;
 			public ArrayList<KeyValuePair> headers = new ArrayList<KeyValuePair>();
+			public int statusCode;
 			public String responseAsString;
 			public Bitmap responseAsImage;
 			public Exception error;
@@ -136,12 +138,12 @@ public class Async
 
 			public void readResponseStream(HttpURLConnection connection, Stack<Closeable> openedStreams, RequestOptions options) throws IOException
 			{
-				int statusCode = connection.getResponseCode();
+				this.statusCode = connection.getResponseCode();
 
 				int contentLength = connection.getContentLength();
 				
 				InputStream inStream;
-				if (statusCode >= 400)
+				if (this.statusCode >= 400)
 				{
 					inStream = connection.getErrorStream();
 				}
@@ -163,6 +165,8 @@ public class Async
 				{
 					responseStream.write(buff, 0, read);
 				}
+				
+				this.raw = responseStream;
 				buff = null;
 				
 				// make the byte array conversion here, not in the JavaScript

--- a/src/src/com/tns/Async.java
+++ b/src/src/com/tns/Async.java
@@ -92,9 +92,26 @@ public class Async
 
 		public static class RequestResult
 		{
-			public ByteArrayOutputStream raw;
+			public static final class ByteArrayOutputStream2 extends java.io.ByteArrayOutputStream 
+			{
+			    public ByteArrayOutputStream2()
+			    {
+			    	super(); 
+			    }
+			    
+			    public ByteArrayOutputStream2(int size) 
+			    { 
+			    	super(size); 
+			    }
+
+			    /** Returns the internal buffer of this ByteArrayOutputStream, without copying. */
+			    public synchronized byte[] buf()
+			    {
+			        return this.buf;
+			    }
+			}
+			
 			public ArrayList<KeyValuePair> headers = new ArrayList<KeyValuePair>();
-			public int statusCode;
 			public String responseAsString;
 			public Bitmap responseAsImage;
 			public Exception error;
@@ -119,10 +136,12 @@ public class Async
 
 			public void readResponseStream(HttpURLConnection connection, Stack<Closeable> openedStreams, RequestOptions options) throws IOException
 			{
-				this.statusCode = connection.getResponseCode();
+				int statusCode = connection.getResponseCode();
 
+				int contentLength = connection.getContentLength();
+				
 				InputStream inStream;
-				if (this.statusCode >= 400)
+				if (statusCode >= 400)
 				{
 					inStream = connection.getErrorStream();
 				}
@@ -131,36 +150,34 @@ public class Async
 					inStream = connection.getInputStream();
 				}
 				openedStreams.push(inStream);
-
-				BufferedInputStream buffer = new java.io.BufferedInputStream(inStream);
+				
+				BufferedInputStream buffer = new java.io.BufferedInputStream(inStream, 4096);
 				openedStreams.push(buffer);
 
-				ByteArrayOutputStream responseStream = new java.io.ByteArrayOutputStream();
+				ByteArrayOutputStream2 responseStream = contentLength != -1 ? new ByteArrayOutputStream2(contentLength) : new ByteArrayOutputStream2();
 				openedStreams.push(responseStream);
 
-				int readByte = -1;
-				while ((readByte = buffer.read()) != -1)
+				byte[] buff = new byte[4096];
+				int read = -1;
+				while ((read = buffer.read(buff, 0, buff.length)) != -1)
 				{
-					responseStream.write(readByte);
+					responseStream.write(buff, 0, read);
 				}
-
-				this.raw = responseStream;
-
+				buff = null;
+				
 				// make the byte array conversion here, not in the JavaScript
 				// world for better performance
 				// since we do not have some explicit way to determine whether
-				// the content-type is image,
-				// we will do it the dumb way :)
+				// the content-type is image
 				try
 				{
 					// TODO: Generally this approach will not work for very
 					// large files
 					BitmapFactory.Options bitmapOptions = new BitmapFactory.Options();
 					bitmapOptions.inJustDecodeBounds = true;
-					byte[] bytes = this.raw.toByteArray();
-
+					
 					// check the size of the bitmap first
-					BitmapFactory.decodeByteArray(bytes, 0, bytes.length, bitmapOptions);
+					BitmapFactory.decodeByteArray(responseStream.buf(), 0, responseStream.size(), bitmapOptions);
 					if (bitmapOptions.outWidth > 0 && bitmapOptions.outHeight > 0)
 					{
 						int scale = 1;
@@ -182,7 +199,7 @@ public class Async
 
 						bitmapOptions.inJustDecodeBounds = false;
 						bitmapOptions.inSampleSize = scale;
-						this.responseAsImage = BitmapFactory.decodeByteArray(bytes, 0, bytes.length, bitmapOptions);
+						this.responseAsImage = BitmapFactory.decodeByteArray(responseStream.buf(), 0, responseStream.size(), bitmapOptions);
 					}
 				}
 				catch (Exception e)
@@ -194,7 +211,7 @@ public class Async
 				if (this.responseAsImage == null)
 				{
 					// convert to string
-					this.responseAsString = this.raw.toString();
+					this.responseAsString = responseStream.toString();
 				}
 			}
 		}


### PR DESCRIPTION
use the ByteArrayOutputStream's internal buffer to skip creating a second array in memory