### PR TITLE
fixed livesync on deleted file

### DIFF
--- a/src/src/com/tns/NativeScriptSyncService.java
+++ b/src/src/com/tns/NativeScriptSyncService.java
@@ -145,6 +145,7 @@ public class NativeScriptSyncService
                 int length = input.readInt();
                 input.readFully(new byte[length]); //ignore the payload
                 executePartialSync(context, syncDir);
+                executeRemovedSync(context, removedSyncDir);
 
                 Platform.runScript(new File(NativeScriptSyncService.this.context.getFilesDir(), "internal/livesync.js"));
                 


### PR DESCRIPTION
when a .xml or .css file is deleted on livesync the files should be deleted in the running device as well

tested on: nexus 5, samsun galaxy s4, emulator with api level 22 (5.1.0)