### PR TITLE
Expose resolvePath to JavaScript

### DIFF
--- a/src/jni/Module.h
+++ b/src/jni/Module.h
@@ -25,6 +25,7 @@ namespace tns
 
 			static void RequireCallback(const v8::FunctionCallbackInfo<v8::Value>& args);
 
+			static void ResolveModulePath(const v8::FunctionCallbackInfo<v8::Value>& args);
 		private:
 			struct Cache;
 

--- a/src/jni/Runtime.cpp
+++ b/src/jni/Runtime.cpp
@@ -392,6 +392,7 @@ Isolate* Runtime::PrepareV8Runtime(const string& filesPath, jstring packageName,
 	globalTemplate->Set(ConvertToV8String("__disableVerboseLogging"), FunctionTemplate::New(isolate, CallbackHandlers::DisableVerboseLoggingMethodCallback));
 	globalTemplate->Set(ConvertToV8String("__exit"), FunctionTemplate::New(isolate, CallbackHandlers::ExitMethodCallback));
 	globalTemplate->Set(ConvertToV8String("__nativeRequire"), FunctionTemplate::New(isolate, Module::RequireCallback));
+	globalTemplate->Set(ConvertToV8String("__resolveModulePath"), FunctionTemplate::New(isolate, Module::ResolveModulePath));
 
 	m_weakRef.Init(isolate, globalTemplate, m_objectManager);
 


### PR DESCRIPTION
Bundling and snapshotting android application requires a way to resolve a relative module path to an absolute one so expose runtime resolvePath method.