### PR TITLE
Support bundling and Java-side requires

### DIFF
--- a/build/project-template-gradle/src/main/java/com/tns/RuntimeHelper.java
+++ b/build/project-template-gradle/src/main/java/com/tns/RuntimeHelper.java
@@ -119,6 +119,12 @@ public class RuntimeHelper
 			
 			runtime.init();
 			runtime.runScript(new File(appDir, "internal/ts_helpers.js"));
+
+			File javaClassesModule = new File(appDir, "app/tns-java-classes.js");
+			if (javaClassesModule.exists()) {
+				runtime.runModule(javaClassesModule);
+			}
+
 			Runtime.initInstance(this.app);
 			runtime.run();
 		}


### PR DESCRIPTION
Webpack bundling will split the final bundle in two chunks:

- tns-java-classes.js: containing NativeScriptApplication, NativeScriptActivity, and all related code.
- bundle.js: containing the rest of the library and application code.

We need to load tns-java-classes (if present) earlier, so that Java-JavaScript mappings get registered.

[Here's](https://github.com/NativeScript/nativescript-dev-webpack/blob/master/tns-java-classes.js) a sample tns-java-classes.js *before* webpacking -- those `require` calls will get changed by webpack.

Ping @jasssonpet, @KristinaKoeva 