### PR TITLE
Delete heapSnapshot package.json key

### DIFF
--- a/src/jni/Constants.cpp
+++ b/src/jni/Constants.cpp
@@ -9,7 +9,6 @@
 
 std::string Constants::APP_ROOT_FOLDER_PATH = "";
 bool Constants::V8_CACHE_COMPILED_CODE = false;
-bool Constants::V8_HEAP_SNAPSHOT = false;
 std::string Constants::V8_STARTUP_FLAGS = "";
 std::string Constants::V8_HEAP_SNAPSHOT_SCRIPT = "";
 std::string Constants::V8_HEAP_SNAPSHOT_BLOB = "";

--- a/src/jni/Constants.h
+++ b/src/jni/Constants.h
@@ -15,7 +15,6 @@ public:
 	static std::string V8_HEAP_SNAPSHOT_SCRIPT;
 	static std::string V8_HEAP_SNAPSHOT_BLOB;
 	static bool V8_CACHE_COMPILED_CODE;
-	static bool V8_HEAP_SNAPSHOT;
 
 	private:
 		Constants()

--- a/src/jni/Runtime.cpp
+++ b/src/jni/Runtime.cpp
@@ -130,13 +130,11 @@ void Runtime::Init(jstring filesPath, bool verboseLoggingEnabled, jstring packag
 	Constants::V8_STARTUP_FLAGS = ArgConverter::jstringToString(v8Flags);
 	JniLocalRef cacheCode(m_env.GetObjectArrayElement(args, 1));
 	Constants::V8_CACHE_COMPILED_CODE = (bool) cacheCode;
-	JniLocalRef snapshot(m_env.GetObjectArrayElement(args, 2));
-	Constants::V8_HEAP_SNAPSHOT = (bool)snapshot;
-	JniLocalRef snapshotScript(m_env.GetObjectArrayElement(args, 3));
+	JniLocalRef snapshotScript(m_env.GetObjectArrayElement(args, 2));
 	Constants::V8_HEAP_SNAPSHOT_SCRIPT = ArgConverter::jstringToString(snapshotScript);
-	JniLocalRef snapshotBlob(m_env.GetObjectArrayElement(args, 4));
+	JniLocalRef snapshotBlob(m_env.GetObjectArrayElement(args, 3));
 	Constants::V8_HEAP_SNAPSHOT_BLOB = ArgConverter::jstringToString(snapshotBlob);
-	JniLocalRef profilerOutputDir(m_env.GetObjectArrayElement(args, 5));
+	JniLocalRef profilerOutputDir(m_env.GetObjectArrayElement(args, 4));
 
 	DEBUG_WRITE("Initializing Telerik NativeScript");
 
@@ -355,7 +353,7 @@ Isolate* Runtime::PrepareV8Runtime(const string& filesPath, jstring packageName,
 
 	create_params.array_buffer_allocator = &g_allocator;
 	// prepare the snapshot blob
-	if (Constants::V8_HEAP_SNAPSHOT)
+	if (!Constants::V8_HEAP_SNAPSHOT_BLOB.empty() || !Constants::V8_HEAP_SNAPSHOT_SCRIPT.empty())
 	{
 		DEBUG_WRITE_FORCE("Snapshot enabled.");
 

--- a/src/src/com/tns/V8Config.java
+++ b/src/src/com/tns/V8Config.java
@@ -11,7 +11,6 @@ class V8Config
 	private static final String AndroidKey = "android";
 	private static final String V8FlagsKey = "v8Flags";
 	private static final String CodeCacheKey = "codeCache";
-	private static final String HeapSnapshotKey = "heapSnapshot";
 	private static final String HeapSnapshotScriptKey = "heapSnapshotScript";
 	private static final String HeapSnapshotBlobKey = "heapSnapshotBlob";
 	private static final String SnapshotFile = "snapshot.blob";
@@ -41,14 +40,10 @@ class V8Config
 				{
 					result[1] = androidObject.getBoolean(CodeCacheKey);
 				}
-				if (androidObject.has(HeapSnapshotKey))
-				{
-					result[2] = androidObject.getBoolean(HeapSnapshotKey);
-				}
 				if(androidObject.has(HeapSnapshotScriptKey))
 				{
 					String value = androidObject.getString(HeapSnapshotScriptKey);
-					result[3] = FileSystem.resolveRelativePath(appDir.getPath(), value, appDir + "/app/");
+					result[2] = FileSystem.resolveRelativePath(appDir.getPath(), value, appDir + "/app/");
 				}
 				if(androidObject.has(HeapSnapshotBlobKey))
 				{
@@ -59,12 +54,12 @@ class V8Config
 					{
 						// this path is expected to be a directory, containing three sub-directories: armeabi-v7a, x86 and arm64-v8a 
 						path = path + "/" + Build.CPU_ABI + "/" + SnapshotFile;
-						result[4] = path;
+						result[3] = path;
 					}
 				}
 				if(androidObject.has(ProfilerOutputDirKey))
 				{
-					result[5] = androidObject.getString(ProfilerOutputDirKey);
+					result[4] = androidObject.getString(ProfilerOutputDirKey);
 				}
 			}
 		}
@@ -82,8 +77,6 @@ class V8Config
 			// v8 startup flags, defaults to --expose_gc due to tns_modules requirement 
 			"--expose_gc",
 			// enable v8 code caching, false by default
-			false,
-			// enable v8 heap snapshot, false by default
 			false,
 			// arbitrary script to be included in the snapshot
 			"",


### PR DESCRIPTION
Replace it with `heapSnapshot = heapSnapshotScript || heapSnapshotBlob `

Related to: https://github.com/NativeScript/NativeScript/issues/1563

Probably this is a good time to do some refactoring to remove the array passed around.

ping @atanasovg, @KristinaKoeva 