### PR TITLE
Fix DexFactory bug when creating proxy

### DIFF
--- a/src/src/com/tns/DexFactory.java
+++ b/src/src/com/tns/DexFactory.java
@@ -194,12 +194,12 @@ public class DexFactory
 	{
 		String classToProxy = className;
 
-		if (className.startsWith("com.tns.gen"))
+		if (className.startsWith("com.tns.gen."))
 		{
 			classToProxy = className.substring(12);
 		}
 
-		if (classToProxy.startsWith("com.tns.gen"))
+		if (classToProxy.startsWith("com.tns.gen."))
 		{
 			throw new InvalidClassException("Can't generate proxy of proxy");
 		}


### PR DESCRIPTION
This PR fixes a bug where originally, when extending classes, if an extended class was named (e.g. "com.tns....") and the name started with **com.tns.gen**`erated.MyExtendedClass`,  the DexFactory would trim the first 12 characters and look up a class with `erated.MyExtendedClass` name in the dex, which resulted in ClassNotFoundException