### PR TITLE
build.gradle creates include.gradle with an extra comma

### DIFF
--- a/build/project-template-gradle/build.gradle
+++ b/build/project-template-gradle/build.gradle
@@ -260,7 +260,11 @@ task createPluginsConfigFile {
 			println "\t+creating product flavors include.gradle file in $configurationsDir folder..."
 			def flavors = pluginNames.join(",")
 			if(appResExists) {
-				flavors = '"' + appResourcesName + '", ' + flavors
+				if (flavors == '') {
+					flavors = '"' + appResourcesName + '"'
+				} else {
+					flavors = '"' + appResourcesName + '", ' + flavors
+				}
 			}
 			flavorsFile << "android { \n"
 			flavorsFile << "\tflavorDimensions " + flavors + "\n"


### PR DESCRIPTION
I have app resources but I have no plugins and no pluginNames so my include.gradle ends with an extra ','.