### PR TITLE
Gatanasov/code cache

### DIFF
--- a/src/jni/Android.mk
+++ b/src/jni/Android.mk
@@ -72,7 +72,7 @@ LOCAL_SRC_FILES := com_tns_AssetExtractor.cpp com_tns_Platform.cpp com_tns_JsDeb
 					FieldAccessor.cpp ArrayElementAccessor.cpp \
 					ExceptionUtil.cpp Util.cpp Logger.cpp Profiler.cpp \
 					ObjectManager.cpp NumericCasts.cpp WeakRef.cpp \
-					MetadataMethodInfo.cpp SimpleProfiler.cpp JType.cpp File.cpp Require.cpp
+					MetadataMethodInfo.cpp SimpleProfiler.cpp JType.cpp File.cpp Require.cpp Constants.cpp
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/include
 LOCAL_LDLIBS    := -llog -landroid -lz
 ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)

--- a/src/jni/ArgConverter.h
+++ b/src/jni/ArgConverter.h
@@ -37,22 +37,6 @@ namespace tns
 
 		static bool ReadJStringInBuffer(jstring value, jsize& utfLength);
 
-		static jlong ObjectToLong(jobject object);
-
-		static jboolean ObjectToBoolean(jobject object);
-
-		static jchar ObjectToChar(jobject object);
-
-		static jbyte ObjectToByte(jobject object);
-
-		static jshort ObjectToShort(jobject object);
-
-		static jint ObjectToInt(jobject object);
-
-		static jfloat ObjectToFloat(jobject object);
-
-		static jdouble ObjectToDouble(jobject object);
-
 		static jstring ObjectToString(jobject object);
 
 		static v8::Local<v8::String> jcharToV8String(jchar value);

--- a/src/jni/Constants.cpp
+++ b/src/jni/Constants.cpp
@@ -1,0 +1,12 @@
+/*
+ * Constants.cpp
+ *
+ *  Created on: Nov 6, 2015
+ *      Author: gatanasov
+ */
+
+#include "Constants.h"
+
+std::string Constants::APP_ROOT_FOLDER_PATH = "";
+bool Constants::V8_CACHE_COMPILED_CODE = false;
+std::string Constants::V8_STARTUP_FLAGS = "";

--- a/src/jni/Constants.h
+++ b/src/jni/Constants.h
@@ -1,6 +1,8 @@
 #ifndef CONSTANTS_H_
 #define CONSTANTS_H_
 
