### PR TITLE
Added a more descriptive error message in the app boostrap.

### DIFF
--- a/src/src/com/tns/Module.java
+++ b/src/src/com/tns/Module.java
@@ -249,7 +249,7 @@ class Module
 		// 2. Check for index.js
 		// 3. Check for bootstrap.js
 
-		String notFoundMessage = "Application entry point file not found. Please specify the file in package.json otherwise make sure the file index.js or bootstrap.js exists. \\n If using typescript make sure your entry point file is transpiled to javascript.";
+		String notFoundMessage = "Application entry point file not found. Please specify the file in package.json otherwise make sure the file index.js or bootstrap.js exists.\\nIf using typescript make sure your entry point file is transpiled to javascript.";
 
         // resolvePathHelper() never returns a non-existing file. Instead it throws an exception.
 		File bootstrapFile;

--- a/src/src/com/tns/Module.java
+++ b/src/src/com/tns/Module.java
@@ -249,18 +249,25 @@ class Module
 		// 2. Check for index.js
 		// 3. Check for bootstrap.js
 
-		File bootstrapFile = resolvePathHelper("./", "");
-		if (!bootstrapFile.exists())
-		{
-			bootstrapFile = resolvePathHelper("./bootstrap", "");
+		String notFoundMessage = "Application entry point file not found. Please specify the file in package.json otherwise make sure the file index.js or bootstrap.js exists. \\n If using typescript make sure your entry point file is transpiled to javascript.";
+
+        // resolvePathHelper() never returns a non-existing file. Instead it throws an exception.
+		File bootstrapFile;
+		try {
+			bootstrapFile = resolvePathHelper("./", "");
+		} catch (NativeScriptException ex) {
+			throw new NativeScriptException(notFoundMessage, ex);
 		}
 
-		if (!bootstrapFile.exists())
-		{
-			throw new NativeScriptException("Application entry point file not found. Please specify either package.json with main field, index.js or bootstrap.js!");
+		if(bootstrapFile == null) {
+			try {
+				bootstrapFile = resolvePathHelper("./bootstrap", "");
+				return bootstrapFile.getAbsolutePath();
+			} catch (NativeScriptException ex) {
+				throw new NativeScriptException(notFoundMessage, ex);
+			}
 		}
 
-		String modulePath = bootstrapFile.getAbsolutePath();
-		return modulePath;
+		return bootstrapFile.getAbsolutePath();
 	}
 }


### PR DESCRIPTION
Before this change the exception that was displayed by the run-time was too specific, lacking any meaningful information to the developer. If there was problem with the app main file the exception was:
"Failed to find module: ./, relative to: /".

Now the error message is:
"Application entry point file not found. Please specify the file in package.json otherwise make sure the file index.js or bootstrap.js exists. If using typescript make sure your entry point file is transpiled to javascript."