### PR TITLE
add id propery to module object

### DIFF
--- a/src/jni/Module.cpp
+++ b/src/jni/Module.cpp
@@ -284,8 +284,9 @@ Local<Object> Module::LoadModule(Isolate *isolate, const string& modulePath)
 
 	moduleObj->Set(ConvertToV8String("require"), require);
 
-	auto moduleId = modulePath.substr(Constants::APP_ROOT_FOLDER_PATH.length() - 4);
-	moduleObj->Set(ConvertToV8String("id"),  ConvertToV8String(moduleId));
+	auto moduleIdProp = ConvertToV8String("id");
+	const auto readOnlyFlags = static_cast<PropertyAttribute>(PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+	moduleObj->DefineOwnProperty(isolate->GetCurrentContext(), moduleIdProp, fileName, readOnlyFlags);
 
 	auto thiz = Object::New(isolate);
 	auto extendsName = ConvertToV8String("__extends");

--- a/src/jni/Module.cpp
+++ b/src/jni/Module.cpp
@@ -286,7 +286,10 @@ Local<Object> Module::LoadModule(Isolate *isolate, const string& modulePath)
 
 	auto moduleIdProp = ConvertToV8String("id");
 	const auto readOnlyFlags = static_cast<PropertyAttribute>(PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
-	moduleObj->DefineOwnProperty(isolate->GetCurrentContext(), moduleIdProp, fileName, readOnlyFlags);
+	Maybe<bool> success = moduleObj->DefineOwnProperty(isolate->GetCurrentContext(), moduleIdProp, fileName, readOnlyFlags);
+	if(success.IsNothing()) {
+		throw NativeScriptException(string("Couldn't execute method 'DefineOwnProperty' on 'moduleObj' in 'Module::LoadModule'."));
+	}
 
 	auto thiz = Object::New(isolate);
 	auto extendsName = ConvertToV8String("__extends");

--- a/src/jni/Module.cpp
+++ b/src/jni/Module.cpp
@@ -284,6 +284,9 @@ Local<Object> Module::LoadModule(Isolate *isolate, const string& modulePath)
 
 	moduleObj->Set(ConvertToV8String("require"), require);
 
+	auto moduleId = modulePath.substr(Constants::APP_ROOT_FOLDER_PATH.length() - 4);
+	moduleObj->Set(ConvertToV8String("id"),  ConvertToV8String(moduleId));
+
 	auto thiz = Object::New(isolate);
 	auto extendsName = ConvertToV8String("__extends");
 	thiz->Set(extendsName, isolate->GetCurrentContext()->Global()->Get(extendsName));


### PR DESCRIPTION
Аdded id property to module which is the path of the module, relative to the root folder.
The iOS runtime has the same behavior and this enables us to run all common tests for both runtimes.

ping: @slavchev @blagoev @atanasovg 