### PR TITLE
respect only jar files that are in plugins with nativescript structure

### DIFF
--- a/build/project-template-gradle/build.gradle
+++ b/build/project-template-gradle/build.gradle
@@ -171,7 +171,7 @@ dependencies {
 	compile fileTree(dir: "libs", include: ["**/*.jar"])
 
 	// take all jars within the node_modules dir
-	compile fileTree(dir: nodeModulesDir, include: ["**/*.jar"])
+	compile fileTree(dir: nodeModulesDir, include: ["**/platforms/android/**/*.jar"])
 
 	// take all jars within the lib/Android dir
 	compile fileTree(dir: libDir, include: ["**/*.jar"])


### PR DESCRIPTION
only jars that are withing the `/platforms/android/` folder will be respected this includes nested folders like:
```
/platforms/android/my.jar
/platforms/android/newFolder/my.jar
/platforms/android/newFolder/newFolder/my.jar
```
but will not include files like:
```
/platforms/my.jar
```

fix for: https://github.com/NativeScript/android-runtime/issues/323