### PR TITLE
Memory map heap snapshot blob file

### DIFF
--- a/src/jni/File.h
+++ b/src/jni/File.h
@@ -12,6 +12,16 @@
 
 namespace tns
 {
+	struct MemoryMappedFile final
+	{
+			static MemoryMappedFile Open(const char* filePath);
+			MemoryMappedFile(void* memory, size_t size);
+			~MemoryMappedFile();
+
+			void* memory = nullptr;
+			size_t size = 0;
+	};
+
 	class File
 	{
 		public:

--- a/src/jni/Runtime.h
+++ b/src/jni/Runtime.h
@@ -8,6 +8,7 @@
 #include "WeakRef.h"
 #include "ArrayBufferHelper.h"
 #include "Profiler.h"
+#include "File.h"
 
 jobject ConvertJsValueToJavaObject(tns::JEnv& env, const v8::Local<v8::Value>& value, int classReturnType);
 
@@ -58,7 +59,8 @@ namespace tns
 
 			Profiler m_profiler;
 
-			v8::StartupData *m_startupData;
+			v8::StartupData *m_startupData = nullptr;
+			MemoryMappedFile *m_heapSnapshotBlob = nullptr;
 
 			static void PrepareExtendFunction(v8::Isolate *isolate, jstring filesPath);
 			v8::Isolate* PrepareV8Runtime(const std::string& filesPath, jstring packageName, jobject jsDebugger, jstring profilerOutputDir);


### PR DESCRIPTION
Avoids the initial memory spike of reading the heap snapshot file in memory and deleting it shortly after.

Related to: https://github.com/NativeScript/NativeScript/issues/1563

ping @atanasovg, @KristinaKoeva