+#include <string>
+
 class Constants
 {
 public:
@@ -11,6 +13,10 @@ public:
 	const static char CLASS_NAME_LOCATION_SEPARATOR = '_';
 
 	static std::string APP_ROOT_FOLDER_PATH;
+
+	static std::string V8_STARTUP_FLAGS;
+
+	static bool V8_CACHE_COMPILED_CODE;
 
 private:
 	Constants() {}

--- a/src/jni/File.cpp
+++ b/src/jni/File.cpp
@@ -7,11 +7,17 @@
 
 #include "File.h"
 #include <sstream>
+#include <fstream>
 
 using namespace std;
 
 namespace tns
 {
+	bool File::Exists(const string& path)
+	{
+		std::ifstream infile(path.c_str());
+		return infile.good();
+	}
 	string File::ReadText(const string& filePath)
 	{
 		int len;

--- a/src/jni/File.h
+++ b/src/jni/File.h
@@ -17,6 +17,7 @@ namespace tns
 		public:
 			static const char* ReadText(const std::string& filePath, int& length, bool& isNew);
 			static std::string ReadText(const std::string& filePath);
+			static bool Exists(const std::string& filePath);
 		private:
 			static const int BUFFER_SIZE = 1024 * 1024;
 			static char* Buffer;

--- a/src/jni/JniLocalRef.cpp
+++ b/src/jni/JniLocalRef.cpp
@@ -1,4 +1,5 @@
 #include "JniLocalRef.h"
+#include "JType.h"
 #include <cassert>
 
 using namespace v8;
@@ -68,6 +69,12 @@ JniLocalRef::operator jstring() const
 JniLocalRef::operator jclass() const
 {
 	return (jclass)m_obj;
+}
+
+JniLocalRef::operator jboolean() const
+{
+	JEnv env;
+	return JType::BooleanValue(env, m_obj);
 }
 
 

--- a/src/jni/JniLocalRef.h
+++ b/src/jni/JniLocalRef.h
@@ -25,6 +25,8 @@ namespace tns
 
 		operator jobject() const;
 
+		operator jboolean() const;
+
 		operator jclass() const;
 
 		operator jstring() const;

--- a/src/jni/NativeScriptRuntime.h
+++ b/src/jni/NativeScriptRuntime.h
@@ -70,13 +70,9 @@ namespace tns
 
 		static void AppFail(jthrowable throwable, const char *message);
 
-		static void RequireCallback(const v8::FunctionCallbackInfo<v8::Value>& args);
-
 		static void CreateGlobalCastFunctions(const v8::Local<v8::ObjectTemplate>& globalTemplate);
 
 		static std::vector<std::string> GetTypeMetadata(const std::string& name, int index);
-
-		static void AddApplicationModule(const std::string& appName, v8::Persistent<v8::Object>* applicationModule);
 
 		static jobjectArray GetMethodOverrides(JEnv& env, const v8::Local<v8::Object>& implementationObject);
 
@@ -90,20 +86,13 @@ namespace tns
 
 		static void CreateTopLevelNamespaces(const v8::Local<v8::Object>& global);
 
-		static void CompileAndRun(std::string modulePath, bool& hasError, v8::Local<v8::Object>& moduleObj);
-
 		static v8::Local<v8::Object> FindClass(const std::string& className);
 
 		static MetadataTreeNode *metadataRoot;
 
 		static jclass PlatformClass;
 
-		static jclass RequireClass;
-
 		static jclass JAVA_LANG_STRING;
-
-		static std::string APP_FILES_DIR;
-
 		//
 
 	private:
@@ -125,8 +114,6 @@ namespace tns
 
 		static jmethodID APP_FAIL_METHOD_ID;
 
-		static jmethodID GET_MODULE_PATH_METHOD_ID;
-
 		static jmethodID GET_TYPE_METADATA;
 
 		static jmethodID ENABLE_VERBOSE_LOGGING_METHOD_ID;
@@ -134,8 +121,6 @@ namespace tns
 		static jmethodID DISABLE_VERBOSE_LOGGING_METHOD_ID;
 
 		static jmethodID GET_CHANGE_IN_BYTES_OF_USED_MEMORY_METHOD_ID;
-
-		static std::map<std::string, v8::Persistent<v8::Object>*> loadedModules;
 
 		static NumericCasts castFunctions;
 

--- a/src/jni/Require.cpp
+++ b/src/jni/Require.cpp
@@ -8,6 +8,10 @@
 #include "File.h"
 #include "V8GlobalHelpers.h"
 #include "NativeScriptAssert.h"
+#include "SimpleProfiler.h"
+#include "ExceptionUtil.h"
+#include "JniLocalRef.h"
+#include "ArgConverter.h"
 
 #include <sstream>
 
@@ -16,7 +20,17 @@ using namespace std;
 
 namespace tns
 {
-	Local<String> Require::LoadModule(const string& path)
+	void Require::Init()
+	{
+		JEnv env;
+
+		RequireClass = env.FindClass("com/tns/Require");
+		assert(RequireClass != nullptr);
+
+		GET_MODULE_PATH_METHOD_ID = env.GetStaticMethodID(RequireClass, "getModulePath", "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;");
+		assert(GET_MODULE_PATH_METHOD_ID != nullptr);
+	}
+	Local<String> Require::LoadScriptText(const string& path)
 	{
 		string content = File::ReadText(path);
 
@@ -36,8 +50,203 @@ namespace tns
 		return ConvertToV8String(result);
 	}
 
+	void Require::Callback(const v8::FunctionCallbackInfo<v8::Value>& args)
+	{
+		SET_PROFILER_FRAME();
+
+		ASSERT_MESSAGE(args.Length() == 2, "require should be called with two parameters");
+		ASSERT_MESSAGE(!args[0]->IsUndefined() && !args[0]->IsNull(), "require called with undefined moduleName parameter");
+		ASSERT_MESSAGE(!args[1]->IsUndefined() && !args[1]->IsNull(), "require called with undefined callingModulePath parameter");
+		ASSERT_MESSAGE(args[0]->IsString(), "require should be called with string parameter");
+		ASSERT_MESSAGE(args[1]->IsString(), "require should be called with string parameter");
+
+		string moduleName = ConvertToString(args[0].As<String>());
+		string callingModuleDirName = ConvertToString(args[1].As<String>());
+
+		JEnv env;
+		JniLocalRef jsModulename(env.NewStringUTF(moduleName.c_str()));
+		JniLocalRef jsCallingModuleDirName(env.NewStringUTF(callingModuleDirName.c_str()));
+		JniLocalRef jsModulePath(env.CallStaticObjectMethod(RequireClass, GET_MODULE_PATH_METHOD_ID, (jstring) jsModulename, (jstring) jsCallingModuleDirName));
+
+		// cache the required modules by full path, not name only, since there might be some collisions with relative paths and names
+		string modulePath = ArgConverter::jstringToString((jstring) jsModulePath);
+
+		if(modulePath == ""){
+			// module not found
+			stringstream ss;
+			ss << "Module \"" << moduleName << "\" not found";
+			string exception = ss.str();
+			ExceptionUtil::GetInstance()->ThrowExceptionToJs(exception);
+			return;
+		}
+		if (modulePath == "EXTERNAL_FILE_ERROR")
+		{
+			// module not found
+			stringstream ss;
+			ss << "Module \"" << moduleName << "\" is located on the external storage. Modules can be private application files ONLY";
+			string exception = ss.str();
+			ExceptionUtil::GetInstance()->ThrowExceptionToJs(exception);
+			return;
+		}
+
+		auto it = loadedModules.find(modulePath);
+
+		Local<Object> moduleObj;
+		bool hasError = false;
+
+		if (it == loadedModules.end())
+		{
+			moduleObj = CompileAndRun(modulePath, hasError);
+		}
+		else
+		{
+			moduleObj = Local<Object>::New(Isolate::GetCurrent(), *((*it).second));
+		}
+
+		if(!hasError){
+			args.GetReturnValue().Set(moduleObj);
+		}
+	}
+
+	Local<Object> Require::CompileAndRun(const string& path, bool& hasError)
+	{
+		auto isolate = Isolate::GetCurrent();
+
+		Local<Value> exportObj = Object::New(isolate);
+		Persistent<Object>* persistentExportObj = new Persistent<Object>(isolate, exportObj.As<Object>());
+		loadedModules.insert(make_pair(path, persistentExportObj));
+
+		TryCatch tc;
+		Local<Object> moduleObj;
+
+		auto scriptText = LoadScriptText(path);
+
+		DEBUG_WRITE("Compiling script (module %s)", path.c_str());
+		auto v8Path = ConvertToV8String(path);
+
+		auto cacheData = TryLoadScriptCache(path);
+
+		ScriptOrigin origin(v8Path);
+		ScriptCompiler::Source source(scriptText, origin, cacheData);
+		ScriptCompiler::CompileOptions option = ScriptCompiler::kNoCompileOptions;
+		Local<Script> script;
+
+		if(cacheData != nullptr)
+		{
+			option = ScriptCompiler::kConsumeCodeCache;
+			script = ScriptCompiler::Compile(isolate->GetCurrentContext(), &source, option).ToLocalChecked();
+		}
+		else
+		{
+			option = ScriptCompiler::kProduceCodeCache;
+			script = ScriptCompiler::Compile(isolate->GetCurrentContext(), &source, option).ToLocalChecked();
+			SaveScriptCache(source, path);
+		}
+
+		DEBUG_WRITE("Compiled script (module %s)", path.c_str());
+
+		if (ExceptionUtil::GetInstance()->HandleTryCatch(tc, "Script " + path + " contains compilation errors!"))
+		{
+			hasError = true;
+		}
+		else if (script.IsEmpty())
+		{
+			//think about more descriptive message -> [script_name] was empty
+			DEBUG_WRITE("%s was empty", path.c_str());
+		}
+		else
+		{
+			DEBUG_WRITE("Running script (module %s)", path.c_str());
+
+			auto f = script->Run().As<Function>();
+			if (ExceptionUtil::GetInstance()->HandleTryCatch(tc, "Error running script " + path))
+			{
+				hasError = true;
+			}
+			else
+			{
+				auto result = f->Call(Object::New(isolate), 1, &exportObj);
+				if(ExceptionUtil::GetInstance()->HandleTryCatch(tc, "Error calling module function "))
+				{
+					hasError = true;
+				}
+				else
+				{
+					moduleObj = result.As<Object>();
+					if (moduleObj.IsEmpty())
+					{
+						auto objectTemplate = ObjectTemplate::New();
+						moduleObj = objectTemplate->NewInstance();
+					}
+
+					DEBUG_WRITE("Script completed (module %s)", path.c_str());
+
+					if (!moduleObj->StrictEquals(exportObj))
+					{
+						loadedModules.erase(path);
+						persistentExportObj->Reset();
+						delete persistentExportObj;
+
+						auto persistentModuleObject = new Persistent<Object>(isolate, moduleObj);
+						loadedModules.insert(make_pair(path, persistentModuleObject));
+					}
+				}
+			}
+		}
+
+		if(hasError)
+		{
+			loadedModules.erase(path);
+			persistentExportObj->Reset();
+			delete persistentExportObj;
+
+			// this handles recursive require calls
+			tc.ReThrow();
+		}
+		else
+		{
+			return moduleObj;
+		}
+	}
+
+	ScriptCompiler::CachedData* Require::TryLoadScriptCache(const std::string& path)
+	{
+		auto cachePath = path + ".cache";
+		if(!File::Exists(cachePath))
+		{
+			return nullptr;
+		}
+
+		auto file = fopen(cachePath.c_str(), "rb" /* read binary */);
+		fseek(file, 0, SEEK_END);
+		auto size = ftell(file);
+		rewind(file);
+
+		uint8_t* data = new uint8_t[size];
+		fread(data, sizeof(uint8_t), size, file);
+
+		auto cache = new ScriptCompiler::CachedData(data, size, ScriptCompiler::CachedData::BufferOwned);
+
+		fclose(file);
+
+		return cache;
+	}
+
+	void Require::SaveScriptCache(const ScriptCompiler::Source& source, const std::string& path)
+	{
+		int length = source.GetCachedData()->length;
+		auto cachePath = path + ".cache";
+		auto file = fopen(cachePath.c_str(), "wb" /* write binary */);
+		fwrite(source.GetCachedData()->data, sizeof(uint8_t), length, file);
+		fclose(file);
+	}
+
 	const char* Require::MODULE_PART_1 = "(function(){\n var module = {}; module.exports = arguments[0]; var exports = module.exports; var __dirname = \"";
 	const char* Require::MODULE_PART_2 = "\"; var __filename = \"";
 	const char* Require::MODULE_PART_3 = "\"; function require(moduleName){ return __global.require(moduleName, __dirname); } module.filename = __filename; this.__extends = __global.__extends; \n";
 	const char* Require::MODULE_PART_4 = "\n return module.exports; \n})";
+
+	map<string, Persistent<Object>*> Require::loadedModules;
+	jmethodID Require::GET_MODULE_PATH_METHOD_ID = nullptr;
+	jclass Require::RequireClass = nullptr;
 }

--- a/src/jni/Require.cpp
+++ b/src/jni/Require.cpp
@@ -12,6 +12,7 @@
 #include "ExceptionUtil.h"
 #include "JniLocalRef.h"
 #include "ArgConverter.h"
+#include "Constants.h"
 
 #include <sstream>
 
@@ -222,6 +223,11 @@ namespace tns
 
 	ScriptCompiler::CachedData* Require::TryLoadScriptCache(const std::string& path)
 	{
+		if(!Constants::V8_CACHE_COMPILED_CODE)
+		{
+			return nullptr;
+		}
+
 		auto cachePath = path + ".cache";
 		if(!File::Exists(cachePath))
 		{

--- a/src/jni/Require.cpp
+++ b/src/jni/Require.cpp
@@ -150,7 +150,10 @@ namespace tns
 		}
 		else
 		{
-			option = ScriptCompiler::kProduceCodeCache;
+			if(Constants::V8_CACHE_COMPILED_CODE)
+			{
+				option = ScriptCompiler::kProduceCodeCache;
+			}
 			script = ScriptCompiler::Compile(isolate->GetCurrentContext(), &source, option).ToLocalChecked();
 			SaveScriptCache(source, path);
 		}

--- a/src/jni/Require.cpp
+++ b/src/jni/Require.cpp
@@ -254,6 +254,11 @@ namespace tns
 
 	void Require::SaveScriptCache(const ScriptCompiler::Source& source, const std::string& path)
 	{
+		if(!Constants::V8_CACHE_COMPILED_CODE)
+		{
+			return;
+		}
+
 		int length = source.GetCachedData()->length;
 		auto cachePath = path + ".cache";
 		auto file = fopen(cachePath.c_str(), "wb" /* write binary */);

--- a/src/jni/Require.cpp
+++ b/src/jni/Require.cpp
@@ -54,11 +54,22 @@ namespace tns
 	{
 		SET_PROFILER_FRAME();
 
-		ASSERT_MESSAGE(args.Length() == 2, "require should be called with two parameters");
-		ASSERT_MESSAGE(!args[0]->IsUndefined() && !args[0]->IsNull(), "require called with undefined moduleName parameter");
-		ASSERT_MESSAGE(!args[1]->IsUndefined() && !args[1]->IsNull(), "require called with undefined callingModulePath parameter");
-		ASSERT_MESSAGE(args[0]->IsString(), "require should be called with string parameter");
-		ASSERT_MESSAGE(args[1]->IsString(), "require should be called with string parameter");
+		auto isolate = Isolate::GetCurrent();
+		if (args.Length() != 2)
+		{
+			isolate->ThrowException(ConvertToV8String("require should be called with two parameters"));
+			return;
+		}
+		if (!args[0]->IsString())
+		{
+			isolate->ThrowException(ConvertToV8String("require's first parameter should be string"));
+			return;
+		}
+		if (!args[1]->IsString())
+		{
+			isolate->ThrowException(ConvertToV8String("require's second parameter should be string"));
+			return;
+		}
 
 		string moduleName = ConvertToString(args[0].As<String>());
 		string callingModuleDirName = ConvertToString(args[1].As<String>());
@@ -100,7 +111,7 @@ namespace tns
 		}
 		else
 		{
-			moduleObj = Local<Object>::New(Isolate::GetCurrent(), *((*it).second));
+			moduleObj = Local<Object>::New(isolate, *((*it).second));
 		}
 
 		if(!hasError){

--- a/src/jni/Require.h
+++ b/src/jni/Require.h
@@ -9,6 +9,7 @@
 #define JNI_REQUIRE_H_
 
 #include "v8.h"
+#include "JEnv.h"
 #include <string>
 
 namespace tns
@@ -16,9 +17,20 @@ namespace tns
 	class Require
 	{
 		public:
-			static v8::Local<v8::String> LoadModule(const std::string& path);
+			static v8::Local<v8::Object> CompileAndRun(const std::string& path, bool& hasError);
+			static void Callback(const v8::FunctionCallbackInfo<v8::Value>& args);
+			static void Init();
 
 		private:
+			static v8::Local<v8::String> LoadScriptText(const std::string& path);
+			static v8::ScriptCompiler::CachedData* TryLoadScriptCache(const std::string& path);
+			static void SaveScriptCache(const v8::ScriptCompiler::Source& source, const std::string& path);
+
+			// fields
+			static jmethodID GET_MODULE_PATH_METHOD_ID;
+			static std::map<std::string, v8::Persistent<v8::Object>*> loadedModules;
+			static jclass RequireClass;
+
 			static const char* MODULE_PART_1;
 			static const char* MODULE_PART_2;
 			static const char* MODULE_PART_3;

--- a/src/src/com/tns/NativeScriptApplication.java
+++ b/src/src/com/tns/NativeScriptApplication.java
@@ -755,6 +755,7 @@ public class NativeScriptApplication extends android.app.Application implements 
 				e.printStackTrace();
 			}
 			ThreadScheduler workThreadScheduler = new WorkThreadScheduler(new Handler(Looper.getMainLooper()));
+			// TODO: Refactor these 11 method parameters!!! E.g. create Settings abstract object and add default implementation object 
 			Platform.init(this, workThreadScheduler, logger, appName, null, rootDir, appDir, debuggerSetupDir, classLoader, dexDir, dexThumb);
 			Platform.runScript(new File(appDir, "internal/prepareExtend.js"));
 			Platform.run();

--- a/src/src/com/tns/Platform.java
+++ b/src/src/com/tns/Platform.java
@@ -25,7 +25,7 @@ import com.tns.internal.ExtractPolicy;
 
 public class Platform
 {
-	private static native void initNativeScript(String filesPath, int appJavaObjectId, boolean verboseLoggingEnabled, String packageName, String jsOptions);
+	private static native void initNativeScript(String filesPath, int appJavaObjectId, boolean verboseLoggingEnabled, String packageName, Object[] v8Options);
 
 	private static native void runNativeScript(String appModuleName);
 	
@@ -132,8 +132,8 @@ public class Platform
 		{
 			throw new RuntimeException("Fail to initialize Require class", ex);
 		}
-		String jsOptions = readJsOptions(appDir);
-		Platform.initNativeScript(Require.getApplicationFilesPath(), appJavaObjectId, logger.isEnabled(), appName, jsOptions);
+		Object[] v8Config = V8Config.fromPackageJSON(appDir);
+		Platform.initNativeScript(Require.getApplicationFilesPath(), appJavaObjectId, logger.isEnabled(), appName, v8Config);
 		
 		if (debuggerSetupDir != null)
 		{
@@ -869,35 +869,5 @@ public class Platform
 		}
 		
 		dexFactory.purgeAllProxies();
-	}
-	
-	private static String readJsOptions(File appDir)
-	{
-		String options = "--expose_gc";
-		
-		File packageInfo = new File (appDir, "/app/package.json");
-		
-		if (packageInfo.exists())
-		{
-			JSONObject object;
-			try
-			{
-				object = FileSystem.readJSONFile(packageInfo);
-				if (object != null)
-				{
-					String opt = object.getString("jsoptions");
-					if (opt != null)
-					{
-						options = opt;
-					}
-				}
-			}
-			catch (Exception e)
-			{
-				if (logger.isEnabled()) e.printStackTrace();
-			}
-		}
-		
-		return options;
 	}
 }

--- a/src/src/com/tns/Platform.java
+++ b/src/src/com/tns/Platform.java
@@ -16,8 +16,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 
-import org.json.JSONObject;
-
 import android.util.SparseArray;
 
 import com.tns.bindings.ProxyGenerator;

--- a/src/src/com/tns/V8Config.java
+++ b/src/src/com/tns/V8Config.java
@@ -1,0 +1,56 @@
+package com.tns;
+
+import java.io.File;
+import org.json.JSONObject;
+
+class V8Config
+{
+	private static final String AndroidKey = "android";
+	private static final String V8FlagsKey = "v8Flags";
+	private static final String CodeCacheKey = "codeCache";
+	
+	public static Object[] fromPackageJSON(File appDir)
+	{
+		Object[] result = MakeDefaultOptions();
+		File packageInfo = new File (appDir, "/app/package.json");
+		if(!packageInfo.exists())
+		{
+			return result;
+		}
+		
+		JSONObject rootObject;
+		try
+		{
+			rootObject = FileSystem.readJSONFile(packageInfo);
+			if (rootObject != null && rootObject.has(AndroidKey))
+			{
+				JSONObject androidObject = rootObject.getJSONObject(AndroidKey);
+				if(androidObject.has(V8FlagsKey))
+				{
+					result[0] = androidObject.getString(V8FlagsKey); 
+				}
+				if(androidObject.has(CodeCacheKey))
+				{
+					result[1] = androidObject.getString(CodeCacheKey); 
+				}
+			}
+		}
+		catch (Exception e)
+		{
+			e.printStackTrace();
+		}
+		
+		return result;
+	}
+	
+	private static Object[] MakeDefaultOptions()
+	{
+		Object[] result = new Object[2];
+		// v8 startup flags, defaults to --expose_gc due to tns_modules requirement 
+		result[0] = "--expose_gc";
+		// enable v8 code caching, false by default
+		result[1] = false;
+		
+		return result;
+	}
+}

--- a/src/src/com/tns/V8Config.java
+++ b/src/src/com/tns/V8Config.java
@@ -11,7 +11,7 @@ class V8Config
 	
 	public static Object[] fromPackageJSON(File appDir)
 	{
-		Object[] result = MakeDefaultOptions();
+		Object[] result = makeDefaultOptions();
 		File packageInfo = new File (appDir, "/app/package.json");
 		if(!packageInfo.exists())
 		{
@@ -43,7 +43,7 @@ class V8Config
 		return result;
 	}
 	
-	private static Object[] MakeDefaultOptions()
+	private static Object[] makeDefaultOptions()
 	{
 		Object[] result = new Object[2];
 		// v8 startup flags, defaults to --expose_gc due to tns_modules requirement 


### PR DESCRIPTION
This pull:

* Extracts the Require-related implementation from the `NativeScriptRuntime` class and puts into the `Require` one.
* Implements the code-caching technique
* Enables configurable options in an application's `package.json` file to turn caching on.

Code-caching is disabled by default. Use the following settings in `app/package.json` to enable it:
```
"android": {
	"codeCache" : "true"
}
```

Additionally, to make it really effective, you should specify the `--nolazy` V8 flag as well (`--expose_gc` is required by the tns-modules package):
```
"android": {
	"v8Flags" : "--nolazy --expose_gc",
	"codeCache" : "true"
}
```