### PR TITLE
enable jasmin report in console

### DIFF
--- a/test-app/assets/app/Infrastructure/Jasmine/jasmine-reporters/junit_reporter.js
+++ b/test-app/assets/app/Infrastructure/Jasmine/jasmine-reporters/junit_reporter.js
@@ -44,11 +44,10 @@
         return path + filename;
     }
     function log(str) {
-    	__log(str);
-//        var con = global.console || console;
-//        if (con && con.log) {
-//            con.log(str);
-//        }
+       var con = global.console || console;
+       if (con && con.log) {
+           con.log(str);
+       }
     }
 
 

--- a/test-app/assets/app/Infrastructure/Jasmine/jasmine-reporters/terminal_reporter.js
+++ b/test-app/assets/app/Infrastructure/Jasmine/jasmine-reporters/terminal_reporter.js
@@ -20,11 +20,7 @@
         return dupe;
     }
     function log(str) {
-    	__log(str);
-//        var con = global.console || console;
-//        if (con && con.log && str) {
-//            con.log(str);
-//        }
+        android.util.Log.d("TNS.Jasmine", str);
     }
 
 


### PR DESCRIPTION
fix for: https://github.com/NativeScript/android-runtime/issues/449

When the android unit tests are running the output is also printed in the logcat.