### PR TITLE
Reimplemented generate-metadata with nodejs so it supports windows ma…

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -11,16 +11,25 @@ module.exports = function(grunt) {
         grunt.log.error("The GIT_COMMIT is not set. This NativeScript Android Runtime will not be tagged with the git commit it is build from\n");
     }
     
-    //if (process.env.JAVA_HOME === "" || process.env.GIT_COMMIT === undefined)
-    //{
-    //    grunt.fail.fatal("The JAVA_HOME is not set. Set the JAVA_HOME to JDK7 or JDK8");
-    //}
+    grunt.util.spawn({ cmd: "ndk-build --version" }, 
+    	function doneFunction(error, result, code) 
+    	{
+    		if (error)
+        {
+            grunt.fail.fatal("ndk-build command not found. Set the PATH variable to include the path to Android NDK directory. \n");
+        }
+    	}
+    );
     
-    //if (process.env.JAVA_HOME.indexof("jdk1.7") === -1 && process.env.JAVA_HOME.indexof("jdk1.8") === -1)
-    //{
-    //    grunt.fail.fatal("The JAVA_HOME is set to unsupported jdk version. Set the JAVA_HOME to JDK7 or JDK8 directory");
-    //}
-    
+    grunt.util.spawn({ cmd: "android -h" }, 
+    	function doneFunction(error, result, code) 
+    	{
+    		if (error)
+        {
+            grunt.fail.fatal("android command not found. Set the PATH variable to include the path to Android SDK directory. \n");
+        }
+    	}
+    );
     
     var pathModule = require("path");
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,9 +1,42 @@
 module.exports = function(grunt) {
 
+
+    if (process.env.ANDROID_HOME === "" || process.env.ANDROID_HOME === undefined)
+    {
+        grunt.fail.fatal("Set ANDROID_HOME to point to the correct Android SDK location\n");
+    }
+    
+    if (process.env.GIT_COMMIT === "" || process.env.GIT_COMMIT === undefined)
+    {
+        grunt.log.error("The GIT_COMMIT is not set. This NativeScript Android Runtime will not be tagged with the git commit it is build from\n");
+    }
+    
+    //if (process.env.JAVA_HOME === "" || process.env.GIT_COMMIT === undefined)
+    //{
+    //    grunt.fail.fatal("The JAVA_HOME is not set. Set the JAVA_HOME to JDK7 or JDK8");
+    //}
+    
+    //if (process.env.JAVA_HOME.indexof("jdk1.7") === -1 && process.env.JAVA_HOME.indexof("jdk1.8") === -1)
+    //{
+    //    grunt.fail.fatal("The JAVA_HOME is set to unsupported jdk version. Set the JAVA_HOME to JDK7 or JDK8 directory");
+    //}
+    
+    
     var pathModule = require("path");
 
     var outDir = "./dist";
     var rootDir = ".";
+    
+    if (process.platform === "win32")
+    {
+        var destinationPackageJsonFileName = rootDir + "/src/package.json"
+        var sourcePackageJsonFileName = rootDir + "/package.json";
+        grunt.log.error("This is windows machine. Coping " + sourcePackageJsonFileName + " to " + destinationPackageJsonFileName + " \n");
+        //delete package.json dummy file in src dir
+        grunt.file.delete(destinationPackageJsonFileName);
+        //copy package.json over to the src dir
+        grunt.file.copy(sourcePackageJsonFileName, destinationPackageJsonFileName);
+    }
 
     var args = {
         metadataGen: grunt.option("metadataGen") || "../android-metadata-generator/dist/tns-android-metadata-generator-0.0.1.tgz",
@@ -60,7 +93,7 @@ module.exports = function(grunt) {
     };
 
     localCfg.packageVersion = getPackageVersion(localCfg.packageJsonFilePath);
-
+    
     grunt.initConfig({
         pkg: grunt.file.readJSON(rootDir + "/package.json"),
         clean: {
@@ -194,7 +227,7 @@ module.exports = function(grunt) {
                 cmd: "npm install " + localCfg.metadataGenPath
             },
             runMetadataGenerator: {
-                cmd: pathModule.normalize("./node_modules/.bin/generate-metadata") + " " + localCfg.libsDir + " ./dist/framework/assets/metadata"
+                cmd: pathModule.normalize("\"node_modules/.bin/generate-metadatajs\"") + " " + localCfg.libsDir + " ./dist/framework/assets/metadata"
             },
 			runTests: {
 				cmd: "npm install && grunt --verbose",

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,5 +1,9 @@
 module.exports = function(grunt) {
 
+    if (process.env.JAVA_HOME === "" || process.env.JAVA_HOME === undefined)
+    {
+        grunt.fail.fatal("Set JAVA_HOME to point to the correct Jdk location\n");
+    }
 
     if (process.env.ANDROID_HOME === "" || process.env.ANDROID_HOME === undefined)
     {
@@ -10,25 +14,40 @@ module.exports = function(grunt) {
     {
         grunt.log.error("The GIT_COMMIT is not set. This NativeScript Android Runtime will not be tagged with the git commit it is build from\n");
     }
+
+    if (!grunt.option("metadataGenSrc") && !grunt.file.exists("../android-metadata-generator"))
+    {
+        grunt.fail.fatal("../android-metadata-generator directory not found and no metadataGenSrc option specified. Clone the android-metadata-generator repo first.\n");
+    }
     
-    grunt.util.spawn({ cmd: "ndk-build --version" }, 
+    grunt.util.spawn({ cmd: "ndk-build" , args: ["--version"] }, 
     	function doneFunction(error, result, code) 
     	{
-    		if (error)
-        {
-            grunt.fail.fatal("ndk-build command not found. Set the PATH variable to include the path to Android NDK directory. \n");
-        }
+    		if (code !== 0)
+            {
+                grunt.fail.fatal("ndk-build command not found. Set the PATH variable to include the path to Android NDK directory.\nError: " + result.stdout  + "\n" + result.stderr + " \nCode:" + code);
+            }
     	}
     );
     
-    grunt.util.spawn({ cmd: "android -h" }, 
+    grunt.util.spawn({ cmd: "android", args: ["-h"] }, 
     	function doneFunction(error, result, code) 
     	{
-    		if (error)
-        {
-            grunt.fail.fatal("android command not found. Set the PATH variable to include the path to Android SDK directory. \n");
-        }
+    		if (code !== 1) //1 is ok result for android tool
+            {
+                grunt.fail.fatal("android command not found. Set the PATH variable to include the path to Android SDK Tools directory.\nError: " + result.stdout  + "\n" + result.stderr + " \nCode:" + code);
+            }
     	}
+    );
+
+    grunt.util.spawn({ cmd: "ant", args: ["--version"] }, 
+        function doneFunction(error, result, code) 
+        {
+            if (code !== 1) //1 is ok result for ant
+            {
+                grunt.fail.fatal("Apache ant command not found. Set the PATH variable to include the path to Ant bin directory.\nError: " + result.stdout  + "\n" + result.stderr + " \nCode:" + code);
+            }
+        }
     );
     
     var pathModule = require("path");

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -20,6 +20,11 @@ module.exports = function(grunt) {
         grunt.fail.fatal("../android-metadata-generator directory not found and no metadataGenSrc option specified. Clone the android-metadata-generator repo first.\n");
     }
     
+    if (!grunt.option("metadataGen") && !grunt.file.exists("../android-metadata-generator/dist/tns-android-metadata-generator-0.0.1.tgz"))
+    {
+        grunt.fail.fatal("android-metadata-generator build output not found and no metadataGen option specified. Build android-metadata-generator first.\n");
+    }
+    
     grunt.util.spawn({ cmd: "ndk-build" , args: ["--version"] }, 
     	function doneFunction(error, result, code) 
     	{
@@ -33,7 +38,10 @@ module.exports = function(grunt) {
     grunt.util.spawn({ cmd: "android", args: ["-h"] }, 
     	function doneFunction(error, result, code) 
     	{
-    		if (code !== 1) //1 is ok result for android tool
+    		var successResult = process.platform === "win32" ? 0 : 1;
+    		
+    		
+    		if (code !== successResult) //1 is ok result for android tool
             {
                 grunt.fail.fatal("android command not found. Set the PATH variable to include the path to Android SDK Tools directory.\nError: " + result.stdout  + "\n" + result.stderr + " \nCode:" + code);
             }
@@ -43,7 +51,8 @@ module.exports = function(grunt) {
     grunt.util.spawn({ cmd: "ant", args: ["--version"] }, 
         function doneFunction(error, result, code) 
         {
-            if (code !== 1) //1 is ok result for ant
+            var successResult = 1;
+            if (code !== successResult) //1 is ok result for ant
             {
                 grunt.fail.fatal("Apache ant command not found. Set the PATH variable to include the path to Ant bin directory.\nError: " + result.stdout  + "\n" + result.stderr + " \nCode:" + code);
             }
@@ -245,7 +254,7 @@ module.exports = function(grunt) {
             },
             generateRuntime: {
                 cmd: "npm install && grunt --verbose",
-                cwd: "./src"
+                cwd: pathModule.normalize("./src")
             },
             buildMetadataGenerator: {
                 cmd: "npm install && grunt --verbose",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "grunt-contrib-copy": "0.5.0",
     "grunt-exec": "0.4.6",
     "grunt-mkdir": "0.1.2",
-    "grunt-replace": "0.7.9"
+    "grunt-replace": "0.7.9",
+    "node-fs" : "0.1.7" 
   }
 }

--- a/src/custom_rules.xml
+++ b/src/custom_rules.xml
@@ -3,7 +3,15 @@
     name="android-runtime-custom-rules"
     default="help" >
 
+
+    <condition property="supportedJavaVersion">
+      <or>
+       <equals arg1="1.7" arg2="${ant.java.version}"/>
+       <equals arg1="1.8" arg2="${ant.java.version}"/>
+      </or>
+    </condition>
     
+    <fail message="Java 1.7 or newer is required. Check if the JAVA_HOME environment variable points to JDK 1.7 or newer" unless="supportedJavaVersion"/>
     
     
     <!--Generating executable jar-->

--- a/src/gruntfile.js
+++ b/src/gruntfile.js
@@ -131,9 +131,7 @@ module.exports = function(grunt) {
                 cmd: "git checkout -- ./manifest.mf"
             },
             jarJavaRuntime: {
-                //cmd: "jar cfm ../../" + "/dist/libs/nativescript.jar ../../manifest.mf com",
                 cmd: "\"" + process.env.JAVA_HOME + "/bin/jar\""  + " umf ./manifest.mf ./bin/NativeScriptRuntime.jar"
-                //,cwd: pathModule.join(localCfg.rootDir, "/bin/classes")
             }
         }
     });

--- a/src/gruntfile.js
+++ b/src/gruntfile.js
@@ -132,7 +132,7 @@ module.exports = function(grunt) {
             },
             jarJavaRuntime: {
                 //cmd: "jar cfm ../../" + "/dist/libs/nativescript.jar ../../manifest.mf com",
-                cmd: "jar umf ./manifest.mf ./bin/NativeScriptRuntime.jar"
+                cmd: "\"" + process.env.JAVA_HOME + "/bin/jar\""  + " umf ./manifest.mf ./bin/NativeScriptRuntime.jar"
                 //,cwd: pathModule.join(localCfg.rootDir, "/bin/classes")
             }
         }


### PR DESCRIPTION
…chines better

Check for set ANDROID_HOME, GIT_COMMIT and JAVA_HOME environment variables and produce errors and warnings if not
Check for supported java version in android runtime ant build (1.7 or 1.8)
Copy over the package.json to /src directory to fix windows grunt build of android runtime
Fixed java manifest update command to include the full path of the jar tool

Added node-fs as devDependency to android-runtime