### PR TITLE
Fix re-throwing errors to V8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 /test-app/libs
 /test-app/metadata
 /test-app/.idea
+.idea
 
 local.properties
 

--- a/runtime/src/main/jni/Module.cpp
+++ b/runtime/src/main/jni/Module.cpp
@@ -14,6 +14,7 @@
 #include "NativeScriptException.h"
 #include "Util.h"
 #include "SimpleProfiler.h"
+#include "include/v8.h"
 
 #include <sstream>
 #include <assert.h>
@@ -200,12 +201,7 @@ void Module::Load(const string& path)
 	auto globalObject = context->Global();
 	auto require = globalObject->Get(context, ConvertToV8String("require")).ToLocalChecked().As<Function>();
 	Local<Value> args[] = { ConvertToV8String(path) };
-	TryCatch tc;
 	require->Call(context, globalObject, 1, args);
-	if (tc.HasCaught())
-	{
-		throw NativeScriptException(tc, "Fail to load module: " + path);
-	}
 }
 
 Local<Object> Module::LoadImpl(Isolate *isolate, const string& moduleName, const string& baseDir, bool& isData)

--- a/runtime/src/main/jni/Runtime.cpp
+++ b/runtime/src/main/jni/Runtime.cpp
@@ -23,6 +23,7 @@
 #include "V8NativeScriptExtension.h"
 #include "Runtime.h"
 #include "ArrayHelper.h"
+#include "include/v8.h"
 #include <sstream>
 #include <android/log.h>
 #include <string>
@@ -248,9 +249,6 @@ void Runtime::CreateJSInstanceNative(JNIEnv *_env, jobject obj, jobject javaObje
 
 	JEnv env(_env);
 
-	// TODO: Do we need a TryCatch here? It is currently not used anywhere
-	TryCatch tc;
-
 	string existingClassName = ArgConverter::jstringToString(className);
 	string jniName = Util::ConvertFromCanonicalToJniName(existingClassName);
 	Local<Object> jsInstance;
@@ -259,9 +257,10 @@ void Runtime::CreateJSInstanceNative(JNIEnv *_env, jobject obj, jobject javaObje
 	auto proxyClassName = m_objectManager->GetClassName(javaObject);
 	DEBUG_WRITE("createJSInstanceNative class %s", proxyClassName.c_str());
 	jsInstance = MetadataNode::CreateExtendedJSWrapper(isolate, m_objectManager, proxyClassName);
+
 	if (jsInstance.IsEmpty())
 	{
-		throw NativeScriptException(string("NativeScript application not initialized correctly. Cannot create extended JS wrapper."));
+		throw NativeScriptException(string("Failed to create JavaScript extend wrapper for class '" + proxyClassName + "'"));
 	}
 
 	implementationObject = MetadataNode::GetImplementationObject(jsInstance);

--- a/runtime/src/main/jni/Runtime.cpp
+++ b/runtime/src/main/jni/Runtime.cpp
@@ -23,7 +23,6 @@
 #include "V8NativeScriptExtension.h"
 #include "Runtime.h"
 #include "ArrayHelper.h"
-#include "include/v8.h"
 #include <sstream>
 #include <android/log.h>
 #include <string>


### PR DESCRIPTION
This pull does:

- Modify the `NativeScriptException.OnUncaughtError` method re-throw to Java instead of simply swallowing the original exception.
- Pass the complete error message when re-throwing from V8