### PR TITLE
Plamen5kov/use 1.3.0 gradle version

### DIFF
--- a/src/build.gradle
+++ b/src/build.gradle
@@ -27,7 +27,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:1.3.0'
     }
 }
 

--- a/src/build.gradle
+++ b/src/build.gradle
@@ -90,11 +90,6 @@ android {
 	lintOptions {
 		abortOnError false
 	}
-	
-	packagingOptions {
-		exclude 'resources.arsc'
-		exclude "AndroidManifest.xml"
-	}
 }
 
 repositories {

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -21,7 +21,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:1.3.0'
     }
 }
 


### PR DESCRIPTION
reverted to 1.3.0 gradle version because, 1.5.0 puts `resources/` `res/` folders together with `AndroidManifest.xml` in `classes.jar` 