### PR TITLE
Make the default template work without the assumption that com.tns.NativeScriptApplication is extended through JS.

### DIFF
--- a/build/project-template-gradle/src/main/java/com/tns/NativeScriptApplication.java
+++ b/build/project-template-gradle/src/main/java/com/tns/NativeScriptApplication.java
@@ -2,8 +2,7 @@ package com.tns;
 
 import android.app.Application;
 
-@JavaScriptImplementation(javaScriptFile = "./tns_modules/application/application.js")
-public class NativeScriptApplication extends android.app.Application implements com.tns.NativeScriptHashCodeProvider {
+public class NativeScriptApplication extends android.app.Application {
 
     private static NativeScriptApplication thiz;
 
@@ -12,40 +11,8 @@ public class NativeScriptApplication extends android.app.Application implements 
     }
 
     public void onCreate() {
+		super.onCreate();
 		new RuntimeHelper(this).initRuntime();
-		if (Runtime.isInitialized()) {
-	        java.lang.Object[] params = null;
-	        com.tns.Runtime.callJSMethod(this, "onCreate", void.class, params);
-		} else {
-			super.onCreate();
-		}
-    }
-
-    public void onLowMemory() {
-    	if (Runtime.isInitialized()) {
-	        java.lang.Object[] params = null;
-	        com.tns.Runtime.callJSMethod(this, "onLowMemory", void.class, params);
-    	} else {
-    		super.onLowMemory();
-    	}
-    }
-
-    public void onTrimMemory(int level) {
-    	if (Runtime.isInitialized()) {
-	        java.lang.Object[] params = new Object[1];
-	        params[0] = level;
-	        com.tns.Runtime.callJSMethod(this, "onTrimMemory", void.class, params);
-    	} else {
-    		super.onTrimMemory(level);
-    	}
-    }
-
-    public boolean equals__super(java.lang.Object other) {
-        return super.equals(other);
-    }
-
-    public int hashCode__super() {
-        return super.hashCode();
     }
 
     public static Application getInstance() {

--- a/build/project-template-gradle/src/main/java/com/tns/RuntimeHelper.java
+++ b/build/project-template-gradle/src/main/java/com/tns/RuntimeHelper.java
@@ -44,6 +44,10 @@ public class RuntimeHelper
 	
 	public void initRuntime()
 	{
+		if (Runtime.isInitialized()) {
+			return;
+		}
+		
 		System.loadLibrary("NativeScript");
 		
 		Logger logger = new LogcatLogger(app);
@@ -117,7 +121,13 @@ public class RuntimeHelper
 			
 			runtime.init();
 			runtime.runScript(new File(appDir, "internal/ts_helpers.js"));
-			Runtime.initInstance(this.app);
+			try {
+				// put this call in a try/catch block because with the latest changes in the modules it is not granted that NativeScriptApplication is extended through JavaScript.
+				Runtime.initInstance(this.app);
+			}
+			catch (Exception e) {
+				
+			}
 			runtime.run();
 		}
 	}


### PR DESCRIPTION
This pull removes the implicit assumption in the default project template that the core modules provide a JavaScript extend to the android.app.Aplication object.