### PR TITLE
Keep snapshot data just after debugger is initialized

### DIFF
--- a/src/jni/Runtime.h
+++ b/src/jni/Runtime.h
@@ -39,6 +39,7 @@ namespace tns
 			jint GenerateNewObjectId(JNIEnv *env, jobject obj);
 			void AdjustAmountOfExternalAllocatedMemoryNative(JNIEnv *env, jobject obj, jlong usedMemory);
 			void PassUncaughtExceptionToJsNative(JNIEnv *env, jobject obj, jthrowable exception, jstring stackTrace);
+			void ClearStartupData(JNIEnv *env, jobject obj);
 
 		private:
 			Runtime(JNIEnv *env, jobject runtime, int id);
@@ -56,6 +57,8 @@ namespace tns
 			WeakRef m_weakRef;
 
 			Profiler m_profiler;
+
+			v8::StartupData *m_startupData;
 
 			static void PrepareExtendFunction(v8::Isolate *isolate, jstring filesPath);
 			v8::Isolate* PrepareV8Runtime(const std::string& filesPath, jstring packageName, jobject jsDebugger, jstring profilerOutputDir);

--- a/src/jni/com_tns_Runtime.cpp
+++ b/src/jni/com_tns_Runtime.cpp
@@ -301,3 +301,14 @@ extern "C" void Java_com_tns_Runtime_passUncaughtExceptionToJsNative(JNIEnv *env
 		nsEx.ReThrowToJava();
 	}
 }
+
+extern "C" void Java_com_tns_Runtime_ClearStartupData(JNIEnv *env, jobject obj, jint runtimeId)
+{
+	auto runtime = TryGetRuntime(runtimeId);
+	if (runtime == nullptr)
+	{
+		return;
+	}
+
+	runtime->ClearStartupData(env, obj);
+}

--- a/src/src/com/tns/Runtime.java
+++ b/src/src/com/tns/Runtime.java
@@ -41,6 +41,8 @@ public class Runtime
 
 	private native void passUncaughtExceptionToJsNative(int runtimeId, Throwable ex, String stackTrace);
 	
+	private native void ClearStartupData(int runtimeId);
+	
 	void passUncaughtExceptionToJs(Throwable ex, String stackTrace)
 	{
 		passUncaughtExceptionToJsNative(getRuntimeId(), ex, stackTrace);
@@ -199,6 +201,7 @@ public class Runtime
 		{
 			jsDebugger.start();
 		}
+		ClearStartupData(getRuntimeId()); // It's safe to delete the data after the V8 debugger is initialized
 		
 		if (logger.isEnabled())
 		{


### PR DESCRIPTION
This makes the debugger work and addresses the issue of runtime memory discussed in #417.

ping @atanasovg, @KristinaKoeva

Related to: https://github.com/NativeScript/NativeScript/issues/1563