### PR TITLE
Add support for the Runtime to consume precompiled snapshot BLOB

### DIFF
--- a/src/jni/Constants.cpp
+++ b/src/jni/Constants.cpp
@@ -12,3 +12,4 @@ bool Constants::V8_CACHE_COMPILED_CODE = false;
 bool Constants::V8_HEAP_SNAPSHOT = false;
 std::string Constants::V8_STARTUP_FLAGS = "";
 std::string Constants::V8_HEAP_SNAPSHOT_SCRIPT = "";
+std::string Constants::V8_HEAP_SNAPSHOT_BLOB = "";

--- a/src/jni/Constants.h
+++ b/src/jni/Constants.h
@@ -13,6 +13,7 @@ public:
 	static std::string APP_ROOT_FOLDER_PATH;
 	static std::string V8_STARTUP_FLAGS;
 	static std::string V8_HEAP_SNAPSHOT_SCRIPT;
+	static std::string V8_HEAP_SNAPSHOT_BLOB;
 	static bool V8_CACHE_COMPILED_CODE;
 	static bool V8_HEAP_SNAPSHOT;
 

--- a/src/src/com/tns/V8Config.java
+++ b/src/src/com/tns/V8Config.java
@@ -1,7 +1,10 @@
 package com.tns;
 
 import java.io.File;
+
 import org.json.JSONObject;
+
+import android.os.Build;
 
 class V8Config
 {
@@ -10,6 +13,8 @@ class V8Config
 	private static final String CodeCacheKey = "codeCache";
 	private static final String HeapSnapshotKey = "heapSnapshot";
 	private static final String HeapSnapshotScriptKey = "heapSnapshotScript";
+	private static final String HeapSnapshotBlobKey = "heapSnapshotBlob";
+	private static final String SnapshotFile = "snapshot.blob";
 	private static final String ProfilerOutputDirKey = "profilerOutputDir";
 	
 	public static Object[] fromPackageJSON(File appDir)
@@ -45,9 +50,21 @@ class V8Config
 					String value = androidObject.getString(HeapSnapshotScriptKey);
 					result[3] = FileSystem.resolveRelativePath(appDir.getPath(), value, appDir + "/app/");
 				}
+				if(androidObject.has(HeapSnapshotBlobKey))
+				{
+					String value = androidObject.getString(HeapSnapshotBlobKey);
+					String path = FileSystem.resolveRelativePath(appDir.getPath(), value, appDir + "/app/");
+					File dir = new File(path);
+					if(dir.exists() && dir.isDirectory()) 
+					{
+						// this path is expected to be a directory, containing three sub-directories: armeabi-v7a, x86 and arm64-v8a 
+						path = path + "/" + Build.CPU_ABI + "/" + SnapshotFile;
+						result[4] = path;
+					}
+				}
 				if(androidObject.has(ProfilerOutputDirKey))
 				{
-					result[4] = androidObject.getString(ProfilerOutputDirKey);
+					result[5] = androidObject.getString(ProfilerOutputDirKey);
 				}
 			}
 		}
@@ -69,6 +86,8 @@ class V8Config
 			// enable v8 heap snapshot, false by default
 			false,
 			// arbitrary script to be included in the snapshot
+			"",
+			// a binary file containing an already saved snapshot
 			"",
 			// V8 profiler output directory
 			""


### PR DESCRIPTION
The Runtime may now be configured (via the package.json file) to consume a precompiled heap snapshot file.