### PR TITLE
Fix include.gradle file generation

### DIFF
--- a/build/project-template-gradle/build.gradle
+++ b/build/project-template-gradle/build.gradle
@@ -222,9 +222,10 @@ task createDefaultIncludeFiles {
 			def dimensionName = sanatizeDimensionName(fileName)
 			createPluginConfigFile = true
 			def foundIncludeFile = false
-			
+			def isAppResDir = false
 			if(fileName == appResourcesName) {
 				appResExists = true
+				isAppResDir = true
 			}
 			
 			println "\t+found plugins: " + fileName
@@ -236,7 +237,7 @@ task createDefaultIncludeFiles {
 				}
 			}
 			
-			if(!appResExists) {
+			if(!isAppResDir) {
 				pluginNames.add('"' + dimensionName + '"')
 			}
 			


### PR DESCRIPTION
When `include.gradle` file is generated, there's a check if the App_Resources directory has been already parsed.
If there's AndroidManifest.xml in the app/App_Resources/Android the global variable appResExists is set to true.
All subsequent plugins will not be added to pluginNames and so will not be added to include.gradle.
For example in case you add AndroidManifest.xml in app/App_Resources and add nativescript-barcodescanner plugin, this is the generated include.gradle on Linux:
```
android {
	flavorDimensions "NativescriptAppResources",
}
```
This way the build fails. The reason is that on Linux the file listing is different and App_Resources dir is processed before nativescript-barcodescanner.
The same project will work on Windows, but it is not guarantee that other projects will not fail in the same case.

In order to fix the issue, I've intorduced a new variable in the body of createDefaultIncludeFiles's iteration over files.
It is set to false on each iterration, so if the current dir is not App_Resources, the plugin will be added to `pluginNames`.
I've kept the code for setting `appResExists` as it is used on other places in the build.gradle.