### PR TITLE
Plamen5kov/fix issuee 366

### DIFF
--- a/src/jni/MetadataNode.cpp
+++ b/src/jni/MetadataNode.cpp
@@ -686,18 +686,17 @@ void MetadataNode::SetInnnerTypes(Isolate *isolate, Local<Function>& ctorFunctio
 			auto type = s_metadataReader.GetNodeType(curChild);
 			auto isStatic = s_metadataReader.IsNodeTypeStatic(type);
 
-			if (isStatic)
-			{
-				auto innerTypeCtorFuncTemplate = childNode->GetConstructorFunctionTemplate(isolate, curChild);
-				auto innerTypeCtorFunc = innerTypeCtorFuncTemplate->GetFunction();
-				auto innerTypeName = ConvertToV8String(curChild->name);
-				ctorFunction->Set(innerTypeName, innerTypeCtorFunc);
-			}
-			else
+			auto innerTypeName = ConvertToV8String(curChild->name);
+			auto innerTypeCtorFuncTemplate = childNode->GetConstructorFunctionTemplate(isolate, curChild);
+			auto innerTypeCtorFunc = innerTypeCtorFuncTemplate->GetFunction();
+
+			if (!isStatic)
 			{
 				auto innerTypeName = ConvertToV8String(curChild->name);
 				prototypeTemplate2->SetAccessor(innerTypeName, InnerClassAccessorGetterCallback, nullptr, External::New(isolate, childNode));
 			}
+
+			ctorFunction->Set(innerTypeName, innerTypeCtorFunc);
 		}
 	}
 }

--- a/test-app/assets/app/tests/field-access-test.js
+++ b/test-app/assets/app/tests/field-access-test.js
@@ -21,4 +21,11 @@ describe("Tests Java object field access", function () {
 		}
 		expect(exceptionCaught).toBe(true);
 	});
+	
+	it("should be able to get public static field of inner type", function () {
+		var AudioSource = android.media.MediaRecorder.AudioSource;
+		var mic_constant = AudioSource.MIC;
+		expect(AudioSource).not.toBe(undefined);
+		expect(mic_constant).toBe(1);
+	});
 });


### PR DESCRIPTION
fix for: https://github.com/NativeScript/android-runtime/issues/366
This PR allows public static members of inner types to be accessed.
```
var MediaSource = android.media.MediaRecorder; //outer class
var AudioSource = MediaSource.AudioSource; //inner class
var micSf = AudioSource.MIC; //inner class static field
```

ping: @atanasovg, @slavchev, @blagoev, @pip3r4o