### PR TITLE
fix long paths

### DIFF
--- a/build/project-template-gradle/build.gradle
+++ b/build/project-template-gradle/build.gradle
@@ -194,85 +194,46 @@ task pluginStructureCheck {
 	}
 }
 
-def createIncludeFile (filePath, fileName, dimensionName) {
-	println "\t+creating include.gradle file for: " + filePath
-	def defaultIncludeFile = new File(filePath, "include.gradle")
-	defaultIncludeFile.write ""
-	defaultIncludeFile << "android { \n"
-	defaultIncludeFile << "\tproductFlavors {\n"
-	defaultIncludeFile << '\t\t"' + fileName + '" {\n'
-	defaultIncludeFile << '\t\t\tdimension "' + dimensionName + '"\n'
-	defaultIncludeFile << "\t\t}\n"
-	defaultIncludeFile << "\t}\n"
-	defaultIncludeFile << "}"
-}
-
-def sanatizeDimensionName(str) {
+def sanitizePluginName(str) {
 	return str.replaceAll(/\W/, "")
 }
 
-//make sure the include.gradle file, produced by the user, has only allowed characters in dimension attribute and remove any invalid characters if necessary
-def updateIncludeGradleFile(subFile, dimensionName) {
-	def igFile = new File(subFile.getAbsolutePath())
-	def newContent = igFile.text.replaceAll(/dimension\s+["'](.+?)["']/)  { fullMatch, fDimension ->
-							def newFg = sanatizeDimensionName(fDimension)
-							dimensionName = newFg
-							return "dimension \"$newFg\""
-						}
-	igFile.text = newContent
-	
-	return dimensionName
+task populatePluginNames {
+    def ft = file(configurationsDir)
+    ft.listFiles().each { fl ->
+        if(fl.isDirectory()) {
+            pluginNames.add(fl.name)
+        }
+    }  
 }
 
-task createDefaultIncludeFiles {
-	description "creates default include.gradle files for added plugins IF NECESSARY"
-	println "$configStage createDefaultIncludeFiles"
-	def ft = file(configurationsDir)
-		
-	ft.listFiles().each { fl ->
-	
-		if(fl.isDirectory()) {
-			def fileName = fl.name
-			def dimensionName = sanatizeDimensionName(fileName)
-			createPluginConfigFile = true
-			def foundIncludeFile = false
-			
-			println "\t+found plugins: " + fileName
-			fl.listFiles().each { subFile ->
-			
-				if(subFile.name == "include.gradle") {
-					foundIncludeFile = true
-					dimensionName = updateIncludeGradleFile(subFile, dimensionName)
-				}
-			}
-			
-			pluginNames.add('"' + dimensionName + '"')
-			
-			if(!foundIncludeFile) {
-				createIncludeFile(fl.getAbsolutePath() ,fileName, dimensionName)
-			}
-		}
-	}
+task createPluginSubprojects {
+	println "$configStage createPluginSubprojects"
+    pluginNames.each {
+        def pluginName = it
+        def sanitizedPluginName = sanitizePluginName(it)
+        def manifestFile = new File("$pluginName/src/main/AndroidManifest.xml")
+        
+        copy {
+            println "Copy plugin"
+            
+            from nodeModulesDir + "$pluginName/platforms/android"
+            into "$pluginName/src/main"
+        }
+        if (!manifestFile.exists()) {
+            manifestFile.write ""
+            manifestFile << "<manifest xmlns:android='http://schemas.android.com/apk/res/android' package='org.nativescript.$sanitizedPluginName'>\n"
+            manifestFile << "</manifest>"          
+        }
+    }
 }
 
-task createPluginsConfigFile {
-	description "creates product flavor config file based on what plugins are added"
-	
-	if(configDir.exists()) {
-		println "$configStage createPluginsConfigFile"
-		
-		def flavorsFile = new File("$configurationsDir/include.gradle")
-		flavorsFile.write "" //clear config file
-		
-		if(createPluginConfigFile) {
-			println "\t+creating product flavors include.gradle file in $configurationsDir folder..."
-			def flavors = pluginNames.join(",")
-			
-			flavorsFile << "android { \n"
-			flavorsFile << "\tflavorDimensions " + flavors + "\n"
-			flavorsFile << "}\n"
-		}
-	}
+task addProjectDependencies {
+	println "$configStage addProjectDependencies"
+    pluginNames.each {
+		println "\t+adding projectdependency: $it"
+        project.dependencies.add("compile", project(":$it"))
+    }
 }
 
 task pluginExtend {
@@ -284,15 +245,11 @@ task pluginExtend {
 		apply from: pathToAppGradle
 	}
 
-	if(configDir.exists()) {
-	println "$configStage pluginExtend"
-		configDir.eachFileRecurse(groovy.io.FileType.FILES) {
-			if(it.name.equals('include.gradle')) {
-				println "\t+applying configuration from: " + it
-				apply from: it
-			}
-		}
-	}
+	def ft = fileTree(dir: nodeModulesDir, include: ["**/platforms/android/**/include.gradle"])
+	ft.each { File igFile ->
+		println igFile
+		apply from: igFile
+	}  
 }
 
 //// doesn't work unless task is explicitly called (TODO: research configurations hook)
@@ -492,9 +449,11 @@ buildMetadata.dependsOn(collectAllJars)
 task buildapk {
 	// problem is compile dependencies need to be changed before configuration stage
 	// and this is the only way so far
+    tasks.createPluginSubprojects.execute()
 	tasks.copyAarDependencies.execute()
-    tasks.addAarDependencies.execute()
-
+	tasks.addAarDependencies.execute()
+    tasks.addProjectDependencies.execute()
+    
 	//done to build only necessary apk
 	if(project.hasProperty("release")) {
 		dependsOn assembleRelease

--- a/build/project-template-gradle/build.gradle
+++ b/build/project-template-gradle/build.gradle
@@ -225,6 +225,21 @@ task createPluginSubprojects {
             manifestFile << "<manifest xmlns:android='http://schemas.android.com/apk/res/android' package='org.nativescript.$sanitizedPluginName'>\n"
             manifestFile << "</manifest>"          
         }
+        else {
+            // Check for package attribute
+            def manifest = new XmlSlurper(false, true).parse(manifestFile)
+            if (manifest.@package == "") {
+                manifest.@package = "org.nativescript." + sanitizedPluginName
+                
+                def outputBuilder = new groovy.xml.StreamingMarkupBuilder()                
+                def xml = groovy.xml.XmlUtil.serialize(outputBuilder.bind {
+                    mkp.declareNamespace("android":"http://schemas.android.com/apk/res/android")
+                    mkp.yield manifest    
+                })
+
+                manifestFile.write xml
+            }            
+        }        
     }
 }
 

--- a/build/project-template-gradle/plugin-project-template/build.gradle
+++ b/build/project-template-gradle/plugin-project-template/build.gradle
@@ -1,0 +1,16 @@
+apply plugin: "com.android.library"
+
+buildDir = "../build"
+
+android {
+    compileSdkVersion compiteCompileSdkVersion()
+	buildToolsVersion computeBuildToolsVersion()
+	
+	defaultConfig {
+		minSdkVersion 17
+		targetSdkVersion computeTargetSdkVersion()
+	}
+}
+dependencies {
+    compile fileTree(dir: "libs", include: ["*.jar"])
+}

--- a/build/project-template-gradle/settings.gradle
+++ b/build/project-template-gradle/settings.gradle
@@ -3,3 +3,24 @@ include "asbg", "ing", "bg"
 project(":asbg").projectDir = file("build-tools/android-static-binding-generator")
 project(":ing").projectDir = file("build-tools/android-static-binding-generator/interface-name-generator")
 project(":bg").projectDir = file("build-tools/android-static-binding-generator/binding-generator")
+
+// Include plugin directories as projects
+def ft = file("configurations")
+ft.listFiles().each { fl ->
+    if(fl.isDirectory()) {
+        def dstr = fl.toString()
+        def pluginName = fl.name
+                
+        // Cleanup
+        delete pluginName
+        
+        copy {
+            from "plugin-project-template"
+            into pluginName
+        } 
+        
+        println "including plugin project $pluginName"
+        include pluginName               
+    }
+}
+


### PR DESCRIPTION
fixes #369. 
Configures each plugin as project and adds it as dependency to the main project (no need to be prebuild in AAR!!!). From what I see this correctly merges resources/manifests, but since i'm not android expert will require some additional testing and verification. 

**Breaking changes**
~~1. Plugins' manifest file must have the `package` attribute~~
2. If the plugin includes some `.jar` files it would be recommended to be put those side `platforms\android\libs` directory so that they will be packed up with the project. 
 
**Bonus**
If plugin has native java code put in the correct `java` subfolder it will automatically be built. This brings possibility of plugins defining their own native code and activities!