### PR TITLE
Move debugger implementation

### DIFF
--- a/build/project-template-gradle/src/main/java/com/tns/AndroidJsDebugger.java
+++ b/build/project-template-gradle/src/main/java/com/tns/AndroidJsDebugger.java
@@ -1,0 +1,470 @@
+package com.tns;
+
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.NoSuchElementException;
+import java.util.Scanner;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager.NameNotFoundException;
+import android.net.LocalServerSocket;
+import android.net.LocalSocket;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.util.Log;
+
+public class AndroidJsDebugger implements Debugger
+{
+	@Override
+	public void onConnect(JsDebugger context)
+	{
+		this.debugContext = context;
+	}
+
+	public static boolean enableDebuggingOverride;
+
+	private Logger logger;
+	private Context context;
+	private DebugLocalServerSocketThread debugServerThread;
+	private JsDebugger debugContext;
+
+	private final static  String STOP_MESSAGE = "STOP_MESSAGE";
+
+	private byte[] LINE_END_BYTES;
+
+	private HandlerThread handlerThread;
+
+	public AndroidJsDebugger(Context context, Logger logger)
+	{
+		this.context = context;
+		this.logger = logger;
+		LINE_END_BYTES = new byte[2];
+		LINE_END_BYTES[0] = (byte) '\r';
+		LINE_END_BYTES[1] = (byte) '\n';
+	}
+
+	private class DebugLocalServerSocketThread extends Thread
+    {
+        private volatile boolean running;
+        private final String name;
+
+        private RequestHandler requestHandler;
+        private LocalServerSocket serverSocket;
+		private ResponseHandler responseHandler;
+		
+        public DebugLocalServerSocketThread(String name)
+        {
+            this.name = name;
+            this.running = false;
+        }
+
+        public void stopResponseHandler()
+		{
+			this.responseHandler.stop();
+		}        
+        
+        public void run()
+        {
+        	Closeable requestHandlerCloseable = new Closeable()
+    		{
+    			@Override
+    			public void close() throws IOException
+    			{
+    				requestHandler.stop();
+    			}
+    		};
+    		
+    		Closeable responseHandlerCloseable = new Closeable()
+    		{
+    			@Override
+    			public void close() throws IOException
+    			{
+    				responseHandler.stop();
+    			}
+    		};
+        	
+            running = true;
+            try
+            {
+                serverSocket = new LocalServerSocket(this.name);
+                try 
+                {
+	                while (running)
+	                {
+	                	try
+	    				{
+	                		LocalSocket socket = serverSocket.accept();
+
+	                		logger.write("NativeScript Debugger new connection on: " + socket.getFileDescriptor().toString());
+	                		
+	    					//out (send messages to node inspector)
+	    					this.responseHandler = new ResponseHandler(socket, requestHandlerCloseable);
+	    					Thread responseThread = new Thread(this.responseHandler);
+	    					responseThread.start();
+	    
+	    					//in (recieve messages from node inspector)
+	    					requestHandler = new RequestHandler(socket, responseHandlerCloseable);
+	    					Thread requestThread = new Thread(requestHandler);
+	    					requestThread.start();
+	    					
+	    					requestThread.join();
+	    					
+	    					this.responseHandler.stop();
+	    					socket.close();
+	    					
+	    					AndroidJsDebugger.this.debugContext.dbgMessages.clear();
+	    					AndroidJsDebugger.this.debugContext.dbgMessages.addAll(AndroidJsDebugger.this.debugContext.compileMessages);
+	    				}
+	    				catch (IOException e)
+	    				{
+	    					e.printStackTrace();
+	    				}
+	                	catch (InterruptedException e) {
+	                		e.printStackTrace();
+	                	}
+	                }
+                }
+                finally
+                {
+                	try
+        			{
+        				serverSocket.close();
+        			}
+        			catch (IOException e)
+        			{
+        				e.printStackTrace();
+        			}
+                }
+            }
+            catch (IOException e)
+            {
+            	e.printStackTrace();
+            }
+        }
+    }
+
+	private enum State
+	{
+		Header, Message
+	}
+	
+	private class RequestHandler implements Runnable
+	{
+		private BufferedReader input;
+		private Scanner scanner;
+		private boolean stop;
+		private Closeable responseHandlerCloseable;
+		
+		public RequestHandler(LocalSocket socket, Closeable responseHandlerCloseable) throws IOException
+		{
+			this.responseHandlerCloseable = responseHandlerCloseable;
+			this.input = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+		}
+
+		public void stop()
+		{
+			this.stop = true;
+			this.scanner.close();
+		}
+		
+		public void run()
+		{
+			scanner = new Scanner(this.input);
+			scanner.useDelimiter("\r\n");
+
+			ArrayList<String> headers = new ArrayList<String>();
+			String line;
+			State state = State.Header;
+			int messageLength = -1;
+			String leftOver = null;
+
+			try
+			{
+				while (!stop && ((line = (leftOver != null) ? leftOver : scanner.nextLine()) != null))
+				{
+					switch (state)
+					{
+					case Header:
+						if (line.length() == 0)
+						{
+							state = State.Message;
+						}
+						else
+						{
+							headers.add(line);
+							if (line.startsWith("Content-Length:"))
+							{
+								String strLen = line.substring(15).trim();
+								messageLength = Integer.parseInt(strLen);
+							}
+							
+							if (leftOver != null)
+							{
+								leftOver = null;
+							}
+						}
+						break;
+						
+					case Message:
+						if ((-1 < messageLength) && (messageLength <= line.length()))
+						{
+							String message = line.substring(0, messageLength);
+							if (messageLength < line.length())
+							{
+								leftOver = line.substring(messageLength);
+							}
+							
+							state = State.Header;
+							headers.clear();
+
+							AndroidJsDebugger.this.debugContext.sendMessage(message);
+						}
+						else
+						{
+							if (leftOver == null)
+							{
+								leftOver = line;
+							}
+							else
+							{
+								leftOver += line;
+							}
+						}
+						break;
+					}
+				}
+			}
+			catch (NoSuchElementException e)
+			{
+				e.printStackTrace();
+
+				try
+				{
+					responseHandlerCloseable.close();
+				}
+				catch (IOException e1)
+				{
+					e1.printStackTrace();
+				}
+			}
+			finally
+			{
+				this.stop = true;
+				//logger.write("sending disconnect to v8 debugger");
+				AndroidJsDebugger.this.debugContext.sendMessage("{\"seq\":0,\"type\":\"request\",\"command\":\"disconnect\"}");
+				
+				scanner.close();
+			}
+		}
+	}
+
+	private class ResponseHandler implements Runnable
+	{
+		private OutputStream output;
+		private boolean stop;
+		private Closeable requestHandlerCloseable;
+
+		public ResponseHandler(LocalSocket socket, Closeable requestHandlerCloseable) throws IOException
+		{
+			this.requestHandlerCloseable = requestHandlerCloseable;
+			this.output = socket.getOutputStream();
+		}
+
+		public void stop()
+		{
+			this.stop = true;
+			AndroidJsDebugger.this.debugContext.dbgMessages.add(STOP_MESSAGE);
+		}
+
+		@Override
+		public void run()
+		{
+			while (!stop)
+			{
+				try
+				{
+					String message = AndroidJsDebugger.this.debugContext.dbgMessages.take();
+					if (message.equals(STOP_MESSAGE))
+					{
+						break;
+					}
+					
+					//Log.d("TNS.JAVA.JsDebugger", "Sending message to inspector:" + message);
+					
+					this.sendMessageToInspector(message);
+				}
+				catch (InterruptedException e)
+				{
+					e.printStackTrace();
+				}
+			}
+			
+			try
+			{
+				this.output.close();
+			}
+			catch (IOException e)
+			{
+				e.printStackTrace();
+			}
+		}
+
+		private void sendMessageToInspector(String msg)
+		{
+			byte[] utf8;
+			try
+			{
+				utf8 = msg.getBytes("UTF8");
+			}
+			catch (UnsupportedEncodingException e1)
+			{
+				utf8 = null;
+				e1.printStackTrace();
+			}
+
+			if (utf8 != null)
+			{
+				try
+				{
+					String s = "Content-Length: " + utf8.length;
+					byte[] arr = s.getBytes("UTF8");
+					output.write(arr);
+					output.write(LINE_END_BYTES);
+					output.write(LINE_END_BYTES);
+					output.write(utf8);
+					output.flush();
+					
+					//Log.d("TNS.JAVA.JsDebugger", "Sent message to inspector:" + msg);
+				}
+				catch (IOException e)
+				{
+					e.printStackTrace();
+					
+					try
+					{
+						requestHandlerCloseable.close();
+					}
+					catch (IOException e1)
+					{
+						e1.printStackTrace();
+					}
+				}
+			}
+		}
+	}
+
+	public void enableAgent()
+	{
+		logger.write("Enabling NativeScript Debugger Agent");
+	}
+
+	public void disableAgent()
+	{
+		logger.write("Disabling NativeScript Debugger Agent");
+		String message = "{\"seq\":0,\"type\":\"request\",\"command\":\"disconnect\"}";
+		
+		AndroidJsDebugger.this.debugContext.sendMessage(message);
+		
+		debugServerThread.stopResponseHandler();
+	}
+
+	private void registerEnableDisableDebuggerReceiver(Handler handler)
+	{
+		String debugAction = context.getPackageName() + "-debug";
+		context.registerReceiver(new BroadcastReceiver()
+		{
+			@Override
+			public void onReceive(Context context, Intent intent)
+			{
+				Bundle bundle = intent.getExtras();
+				if (bundle != null)
+				{
+					boolean enable = bundle.getBoolean("enable", false);
+					if (enable)
+					{
+						enableAgent();
+					}
+					else
+					{
+						disableAgent(); 
+					}
+				}
+			}
+		}, new IntentFilter(debugAction), null, handler);
+	}
+	
+	private boolean getDebugBreakFlagAndClearIt()
+	{
+		File debugBreakFile = new File("/data/local/tmp", context.getPackageName() + "-debugbreak");
+		if (debugBreakFile.exists() && !debugBreakFile.isDirectory() && debugBreakFile.length() == 0)
+		{
+			try
+			{
+				java.io.FileWriter fileWriter = new java.io.FileWriter(debugBreakFile);
+				fileWriter.write("used");
+				fileWriter.close();
+			}
+			catch (IOException e)
+			{
+				Log.e("TNS", "Debug break temp file can not be marked as used. Debug sessions may not work correctly. file: " + debugBreakFile.getAbsolutePath());
+				e.printStackTrace();
+			}
+			
+			return true;
+		}
+		
+		return false;
+	}
+
+	public void start()
+	{
+		debugServerThread = new DebugLocalServerSocketThread(context.getPackageName() + "-debug");
+		debugServerThread.start();
+		
+		handlerThread = new HandlerThread("debugAgentBroadCastReceiverHandler");
+		handlerThread.start();
+		Handler handler = new Handler(handlerThread.getLooper());
+		
+		this.registerEnableDisableDebuggerReceiver(handler);
+		
+		boolean shouldDebugBreak = getDebugBreakFlagAndClearIt();
+		if (shouldDebugBreak)
+		{
+			AndroidJsDebugger.this.debugContext.enableAgent();
+			AndroidJsDebugger.this.debugContext.debugBreak();
+		}
+	}
+	
+	public static boolean isDebuggableApp(Context context)
+	{
+		if (enableDebuggingOverride)
+		{
+			return true;
+		}
+		
+		int flags;
+		try
+		{
+			flags = context.getPackageManager().getPackageInfo(context.getPackageName(), 0).applicationInfo.flags;
+		}
+		catch (NameNotFoundException e)
+		{
+			flags = 0;
+			e.printStackTrace();
+		}
+
+		boolean isDebuggableApp = ((flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0);
+		return isDebuggableApp;
+	}
+}

--- a/build/project-template-gradle/src/main/java/com/tns/ErrorReport.java
+++ b/build/project-template-gradle/src/main/java/com/tns/ErrorReport.java
@@ -114,14 +114,14 @@ class ErrorReport
 	{
 		Class<?> errorActivityClass = ErrorReportActivity.class;
 
-		if (JsDebugger.isDebuggableApp(context))		
+		if (AndroidJsDebugger.isDebuggableApp(context))		
 		{		
 			errorActivityClass = ErrorReportActivity.class;
 		}
 		else {
 			return null;
 		}
-
+		
 		Intent intent = new Intent(context, errorActivityClass);
 
 		intent.putExtra(EXTRA_NATIVESCRIPT_ERROR_REPORT, EXTRA_ERROR_REPORT_VALUE);

--- a/build/project-template-gradle/src/main/java/com/tns/LogcatLogger.java
+++ b/build/project-template-gradle/src/main/java/com/tns/LogcatLogger.java
@@ -41,9 +41,10 @@ public final class LogcatLogger implements Logger
 
 	private void initLogging(Context context)
 	{
-		boolean isDebuggableApp = JsDebugger.isDebuggableApp(context);
-
-		if (isDebuggableApp)
+		// TODO: Pete
+		// boolean isDebuggableApp = JsDebugger.isDebuggableApp(context);
+		// if (isDebuggableApp)
+		if (true)
 		{
 			String verboseLoggingProp = Util.readSystemProperty("nativescript.verbose.logging");
 

--- a/build/project-template-gradle/src/main/java/com/tns/LogcatLogger.java
+++ b/build/project-template-gradle/src/main/java/com/tns/LogcatLogger.java
@@ -6,7 +6,7 @@ import android.util.Log;
 public final class LogcatLogger implements Logger
 {
 	private final static String DEFAULT_LOG_TAG = "TNS.Java";
-	
+
 	private boolean enabled;
 
 	public LogcatLogger(boolean isEnabled, Context context)
@@ -41,10 +41,8 @@ public final class LogcatLogger implements Logger
 
 	private void initLogging(Context context)
 	{
-		// TODO: Pete
-		// boolean isDebuggableApp = JsDebugger.isDebuggableApp(context);
-		// if (isDebuggableApp)
-		if (true)
+		boolean isDebuggableApp = AndroidJsDebugger.isDebuggableApp(context);
+		if (isDebuggableApp)
 		{
 			String verboseLoggingProp = Util.readSystemProperty("nativescript.verbose.logging");
 

--- a/build/project-template-gradle/src/main/java/com/tns/RuntimeHelper.java
+++ b/build/project-template-gradle/src/main/java/com/tns/RuntimeHelper.java
@@ -46,7 +46,8 @@ public class RuntimeHelper
 	{
 		System.loadLibrary("NativeScript");
 		
-		Logger logger = new LogcatLogger(false, app);
+		Logger logger = new LogcatLogger(true, app);
+		Debugger debugger = new AndroidJsDebugger(app, logger);
 		
 		boolean showErrorIntent = hasErrorIntent();
 		if (!showErrorIntent)
@@ -89,7 +90,7 @@ public class RuntimeHelper
 				e.printStackTrace();
 			}
 			ThreadScheduler workThreadScheduler = new WorkThreadScheduler(new Handler(Looper.getMainLooper()));
-			Configuration config = new Configuration(this.app, workThreadScheduler, logger, appName, null, rootDir, appDir, classLoader, dexDir, dexThumb);
+			Configuration config = new Configuration(workThreadScheduler, logger, debugger, appName, null, rootDir, appDir, classLoader, dexDir, dexThumb);
 			Runtime runtime = new Runtime(config);
 			
 			exHandler.setRuntime(runtime);
@@ -114,21 +115,29 @@ public class RuntimeHelper
 				}
 			}
 			
-			
-
-			
 			runtime.init();
 			runtime.runScript(new File(appDir, "internal/ts_helpers.js"));
-
-			File javaClassesModule = new File(appDir, "app/tns-java-classes.js");
-			if (javaClassesModule.exists()) {
-				runtime.runModule(javaClassesModule);
-			}
-
 			Runtime.initInstance(this.app);
 			runtime.run();
 		}
 	}
+	
+/*	public static boolean isDebuggableApp(Context context)
+	{
+		int flags;
+		try
+		{
+			flags = context.getPackageManager().getPackageInfo(context.getPackageName(), 0).applicationInfo.flags;
+		}
+		catch (NameNotFoundException e)
+		{
+			flags = 0;
+			e.printStackTrace();
+		}
+
+		boolean isDebuggableApp = ((flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0);
+		return isDebuggableApp;
+	}*/
 	
 	private final String logTag = "MyApp";
 }

--- a/src/jni/Application.mk
+++ b/src/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_ABI := x86 #armeabi-v7a x86 arm64-v8a
+APP_ABI := armeabi-v7a x86 arm64-v8a
 
 APP_STL := stlport_static
 #APP_STL := gnustl_static

--- a/src/jni/Application.mk
+++ b/src/jni/Application.mk
@@ -1,4 +1,4 @@
-APP_ABI := armeabi-v7a x86 arm64-v8a
+APP_ABI := x86 #armeabi-v7a x86 arm64-v8a
 
 APP_STL := stlport_static
 #APP_STL := gnustl_static

--- a/src/src/com/tns/Configuration.java
+++ b/src/src/com/tns/Configuration.java
@@ -6,9 +6,9 @@ import android.app.Application;
 
 public class Configuration
 {
-	public final Application application;
 	public final ThreadScheduler threadScheduler;
 	public final Logger logger;
+	public final Debugger debugger;
 	public final String appName;
 	public final File runtimeLibPath;
 	public final File rootDir;
@@ -17,13 +17,13 @@ public class Configuration
 	public final File dexDir;
 	public final String dexThumb;
 	
-	public Configuration(Application application, ThreadScheduler threadScheduler, Logger logger, 
+	public Configuration(ThreadScheduler threadScheduler, Logger logger,  Debugger debugger,
 			String appName, File runtimeLibPath, File rootDir, File appDir, ClassLoader classLoader,
 			File dexDir, String dexThumb)
 	{
-		this.application = application;
 		this.threadScheduler = threadScheduler;
 		this.logger = logger;
+		this.debugger = debugger;
 		this.appName = appName;
 		this.runtimeLibPath = runtimeLibPath;
 		this.rootDir = rootDir;

--- a/src/src/com/tns/Debugger.java
+++ b/src/src/com/tns/Debugger.java
@@ -1,0 +1,12 @@
+package com.tns;
+
+public interface Debugger
+{
+	void start();
+	
+	void disableAgent();
+	
+	void enableAgent();
+	
+	void onConnect(JsDebugger context);
+}

--- a/src/src/com/tns/JsDebugger.java
+++ b/src/src/com/tns/JsDebugger.java
@@ -1,420 +1,75 @@
 package com.tns;
 
-import java.io.BufferedReader;
-import java.io.Closeable;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
-import java.util.ArrayList;
-import java.util.NoSuchElementException;
-import java.util.Scanner;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import android.content.BroadcastReceiver;
-import android.content.Context;
-import android.content.Intent;
-import android.content.IntentFilter;
-import android.content.pm.ApplicationInfo;
-import android.content.pm.PackageManager.NameNotFoundException;
-import android.net.LocalServerSocket;
-import android.net.LocalSocket;
-import android.os.Bundle;
-import android.os.Handler;
-import android.os.HandlerThread;
-import android.util.Log;
-
 public class JsDebugger
 {
-	public static boolean enableDebuggingOverride;
+	public native void processDebugMessages();
 
+	public native void enable();
 
-	private static native void processDebugMessages();
+	public native void disable();
 
-	private static native void enable();
+	public native void debugBreak();
 
-	private static native void disable();
-
-	private static native void debugBreak();
-
-	private static native void sendCommand(byte[] command, int length);
+	public native void sendCommand(byte[] command, int length);
 	
-	private static native boolean isDebuggerActive();
-
-	private ThreadScheduler threadScheduler;
-
-	private LinkedBlockingQueue<String> dbgMessages = new LinkedBlockingQueue<String>();
-	private LinkedBlockingQueue<String> compileMessages = new LinkedBlockingQueue<String>();
-	
-	private Logger logger;
-	private Context context;
-	private DebugLocalServerSocketThread debugServerThread;
+	public native static boolean isDebuggerActive();
 
 	private final static  String STOP_MESSAGE = "STOP_MESSAGE";
 	
 	private byte[] LINE_END_BYTES;
 
-	private HandlerThread handlerThread;
+	private final Debugger debugger;
 	
-	public JsDebugger(Context context, Logger logger, ThreadScheduler threadScheduler)
-	{
-		this.context = context;
-		this.logger = logger;
-		this.threadScheduler = threadScheduler;
-		
-		LINE_END_BYTES = new byte[2];
-		LINE_END_BYTES[0] = (byte) '\r';
-		LINE_END_BYTES[1] = (byte) '\n';
-	}
-
-	private class DebugLocalServerSocketThread extends Thread
-    {
-        private volatile boolean running;
-        private final String name;
-
-        private RequestHandler requestHandler;
-        private LocalServerSocket serverSocket;
-		private ResponseHandler responseHandler;
-		
-		
-        public DebugLocalServerSocketThread(String name)
-        {
-            this.name = name;
-            this.running = false;
-        }
-
-        public void stopResponseHandler()
-		{
-			this.responseHandler.stop();
-		}
-        
-        
-        public void run()
-        {
-        	Closeable requestHandlerCloseable = new Closeable()
-    		{
-    			@Override
-    			public void close() throws IOException
-    			{
-    				requestHandler.stop();
-    			}
-    		};
-    		
-    		Closeable responseHandlerCloseable = new Closeable()
-    		{
-    			@Override
-    			public void close() throws IOException
-    			{
-    				responseHandler.stop();
-    			}
-    		};
-        	
-            running = true;
-            try
-            {
-                serverSocket = new LocalServerSocket(this.name);
-                try 
-                {
-	                while (running)
-	                {
-	                	try
-	    				{
-	                		LocalSocket socket = serverSocket.accept();
-
-	                		logger.write("NativeScript Debugger new connection on: " + socket.getFileDescriptor().toString());
-	                		
-	    					//out (send messages to node inspector)
-	    					this.responseHandler = new ResponseHandler(socket, requestHandlerCloseable);
-	    					Thread responseThread = new Thread(this.responseHandler);
-	    					responseThread.start();
-	    
-	    					//in (recieve messages from node inspector)
-	    					requestHandler = new RequestHandler(socket, responseHandlerCloseable);
-	    					Thread requestThread = new Thread(requestHandler);
-	    					requestThread.start();
-	    					
-	    					requestThread.join();
-	    					
-	    					this.responseHandler.stop();
-	    					socket.close();
-	    					
-	    					dbgMessages.clear();
-	                		dbgMessages.addAll(compileMessages);
-	    				}
-	    				catch (IOException e)
-	    				{
-	    					e.printStackTrace();
-	    				}
-	                	catch (InterruptedException e) {
-	                		e.printStackTrace();
-	                	}
-	                }
-                }
-                finally
-                {
-                	try
-        			{
-        				serverSocket.close();
-        			}
-        			catch (IOException e)
-        			{
-        				e.printStackTrace();
-        			}
-                }
-            }
-            catch (IOException e)
-            {
-            	e.printStackTrace();
-            }
-        }
-    }
-
-	private enum State
-	{
-		Header, Message
-	}
+	private final ThreadScheduler threadScheduler;
 	
-	private class RequestHandler implements Runnable
+	private final Runnable dispatchProcessDebugMessages = new Runnable()
 	{
-		private BufferedReader input;
-		private Scanner scanner;
-
-		Runnable dispatchProcessDebugMessages = new Runnable()
-		{
-			@Override
-			public void run()
-			{
-				processDebugMessages();
-			}
-		};
-
-		private boolean stop;
-		private Closeable responseHandlerCloseable;
-		
-		public RequestHandler(LocalSocket socket, Closeable responseHandlerCloseable) throws IOException
-		{
-			this.responseHandlerCloseable = responseHandlerCloseable;
-			this.input = new BufferedReader(new InputStreamReader(socket.getInputStream()));
-		}
-
-		public void stop()
-		{
-			this.stop = true;
-			this.scanner.close();
-		}
-		
-		public void run()
-		{
-			scanner = new Scanner(this.input);
-			scanner.useDelimiter("\r\n");
-
-			ArrayList<String> headers = new ArrayList<String>();
-			String line;
-			State state = State.Header;
-			int messageLength = -1;
-			String leftOver = null;
-
-			try
-			{
-				while (!stop && ((line = (leftOver != null) ? leftOver : scanner.nextLine()) != null))
-				{
-					switch (state)
-					{
-					case Header:
-						if (line.length() == 0)
-						{
-							state = State.Message;
-						}
-						else
-						{
-							headers.add(line);
-							if (line.startsWith("Content-Length:"))
-							{
-								String strLen = line.substring(15).trim();
-								messageLength = Integer.parseInt(strLen);
-							}
-							
-							if (leftOver != null)
-							{
-								leftOver = null;
-							}
-						}
-						break;
-						
-					case Message:
-						if ((-1 < messageLength) && (messageLength <= line.length()))
-						{
-							String msg = line.substring(0, messageLength);
-							if (messageLength < line.length())
-							{
-								leftOver = line.substring(messageLength);
-							}
-							
-							state = State.Header;
-							headers.clear();
-
-							sendMessageToV8(msg);
-						}
-						else
-						{
-							if (leftOver == null)
-							{
-								leftOver = line;
-							}
-							else
-							{
-								leftOver += line;
-							}
-						}
-						break;
-					}
-				}
-			}
-			catch (NoSuchElementException e)
-			{
-				e.printStackTrace();
-
-				try
-				{
-					responseHandlerCloseable.close();
-				}
-				catch (IOException e1)
-				{
-					e1.printStackTrace();
-				}
-			}
-			finally
-			{
-				this.stop = true;
-				//logger.write("sending disconnect to v8 debugger");
-				sendMessageToV8("{\"seq\":0,\"type\":\"request\",\"command\":\"disconnect\"}");
-				scanner.close();
-			}
-		}
-
-		private void sendMessageToV8(String message)
-		{
-			try
-			{
-				//Log.d("TNS.JAVA.JsDebugger", "Sending message to v8:" + message);
-				
-				byte[] cmdBytes = message.getBytes("UTF-16LE");
-				int cmdLength = cmdBytes.length;
-				sendCommand(cmdBytes, cmdLength);
-
-				threadScheduler.post(dispatchProcessDebugMessages);
-			}
-			catch (UnsupportedEncodingException e)
-			{
-				e.printStackTrace();
-			}
-		}
-	}
-
-	private class ResponseHandler implements Runnable
-	{
-		private OutputStream output;
-		private boolean stop;
-		private Closeable requestHandlerCloseable;
-
-		public ResponseHandler(LocalSocket socket, Closeable requestHandlerCloseable) throws IOException
-		{
-			this.requestHandlerCloseable = requestHandlerCloseable;
-			this.output = socket.getOutputStream();
-		}
-
-		public void stop()
-		{
-			this.stop = true;
-			dbgMessages.add(STOP_MESSAGE);
-		}
-
 		@Override
 		public void run()
 		{
-			while (!stop)
-			{
-				try
-				{
-					String message = dbgMessages.take();
-					if (message.equals(STOP_MESSAGE))
-					{
-						break;
-					}
-					
-					//Log.d("TNS.JAVA.JsDebugger", "Sending message to inspector:" + message);
-					
-					sendMessageToInspector(message);
-				}
-				catch (InterruptedException e)
-				{
-					e.printStackTrace();
-				}
-			}
-			
-			try
-			{
-				this.output.close();
-			}
-			catch (IOException e)
-			{
-				e.printStackTrace();
-			}
+			processDebugMessages();
 		}
-
-		private void sendMessageToInspector(String msg)
-		{
-			byte[] utf8;
-			try
-			{
-				utf8 = msg.getBytes("UTF8");
-			}
-			catch (UnsupportedEncodingException e1)
-			{
-				utf8 = null;
-				e1.printStackTrace();
-			}
-
-			if (utf8 != null)
-			{
-				try
-				{
-					String s = "Content-Length: " + utf8.length;
-					byte[] arr = s.getBytes("UTF8");
-					output.write(arr);
-					output.write(LINE_END_BYTES);
-					output.write(LINE_END_BYTES);
-					output.write(utf8);
-					output.flush();
-					
-					//Log.d("TNS.JAVA.JsDebugger", "Sent message to inspector:" + msg);
-				}
-				catch (IOException e)
-				{
-					e.printStackTrace();
-					
-					try
-					{
-						requestHandlerCloseable.close();
-					}
-					catch (IOException e1)
-					{
-						e1.printStackTrace();
-					}
-				}
-			}
-		}
+	};
+	
+	public LinkedBlockingQueue<String> dbgMessages = new LinkedBlockingQueue<String>();
+	public LinkedBlockingQueue<String> compileMessages = new LinkedBlockingQueue<String>();
+	
+	public JsDebugger(Debugger debugger, ThreadScheduler threadScheduler)
+	{
+		this.debugger = debugger;
+		this.threadScheduler = threadScheduler;
+		
+		this.debugger.onConnect(this);
 	}
 
-	@RuntimeCallable
-	private void enqueueMessage(String message)
+	public void sendMessage(String message)
 	{
-		//logger.write("Debug msg:" + message);
+		byte[] cmdBytes = null;
 		
+		try
+		{
+			cmdBytes = message.getBytes("UTF-16LE");
+		}
+		catch (UnsupportedEncodingException e)
+		{
+			e.printStackTrace();
+		}
+		int cmdLength = cmdBytes.length;
+		
+		sendCommand(cmdBytes, cmdLength);
+		
+		threadScheduler.post(dispatchProcessDebugMessages);
+	}
+	
+	@RuntimeCallable
+	public void enqueueMessage(String message)
+	{
 		dbgMessages.add(message);
 		
 		if (message.contains("type\":\"event") &&
@@ -426,7 +81,7 @@ public class JsDebugger
 	}
 	
 	@RuntimeCallable
-	private void enqueueConsoleMessage(String text, String level, int lineNumber, int columnNumber, String srcFileName)
+	public void enqueueConsoleMessage(String text, String level, int lineNumber, int columnNumber, String srcFileName)
 	{
 		//    			var consoleEvent = {
 		//	    			"seq":0,
@@ -477,7 +132,7 @@ public class JsDebugger
 			
 			String sendingText = consoleMessage.toString();
 			
-			logger.write("Sending console message to inspector:" + sendingText);
+			//logger.write("Sending console message to inspector:" + sendingText);
 			
 			dbgMessages.add(sendingText);
 		}
@@ -488,128 +143,26 @@ public class JsDebugger
 	}
 
 	@RuntimeCallable
-	private void enableAgent()
+	public void enableAgent()
 	{
-		logger.write("Enabling NativeScript Debugger Agent");
 		enable();
+		
+		this.debugger.enableAgent();
 	}
 
 	@RuntimeCallable
-	private void disableAgent()
+	public void disableAgent()
 	{
-		logger.write("Disabling NativeScript Debugger Agent");
 		disable();
 		
-		
-		String message = "{\"seq\":0,\"type\":\"request\",\"command\":\"disconnect\"}";
-		
-		byte[] cmdBytes;
-		try
-		{
-			cmdBytes = message.getBytes("UTF-16LE");
-			int cmdLength = cmdBytes.length;
-			sendCommand(cmdBytes, cmdLength);
-		}
-		catch (UnsupportedEncodingException e)
-		{
-			e.printStackTrace();
-		}
-		
-		debugServerThread.stopResponseHandler();
-	}
-
-	private void registerEnableDisableDebuggerReceiver(Handler handler)
-	{
-		String debugAction = context.getPackageName() + "-debug";
-		context.registerReceiver(new BroadcastReceiver()
-		{
-			@Override
-			public void onReceive(Context context, Intent intent)
-			{
-				Bundle bundle = intent.getExtras();
-				if (bundle != null)
-				{
-					boolean enable = bundle.getBoolean("enable", false);
-					if (enable)
-					{
-						enableAgent();
-					}
-					else
-					{
-						disableAgent(); 
-					}
-				}
-			}
-		}, new IntentFilter(debugAction), null, handler);
-	}
-	
-	
-
-	private boolean getDebugBreakFlagAndClearIt()
-	{
-		File debugBreakFile = new File("/data/local/tmp", context.getPackageName() + "-debugbreak");
-		if (debugBreakFile.exists() && !debugBreakFile.isDirectory() && debugBreakFile.length() == 0)
-		{
-			try
-			{
-				java.io.FileWriter fileWriter = new java.io.FileWriter(debugBreakFile);
-				fileWriter.write("used");
-				fileWriter.close();
-			}
-			catch (IOException e)
-			{
-				Log.e("TNS", "Debug break temp file can not be marked as used. Debug sessions may not work correctly. file: " + debugBreakFile.getAbsolutePath());
-				e.printStackTrace();
-			}
-			
-			return true;
-		}
-		
-		return false;
+		this.debugger.disableAgent();
 	}
 
 	public void start()
 	{
-		debugServerThread = new DebugLocalServerSocketThread(context.getPackageName() + "-debug");
-		debugServerThread.start();
-		
-		
-		handlerThread = new HandlerThread("debugAgentBroadCastReceiverHandler");
-		handlerThread.start();
-		Handler handler = new Handler(handlerThread.getLooper());
-		
-		registerEnableDisableDebuggerReceiver(handler);
-		
-		boolean shouldDebugBreak = getDebugBreakFlagAndClearIt();
-		if (shouldDebugBreak)
-		{
-			enableAgent();
-			debugBreak();
-		}
+		this.debugger.start();
 	}
 	
-	public static boolean isDebuggableApp(Context context)
-	{
-		if (enableDebuggingOverride)
-		{
-			return true;
-		}
-		
-		int flags;
-		try
-		{
-			flags = context.getPackageManager().getPackageInfo(context.getPackageName(), 0).applicationInfo.flags;
-		}
-		catch (NameNotFoundException e)
-		{
-			flags = 0;
-			e.printStackTrace();
-		}
-
-		boolean isDebuggableApp = ((flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0);
-		return isDebuggableApp;
-	}
-
 	public static boolean isJsDebuggerActive()
 	{
 		return isDebuggerActive();

--- a/src/src/com/tns/Runtime.java
+++ b/src/src/com/tns/Runtime.java
@@ -159,10 +159,10 @@ public class Runtime
 	
 	public void init()
 	{
-		init(config.application, config.threadScheduler, config.logger, config.appName, config.runtimeLibPath, config.rootDir, config.appDir, config.classLoader, config.dexDir, config.dexThumb);
+		init(config.threadScheduler, config.logger, config.debugger, config.appName, config.runtimeLibPath, config.rootDir, config.appDir, config.classLoader, config.dexDir, config.dexThumb);
 	}
 
-	private void init(Application application, ThreadScheduler threadScheduler, Logger logger, String appName, File runtimeLibPath, File rootDir, File appDir, ClassLoader classLoader, File dexDir, String dexThumb) throws RuntimeException
+	private void init(ThreadScheduler threadScheduler, Logger logger, Debugger debugger, String appName, File runtimeLibPath, File rootDir, File appDir, ClassLoader classLoader, File dexDir, String dexThumb) throws RuntimeException
 	{
 		if (initialized)
 		{
@@ -190,9 +190,9 @@ public class Runtime
 		}
 		Object[] v8Config = V8Config.fromPackageJSON(appDir);
 
-		if (JsDebugger.isDebuggableApp(application))
+		if (debugger != null)//JsDebugger.isDebuggableApp(application))
 		{
-			jsDebugger = new JsDebugger(application, logger, threadScheduler);
+			jsDebugger = new JsDebugger(debugger, threadScheduler);
 		}
 		
 		initNativeScript(getRuntimeId(), Module.getApplicationFilesPath(), logger.isEnabled(), appName, v8Config, jsDebugger);
@@ -201,6 +201,7 @@ public class Runtime
 		{
 			jsDebugger.start();
 		}
+		
 		ClearStartupData(getRuntimeId()); // It's safe to delete the data after the V8 debugger is initialized
 		
 		if (logger.isEnabled())

--- a/test-app/assets/app/MyActivity.js
+++ b/test-app/assets/app/MyActivity.js
@@ -29,8 +29,8 @@ var MyActivity = (function (_super) {
     MyActivity.prototype.onCreate = function (bundle) {
         _super.prototype.onCreate.call(this, bundle);
         
-    	require("./tests/testsWithContext").run(this);
-    	execute(); //run jasmine
+//    	require("./tests/testsWithContext").run(this);
+//    	execute(); //run jasmine
 
     	var layout = new android.widget.LinearLayout(this);
     	layout.setOrientation(1);
@@ -54,6 +54,7 @@ var MyActivity = (function (_super) {
     	button.setOnClickListener(new android.view.View.OnClickListener("AppClickListener", {
     		onClick:  function() {
     			button.setBackgroundColor(colors[taps % colors.length]);
+    			
     			taps++;
     		}}));
     };

--- a/test-app/assets/app/MyActivity.js
+++ b/test-app/assets/app/MyActivity.js
@@ -29,8 +29,8 @@ var MyActivity = (function (_super) {
     MyActivity.prototype.onCreate = function (bundle) {
         _super.prototype.onCreate.call(this, bundle);
         
-//    	require("./tests/testsWithContext").run(this);
-//    	execute(); //run jasmine
+    	require("./tests/testsWithContext").run(this);
+    	execute(); //run jasmine
 
     	var layout = new android.widget.LinearLayout(this);
     	layout.setOrientation(1);

--- a/test-app/src/com/tns/AndroidJsDebugger.java
+++ b/test-app/src/com/tns/AndroidJsDebugger.java
@@ -1,0 +1,470 @@
+package com.tns;
+
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.NoSuchElementException;
+import java.util.Scanner;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager.NameNotFoundException;
+import android.net.LocalServerSocket;
+import android.net.LocalSocket;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.util.Log;
+
+public class AndroidJsDebugger implements Debugger
+{
+	@Override
+	public void onConnect(JsDebugger context)
+	{
+		this.debugContext = context;
+	}
+
+	public static boolean enableDebuggingOverride;
+
+	private Logger logger;
+	private Context context;
+	private DebugLocalServerSocketThread debugServerThread;
+	private JsDebugger debugContext;
+
+	private final static  String STOP_MESSAGE = "STOP_MESSAGE";
+
+	private byte[] LINE_END_BYTES;
+
+	private HandlerThread handlerThread;
+
+	public AndroidJsDebugger(Context context, Logger logger)
+	{
+		this.context = context;
+		this.logger = logger;
+		LINE_END_BYTES = new byte[2];
+		LINE_END_BYTES[0] = (byte) '\r';
+		LINE_END_BYTES[1] = (byte) '\n';
+	}
+
+	private class DebugLocalServerSocketThread extends Thread
+    {
+        private volatile boolean running;
+        private final String name;
+
+        private RequestHandler requestHandler;
+        private LocalServerSocket serverSocket;
+		private ResponseHandler responseHandler;
+		
+        public DebugLocalServerSocketThread(String name)
+        {
+            this.name = name;
+            this.running = false;
+        }
+
+        public void stopResponseHandler()
+		{
+			this.responseHandler.stop();
+		}        
+        
+        public void run()
+        {
+        	Closeable requestHandlerCloseable = new Closeable()
+    		{
+    			@Override
+    			public void close() throws IOException
+    			{
+    				requestHandler.stop();
+    			}
+    		};
+    		
+    		Closeable responseHandlerCloseable = new Closeable()
+    		{
+    			@Override
+    			public void close() throws IOException
+    			{
+    				responseHandler.stop();
+    			}
+    		};
+        	
+            running = true;
+            try
+            {
+                serverSocket = new LocalServerSocket(this.name);
+                try 
+                {
+	                while (running)
+	                {
+	                	try
+	    				{
+	                		LocalSocket socket = serverSocket.accept();
+
+	                		logger.write("NativeScript Debugger new connection on: " + socket.getFileDescriptor().toString());
+	                		
+	    					//out (send messages to node inspector)
+	    					this.responseHandler = new ResponseHandler(socket, requestHandlerCloseable);
+	    					Thread responseThread = new Thread(this.responseHandler);
+	    					responseThread.start();
+	    
+	    					//in (recieve messages from node inspector)
+	    					requestHandler = new RequestHandler(socket, responseHandlerCloseable);
+	    					Thread requestThread = new Thread(requestHandler);
+	    					requestThread.start();
+	    					
+	    					requestThread.join();
+	    					
+	    					this.responseHandler.stop();
+	    					socket.close();
+	    					
+	    					AndroidJsDebugger.this.debugContext.dbgMessages.clear();
+	    					AndroidJsDebugger.this.debugContext.dbgMessages.addAll(AndroidJsDebugger.this.debugContext.compileMessages);
+	    				}
+	    				catch (IOException e)
+	    				{
+	    					e.printStackTrace();
+	    				}
+	                	catch (InterruptedException e) {
+	                		e.printStackTrace();
+	                	}
+	                }
+                }
+                finally
+                {
+                	try
+        			{
+        				serverSocket.close();
+        			}
+        			catch (IOException e)
+        			{
+        				e.printStackTrace();
+        			}
+                }
+            }
+            catch (IOException e)
+            {
+            	e.printStackTrace();
+            }
+        }
+    }
+
+	private enum State
+	{
+		Header, Message
+	}
+	
+	private class RequestHandler implements Runnable
+	{
+		private BufferedReader input;
+		private Scanner scanner;
+		private boolean stop;
+		private Closeable responseHandlerCloseable;
+		
+		public RequestHandler(LocalSocket socket, Closeable responseHandlerCloseable) throws IOException
+		{
+			this.responseHandlerCloseable = responseHandlerCloseable;
+			this.input = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+		}
+
+		public void stop()
+		{
+			this.stop = true;
+			this.scanner.close();
+		}
+		
+		public void run()
+		{
+			scanner = new Scanner(this.input);
+			scanner.useDelimiter("\r\n");
+
+			ArrayList<String> headers = new ArrayList<String>();
+			String line;
+			State state = State.Header;
+			int messageLength = -1;
+			String leftOver = null;
+
+			try
+			{
+				while (!stop && ((line = (leftOver != null) ? leftOver : scanner.nextLine()) != null))
+				{
+					switch (state)
+					{
+					case Header:
+						if (line.length() == 0)
+						{
+							state = State.Message;
+						}
+						else
+						{
+							headers.add(line);
+							if (line.startsWith("Content-Length:"))
+							{
+								String strLen = line.substring(15).trim();
+								messageLength = Integer.parseInt(strLen);
+							}
+							
+							if (leftOver != null)
+							{
+								leftOver = null;
+							}
+						}
+						break;
+						
+					case Message:
+						if ((-1 < messageLength) && (messageLength <= line.length()))
+						{
+							String message = line.substring(0, messageLength);
+							if (messageLength < line.length())
+							{
+								leftOver = line.substring(messageLength);
+							}
+							
+							state = State.Header;
+							headers.clear();
+
+							AndroidJsDebugger.this.debugContext.sendMessage(message);
+						}
+						else
+						{
+							if (leftOver == null)
+							{
+								leftOver = line;
+							}
+							else
+							{
+								leftOver += line;
+							}
+						}
+						break;
+					}
+				}
+			}
+			catch (NoSuchElementException e)
+			{
+				e.printStackTrace();
+
+				try
+				{
+					responseHandlerCloseable.close();
+				}
+				catch (IOException e1)
+				{
+					e1.printStackTrace();
+				}
+			}
+			finally
+			{
+				this.stop = true;
+				//logger.write("sending disconnect to v8 debugger");
+				AndroidJsDebugger.this.debugContext.sendMessage("{\"seq\":0,\"type\":\"request\",\"command\":\"disconnect\"}");
+				
+				scanner.close();
+			}
+		}
+	}
+
+	private class ResponseHandler implements Runnable
+	{
+		private OutputStream output;
+		private boolean stop;
+		private Closeable requestHandlerCloseable;
+
+		public ResponseHandler(LocalSocket socket, Closeable requestHandlerCloseable) throws IOException
+		{
+			this.requestHandlerCloseable = requestHandlerCloseable;
+			this.output = socket.getOutputStream();
+		}
+
+		public void stop()
+		{
+			this.stop = true;
+			AndroidJsDebugger.this.debugContext.dbgMessages.add(STOP_MESSAGE);
+		}
+
+		@Override
+		public void run()
+		{
+			while (!stop)
+			{
+				try
+				{
+					String message = AndroidJsDebugger.this.debugContext.dbgMessages.take();
+					if (message.equals(STOP_MESSAGE))
+					{
+						break;
+					}
+					
+					//Log.d("TNS.JAVA.JsDebugger", "Sending message to inspector:" + message);
+					
+					this.sendMessageToInspector(message);
+				}
+				catch (InterruptedException e)
+				{
+					e.printStackTrace();
+				}
+			}
+			
+			try
+			{
+				this.output.close();
+			}
+			catch (IOException e)
+			{
+				e.printStackTrace();
+			}
+		}
+
+		private void sendMessageToInspector(String msg)
+		{
+			byte[] utf8;
+			try
+			{
+				utf8 = msg.getBytes("UTF8");
+			}
+			catch (UnsupportedEncodingException e1)
+			{
+				utf8 = null;
+				e1.printStackTrace();
+			}
+
+			if (utf8 != null)
+			{
+				try
+				{
+					String s = "Content-Length: " + utf8.length;
+					byte[] arr = s.getBytes("UTF8");
+					output.write(arr);
+					output.write(LINE_END_BYTES);
+					output.write(LINE_END_BYTES);
+					output.write(utf8);
+					output.flush();
+					
+					//Log.d("TNS.JAVA.JsDebugger", "Sent message to inspector:" + msg);
+				}
+				catch (IOException e)
+				{
+					e.printStackTrace();
+					
+					try
+					{
+						requestHandlerCloseable.close();
+					}
+					catch (IOException e1)
+					{
+						e1.printStackTrace();
+					}
+				}
+			}
+		}
+	}
+
+	public void enableAgent()
+	{
+		logger.write("Enabling NativeScript Debugger Agent");
+	}
+
+	public void disableAgent()
+	{
+		logger.write("Disabling NativeScript Debugger Agent");
+		String message = "{\"seq\":0,\"type\":\"request\",\"command\":\"disconnect\"}";
+		
+		AndroidJsDebugger.this.debugContext.sendMessage(message);
+		
+		debugServerThread.stopResponseHandler();
+	}
+
+	private void registerEnableDisableDebuggerReceiver(Handler handler)
+	{
+		String debugAction = context.getPackageName() + "-debug";
+		context.registerReceiver(new BroadcastReceiver()
+		{
+			@Override
+			public void onReceive(Context context, Intent intent)
+			{
+				Bundle bundle = intent.getExtras();
+				if (bundle != null)
+				{
+					boolean enable = bundle.getBoolean("enable", false);
+					if (enable)
+					{
+						enableAgent();
+					}
+					else
+					{
+						disableAgent(); 
+					}
+				}
+			}
+		}, new IntentFilter(debugAction), null, handler);
+	}
+	
+	private boolean getDebugBreakFlagAndClearIt()
+	{
+		File debugBreakFile = new File("/data/local/tmp", context.getPackageName() + "-debugbreak");
+		if (debugBreakFile.exists() && !debugBreakFile.isDirectory() && debugBreakFile.length() == 0)
+		{
+			try
+			{
+				java.io.FileWriter fileWriter = new java.io.FileWriter(debugBreakFile);
+				fileWriter.write("used");
+				fileWriter.close();
+			}
+			catch (IOException e)
+			{
+				Log.e("TNS", "Debug break temp file can not be marked as used. Debug sessions may not work correctly. file: " + debugBreakFile.getAbsolutePath());
+				e.printStackTrace();
+			}
+			
+			return true;
+		}
+		
+		return false;
+	}
+
+	public void start()
+	{
+		debugServerThread = new DebugLocalServerSocketThread(context.getPackageName() + "-debug");
+		debugServerThread.start();
+		
+		handlerThread = new HandlerThread("debugAgentBroadCastReceiverHandler");
+		handlerThread.start();
+		Handler handler = new Handler(handlerThread.getLooper());
+		
+		this.registerEnableDisableDebuggerReceiver(handler);
+		
+		boolean shouldDebugBreak = getDebugBreakFlagAndClearIt();
+		if (shouldDebugBreak)
+		{
+			AndroidJsDebugger.this.debugContext.enableAgent();
+			AndroidJsDebugger.this.debugContext.debugBreak();
+		}
+	}
+	
+	public static boolean isDebuggableApp(Context context)
+	{
+		if (enableDebuggingOverride)
+		{
+			return true;
+		}
+		
+		int flags;
+		try
+		{
+			flags = context.getPackageManager().getPackageInfo(context.getPackageName(), 0).applicationInfo.flags;
+		}
+		catch (NameNotFoundException e)
+		{
+			flags = 0;
+			e.printStackTrace();
+		}
+
+		boolean isDebuggableApp = ((flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0);
+		return isDebuggableApp;
+	}
+}

--- a/test-app/src/com/tns/ErrorReport.java
+++ b/test-app/src/com/tns/ErrorReport.java
@@ -114,6 +114,14 @@ class ErrorReport
 	{
 		Class<?> errorActivityClass = ErrorReportActivity.class;
 
+		if (AndroidJsDebugger.isDebuggableApp(context))		
+		{		
+			errorActivityClass = ErrorReportActivity.class;
+		}
+		else {
+			return null;
+		}
+		
 		Intent intent = new Intent(context, errorActivityClass);
 
 		intent.putExtra(EXTRA_NATIVESCRIPT_ERROR_REPORT, EXTRA_ERROR_REPORT_VALUE);

--- a/test-app/src/com/tns/LogcatLogger.java
+++ b/test-app/src/com/tns/LogcatLogger.java
@@ -41,9 +41,7 @@ public final class LogcatLogger implements Logger
 
 	private void initLogging(Context context)
 	{
-		boolean isDebuggableApp = JsDebugger.isDebuggableApp(context);
-
-		if (isDebuggableApp)
+		if (true)
 		{
 			String verboseLoggingProp = Util.readSystemProperty("nativescript.verbose.logging");
 

--- a/test-app/src/com/tns/LogcatLogger.java
+++ b/test-app/src/com/tns/LogcatLogger.java
@@ -41,6 +41,9 @@ public final class LogcatLogger implements Logger
 
 	private void initLogging(Context context)
 	{
+		// TODO: Pete
+		// boolean isDebuggableApp = JsDebugger.isDebuggableApp(context);
+		// if (isDebuggableApp)
 		if (true)
 		{
 			String verboseLoggingProp = Util.readSystemProperty("nativescript.verbose.logging");

--- a/test-app/src/com/tns/LogcatLogger.java
+++ b/test-app/src/com/tns/LogcatLogger.java
@@ -6,7 +6,7 @@ import android.util.Log;
 public final class LogcatLogger implements Logger
 {
 	private final static String DEFAULT_LOG_TAG = "TNS.Java";
-	
+
 	private boolean enabled;
 
 	public LogcatLogger(boolean isEnabled, Context context)
@@ -41,10 +41,8 @@ public final class LogcatLogger implements Logger
 
 	private void initLogging(Context context)
 	{
-		// TODO: Pete
-		// boolean isDebuggableApp = JsDebugger.isDebuggableApp(context);
-		// if (isDebuggableApp)
-		if (true)
+		boolean isDebuggableApp = AndroidJsDebugger.isDebuggableApp(context);
+		if (isDebuggableApp)
 		{
 			String verboseLoggingProp = Util.readSystemProperty("nativescript.verbose.logging");
 

--- a/test-app/src/com/tns/RuntimeHelper.java
+++ b/test-app/src/com/tns/RuntimeHelper.java
@@ -122,22 +122,5 @@ public class RuntimeHelper
 		}
 	}
 	
-/*	public static boolean isDebuggableApp(Context context)
-	{
-		int flags;
-		try
-		{
-			flags = context.getPackageManager().getPackageInfo(context.getPackageName(), 0).applicationInfo.flags;
-		}
-		catch (NameNotFoundException e)
-		{
-			flags = 0;
-			e.printStackTrace();
-		}
-
-		boolean isDebuggableApp = ((flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0);
-		return isDebuggableApp;
-	}*/
-	
 	private final String logTag = "MyApp";
 }

--- a/test-app/src/com/tns/RuntimeHelper.java
+++ b/test-app/src/com/tns/RuntimeHelper.java
@@ -47,6 +47,7 @@ public class RuntimeHelper
 		System.loadLibrary("NativeScript");
 		
 		Logger logger = new LogcatLogger(true, app);
+		Debugger debugger = new AndroidJsDebugger(app, logger);
 		
 		boolean showErrorIntent = hasErrorIntent();
 		if (!showErrorIntent)
@@ -89,7 +90,7 @@ public class RuntimeHelper
 				e.printStackTrace();
 			}
 			ThreadScheduler workThreadScheduler = new WorkThreadScheduler(new Handler(Looper.getMainLooper()));
-			Configuration config = new Configuration(this.app, workThreadScheduler, logger, appName, null, rootDir, appDir, classLoader, dexDir, dexThumb);
+			Configuration config = new Configuration(workThreadScheduler, logger, debugger, appName, null, rootDir, appDir, classLoader, dexDir, dexThumb);
 			Runtime runtime = new Runtime(config);
 			
 			exHandler.setRuntime(runtime);
@@ -114,15 +115,29 @@ public class RuntimeHelper
 				}
 			}
 			
-			
-
-			
 			runtime.init();
 			runtime.runScript(new File(appDir, "internal/ts_helpers.js"));
 			Runtime.initInstance(this.app);
 			runtime.run();
 		}
 	}
+	
+/*	public static boolean isDebuggableApp(Context context)
+	{
+		int flags;
+		try
+		{
+			flags = context.getPackageManager().getPackageInfo(context.getPackageName(), 0).applicationInfo.flags;
+		}
+		catch (NameNotFoundException e)
+		{
+			flags = 0;
+			e.printStackTrace();
+		}
+
+		boolean isDebuggableApp = ((flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0);
+		return isDebuggableApp;
+	}*/
 	
 	private final String logTag = "MyApp";
 }


### PR DESCRIPTION
Moved the android debugger implementation to the project template leaving native calls to JsDebugger in the runtime

ping @slavchev @blagoev @Plamen5kov @atanasovg 