### PR TITLE
Update gradle wrapper version to 2.10, and gradle plugin to 2.1.2

### DIFF
--- a/build-artifacts/project-template-gradle/build.gradle
+++ b/build-artifacts/project-template-gradle/build.gradle
@@ -25,7 +25,7 @@ buildscript {
     }
 
 	dependencies {
-		classpath "com.android.tools.build:gradle:1.5.0"
+		classpath "com.android.tools.build:gradle:2.1.2"
 	}
 }
 

--- a/build-artifacts/project-template-gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/build-artifacts/project-template-gradle/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-bin.zip


### PR DESCRIPTION
<!--Dear friend, we, the rest of the NativeScript community thank you for your
contribution! Because we want to present a really nice, readable changelog with each
release, please provide the following information: -->

### Description
The changes in this PR mean to update the android tool gradle plugin version to 2.1.2 (from 1.5.0) which, since 2.0, contains build speed optimizations for debug build variants.

### Does your pull request have [unit tests](https://github.com/NativeScript/NativeScript/blob/master/running-tests.md)?
<!--If not, why?
If not, please tell us why tests are not included, and list all steps needed to test your pull request manually. -->
Manual benchmarking showed a cut of a little over 1/5th the original initial build time (35-38s down to 26-30) on a new application.

On Groceries, after the initial fetch of `node_modules` and platforms old gradle built the app in **47.5**s whereas the updated gradle was done in **40**s

ping @NativeScript/android-runtime 
