### PR TITLE
Snapshot data memory managment

### DIFF
--- a/src/jni/Runtime.cpp
+++ b/src/jni/Runtime.cpp
@@ -61,6 +61,11 @@ Runtime::Runtime(JNIEnv *env, jobject runtime, int id)
 	s_id2RuntimeCache.insert(make_pair(id, this));
 }
 
+Runtime::~Runtime() {
+	delete m_startupData->data;
+	delete m_startupData;
+}
+
 Runtime* Runtime::GetRuntime(int runtimeId)
 {
 	auto itFound = s_id2RuntimeCache.find(runtimeId);
@@ -342,19 +347,27 @@ Isolate* Runtime::PrepareV8Runtime(const string& filesPath, jstring packageName,
 	V8::Initialize();
 
 	Isolate::CreateParams create_params;
-	StartupData startup_data;
 	string customScript;
 
 	create_params.array_buffer_allocator = &g_allocator;
 	// prepare the snapshot blob
 	if (Constants::V8_HEAP_SNAPSHOT)
 	{
+		DEBUG_WRITE_FORCE("Snapshot enabled.");
+
+		// From V8 documentation:
+		// To avoid unnecessary copies of data, V8 will point directly into the
+		// given data blob, so pretty please keep it around until V8 exit.
+		m_startupData = new StartupData();
+
 		auto snapshotPath = filesPath + "/internal/snapshot.blob";
 		if( File::Exists(snapshotPath))
 		{
 			int length;
-			startup_data.data = reinterpret_cast<char*>(File::ReadBinary(snapshotPath, length));
-			startup_data.raw_size = length;
+			m_startupData->data = reinterpret_cast<char*>(File::ReadBinary(snapshotPath, length));
+			m_startupData->raw_size = length;
+
+			DEBUG_WRITE_FORCE("Snapshot read %s (%dB).", snapshotPath.c_str(), length);
 		}
 		else
 		{
@@ -364,11 +377,25 @@ Isolate* Runtime::PrepareV8Runtime(const string& filesPath, jstring packageName,
 				customScript = File::ReadText(Constants::V8_HEAP_SNAPSHOT_SCRIPT);
 			}
 
-			startup_data = V8::CreateSnapshotDataBlob(customScript.c_str());
-			File::WriteBinary(snapshotPath, startup_data.data, startup_data.raw_size);
+			DEBUG_WRITE_FORCE("Creating heap snapshot");
+			*m_startupData = V8::CreateSnapshotDataBlob(customScript.c_str());
+
+			if (m_startupData->raw_size == 0) {
+				DEBUG_WRITE_FORCE("Failed to create heap snapshot.");
+			} else {
+				bool writeSuccess = File::WriteBinary(snapshotPath, m_startupData->data, m_startupData->raw_size);
+
+				if (!writeSuccess) {
+					DEBUG_WRITE_FORCE("Failed to save created snapshot.");
+				} else {
+					DEBUG_WRITE_FORCE("Saved snapshot of %s (%dB) in %s (%dB)",
+							Constants::V8_HEAP_SNAPSHOT_SCRIPT.c_str(), customScript.size(),
+							snapshotPath.c_str(), m_startupData->raw_size);
+				}
+			}
 		}
 
-		create_params.snapshot_blob = &startup_data;
+		create_params.snapshot_blob = m_startupData;
 	}
 
 	auto isolate = Isolate::New(create_params);
@@ -401,12 +428,6 @@ Isolate* Runtime::PrepareV8Runtime(const string& filesPath, jstring packageName,
 
 	Local<Context> context = Context::New(isolate, nullptr, globalTemplate);
 	PrimaryContext = new Persistent<Context>(isolate, context);
-
-	if (Constants::V8_HEAP_SNAPSHOT)
-	{
-		// we own the snapshot buffer, delete it
-		delete[] startup_data.data;
-	}
 
 	context_scope = new Context::Scope(context);
 

--- a/src/jni/Runtime.h
+++ b/src/jni/Runtime.h
@@ -42,6 +42,7 @@ namespace tns
 
 		private:
 			Runtime(JNIEnv *env, jobject runtime, int id);
+			virtual ~Runtime();
 
 			JEnv m_env;
 			int m_id;
@@ -56,6 +57,8 @@ namespace tns
 			WeakRef m_weakRef;
 
 			Profiler m_profiler;
+
+			v8::StartupData *m_startupData;
 
 			static void PrepareExtendFunction(v8::Isolate *isolate, jstring filesPath);
 			v8::Isolate* PrepareV8Runtime(const std::string& filesPath, jstring packageName, jobject jsDebugger, jstring profilerOutputDir);


### PR DESCRIPTION
This stops the debugger from crashing.

https://github.com/NativeScript/android-runtime/blob/3e6f6ea24b443805aa743b80bb434ab5df98f214/src/jni/include/v8.h#L5989-L5990

Related to: https://github.com/NativeScript/NativeScript/issues/1563

Ping @atanasovg, @KristinaKoeva.