### PR TITLE
Improve error activity

### DIFF
--- a/build-artifacts/project-template-gradle/build.gradle
+++ b/build-artifacts/project-template-gradle/build.gradle
@@ -184,6 +184,7 @@ dependencies {
 	
     compile "com.android.support:support-v4:$suppotVer"
     compile "com.android.support:appcompat-v7:$suppotVer"
+	compile "com.android.support:design:$suppotVer"
 
     // take all jars within the libs dir
 	compile fileTree(dir: "$projectDir/libs", include: ["**/*.jar"])

--- a/build-artifacts/project-template-gradle/src/main/AndroidManifest.xml
+++ b/build-artifacts/project-template-gradle/src/main/AndroidManifest.xml
@@ -33,7 +33,8 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name="com.tns.ErrorReportActivity"/>
+        <activity android:name="com.tns.ErrorReportActivity"
+                  android:theme="@style/NoActionBar" />
     </application>
 
 </manifest>

--- a/build-artifacts/project-template-gradle/src/main/java/com/tns/ErrorReport.java
+++ b/build-artifacts/project-template-gradle/src/main/java/com/tns/ErrorReport.java
@@ -51,10 +51,10 @@ class ErrorReport implements TabLayout.OnTabSelectedListener {
 
 	private static String exceptionMsg;
 	private static String logcatMsg;
+	private static String pID;
 
 	private final static String EXTRA_NATIVESCRIPT_ERROR_REPORT = "NativeScriptErrorMessage";
 	private final static String EXTRA_ERROR_REPORT_MSG = "msg";
-	private final static String EXTRA_LOGCAT_MSG = "logcat";
 	private final static int EXTRA_ERROR_REPORT_VALUE = 1;
 
 	private static final int REQUEST_EXTERNAL_STORAGE = 1;
@@ -82,14 +82,16 @@ class ErrorReport implements TabLayout.OnTabSelectedListener {
 		this.context = activity.getApplicationContext();
 	}
 
-	static boolean startActivity(final Context context, String errorMessage, String logcatMessage) {
+	static boolean startActivity(final Context context, String errorMessage) {
 		final Intent intent = getIntent(context);
 		if (intent == null) {
 			return false; // (if in release mode) don't do anything
 		}
 
 		intent.putExtra(EXTRA_ERROR_REPORT_MSG, errorMessage);
-		intent.putExtra(EXTRA_LOGCAT_MSG, logcatMessage);
+
+		String PID = Integer.toString(android.os.Process.myPid());
+		intent.putExtra(pID, PID);
 
 		createErrorFile(context);
 
@@ -146,9 +148,8 @@ class ErrorReport implements TabLayout.OnTabSelectedListener {
 	* Gets the process Id of the running app and filters all
 	* output that doesn't belong to that process
 	* */
-	static String getLogcat() {
+	public static String getLogcat(String pId) {
 		String content;
-		String pId = Integer.toString(android.os.Process.myPid());
 
 		try {
 			String logcatCommand = "logcat -d";
@@ -193,11 +194,13 @@ class ErrorReport implements TabLayout.OnTabSelectedListener {
 		return value == EXTRA_ERROR_REPORT_VALUE;
 	}
 
-	void buildUI(AppCompatActivity activity) {
+	void buildUI() {
 		Intent intent = activity.getIntent();
 
 		exceptionMsg = intent.getStringExtra(EXTRA_ERROR_REPORT_MSG);
-		logcatMsg = intent.getStringExtra(EXTRA_LOGCAT_MSG);
+
+		String processId = intent.getStringExtra(pID);
+		logcatMsg = getLogcat(processId);
 
 		int errActivityId = this.context.getResources().getIdentifier("error_activity", "layout", this.context.getPackageName());
 

--- a/build-artifacts/project-template-gradle/src/main/java/com/tns/ErrorReport.java
+++ b/build-artifacts/project-template-gradle/src/main/java/com/tns/ErrorReport.java
@@ -1,11 +1,18 @@
 package com.tns;
 
+import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
+import android.Manifest;
 import android.app.Activity;
 import android.app.PendingIntent;
 import android.app.PendingIntent.CanceledException;
@@ -13,47 +20,82 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
-import android.graphics.drawable.GradientDrawable;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+import android.os.Environment;
+import android.support.design.widget.TabLayout;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentStatePagerAdapter;
+import android.support.v4.view.ViewPager;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
 import android.text.method.ScrollingMovementMethod;
 import android.util.Log;
+import android.view.LayoutInflater;
 import android.view.View;
-import android.view.View.OnClickListener;
+import android.view.ViewGroup;
 import android.widget.Button;
-import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
-class ErrorReport
-{
+
+class ErrorReport implements TabLayout.OnTabSelectedListener {
 	public static final String ERROR_FILE_NAME = "hasError";
-	private final Activity activity;
+	private static AppCompatActivity activity;
+
+	private TabLayout tabLayout;
+	private ViewPager viewPager;
+	private Context context;
+
+	private static String exceptionMsg;
+	private static String logcatMsg;
 
 	private final static String EXTRA_NATIVESCRIPT_ERROR_REPORT = "NativeScriptErrorMessage";
 	private final static String EXTRA_ERROR_REPORT_MSG = "msg";
+	private final static String EXTRA_LOGCAT_MSG = "logcat";
 	private final static int EXTRA_ERROR_REPORT_VALUE = 1;
 
-	public ErrorReport(Activity activity)
-	{
-		this.activity = activity;
+	private static final int REQUEST_EXTERNAL_STORAGE = 1;
+	private static String[] PERMISSIONS_STORAGE = {
+			Manifest.permission.READ_EXTERNAL_STORAGE,
+			Manifest.permission.WRITE_EXTERNAL_STORAGE
+	};
+
+	public static void verifyStoragePermissions(Activity activity) {
+		// Check if we have write permission
+		int permission = ActivityCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+
+		if (permission != PackageManager.PERMISSION_GRANTED) {
+			// We don't have permission so prompt the user
+			ActivityCompat.requestPermissions(
+					activity,
+					PERMISSIONS_STORAGE,
+					REQUEST_EXTERNAL_STORAGE
+			);
+		}
 	}
 
-	static boolean startActivity(final Context context, String errorMessage)
-	{
+	public ErrorReport(AppCompatActivity activity) {
+		ErrorReport.activity = activity;
+		this.context = activity.getApplicationContext();
+	}
+
+	static boolean startActivity(final Context context, String errorMessage, String logcatMessage) {
 		final Intent intent = getIntent(context);
-		if (intent == null)
-		{
+		if (intent == null) {
 			return false; // (if in release mode) don't do anything
 		}
 
 		intent.putExtra(EXTRA_ERROR_REPORT_MSG, errorMessage);
+		intent.putExtra(EXTRA_LOGCAT_MSG, logcatMessage);
 
 		createErrorFile(context);
 
-		try
-		{
+		try {
 			startPendingErrorActivity(context, intent);
-		}
-		catch (CanceledException e)
-		{
+		} catch (CanceledException e) {
 			Log.d("ErrorReport", "Couldn't send pending intent! Exception: " + e.getMessage());
 		}
 
@@ -62,11 +104,9 @@ class ErrorReport
 		return true;
 	}
 
-	static void killProcess(Context context)
-	{
+	static void killProcess(Context context) {
 		// finish current activity and all below it first
-		if (context instanceof Activity)
-		{
+		if (context instanceof Activity) {
 			((Activity) context).finishAffinity();
 		}
 
@@ -74,35 +114,27 @@ class ErrorReport
 		android.os.Process.killProcess(android.os.Process.myPid());
 	}
 
-	static void startPendingErrorActivity(Context context, Intent intent) throws CanceledException
-	{
+	static void startPendingErrorActivity(Context context, Intent intent) throws CanceledException {
 		PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
 
 		pendingIntent.send(context, 0, intent);
 	}
 
-	static String getErrorMessage(Throwable ex)
-	{
+	static String getErrorMessage(Throwable ex) {
 		String content;
 		PrintStream ps = null;
 
-		try
-		{
+		try {
 			ByteArrayOutputStream baos = new ByteArrayOutputStream();
 			ps = new PrintStream(baos);
 			ex.printStackTrace(ps);
 
-			try
-			{
+			try {
 				content = baos.toString("US-ASCII");
-			}
-			catch (UnsupportedEncodingException e)
-			{
+			} catch (UnsupportedEncodingException e) {
 				content = e.getMessage();
 			}
-		}
-		finally
-		{
+		} finally {
 			if (ps != null)
 				ps.close();
 		}
@@ -110,18 +142,43 @@ class ErrorReport
 		return content;
 	}
 
-	static Intent getIntent(Context context)
-	{
+	/*
+	* Gets the process Id of the running app and filters all
+	* output that doesn't belong to that process
+	* */
+	static String getLogcat() {
+		String content;
+		String pId = Integer.toString(android.os.Process.myPid());
+
+		try {
+			String logcatCommand = "logcat -d";
+			Process process = java.lang.Runtime.getRuntime().exec(logcatCommand);
+
+			BufferedReader bufferedReader = new BufferedReader(
+					new InputStreamReader(process.getInputStream()));
+
+			StringBuilder log = new StringBuilder();
+			String line = "";
+			String lineSeparator = System.getProperty("line.separator");
+			while ((line = bufferedReader.readLine()) != null) {
+				if(line.contains(pId)) {
+					log.append(line);
+					log.append(lineSeparator);
+				}
+			}
+
+			content = log.toString();
+		} catch (IOException e) {
+			content = "Failed to read logcat";
+			Log.e("TNS.Android", content);
+		}
+
+		return content;
+	}
+
+	static Intent getIntent(Context context) {
 		Class<?> errorActivityClass = ErrorReportActivity.class;
 
-		if (AndroidJsDebugger.isDebuggableApp(context))		
-		{		
-			errorActivityClass = ErrorReportActivity.class;
-		}
-		else {
-			return null;
-		}
-		
 		Intent intent = new Intent(context, errorActivityClass);
 
 		intent.putExtra(EXTRA_NATIVESCRIPT_ERROR_REPORT, EXTRA_ERROR_REPORT_VALUE);
@@ -130,64 +187,173 @@ class ErrorReport
 		return intent;
 	}
 
-	static boolean hasIntent(Intent intent)
-	{
+	static boolean hasIntent(Intent intent) {
 		int value = intent.getIntExtra(EXTRA_NATIVESCRIPT_ERROR_REPORT, 0);
 
 		return value == EXTRA_ERROR_REPORT_VALUE;
 	}
 
-	void buildUI()
-	{
-		Context context = activity;
+	void buildUI(AppCompatActivity activity) {
 		Intent intent = activity.getIntent();
-		final String msg = intent.getStringExtra(EXTRA_ERROR_REPORT_MSG);
 
-		// container
-		LinearLayout layout = new LinearLayout(context);
-		layout.setOrientation(LinearLayout.VERTICAL);
-		activity.setContentView(layout);
+		exceptionMsg = intent.getStringExtra(EXTRA_ERROR_REPORT_MSG);
+		logcatMsg = intent.getStringExtra(EXTRA_LOGCAT_MSG);
 
-		// header
-		TextView txtHeader = new TextView(context);
-		txtHeader.setText("Unhandled Exception");
+		int errActivityId = this.context.getResources().getIdentifier("error_activity", "layout", this.context.getPackageName());
 
-		// error + stacktrace
-		TextView txtErrorMsg = new TextView(context);
-		txtErrorMsg.setText(msg);
-		txtErrorMsg.setHeight(1000);
-		txtErrorMsg.setMovementMethod(new ScrollingMovementMethod());
+		activity.setContentView(errActivityId);
 
-		// copy button
-		Button copyToClipboard = new Button(context);
-		copyToClipboard.setText("Copy to clipboard");
-		copyToClipboard.setOnClickListener(new OnClickListener()
-		{
-			@Override
-			public void onClick(View v)
-			{
+		int toolBarId = this.context.getResources().getIdentifier("toolbar", "id", this.context.getPackageName());
 
-				ClipboardManager clipboard = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
-				ClipData clip = ClipData.newPlainText("nsError", msg);
-				clipboard.setPrimaryClip(clip);
-			}
-		});
+		Toolbar toolbar = (Toolbar) activity.findViewById(toolBarId);
+		activity.setSupportActionBar(toolbar);
 
-		layout.addView(txtHeader);
-		layout.addView(txtErrorMsg);
-		layout.addView(copyToClipboard);
+		int tabLayoutId = this.context.getResources().getIdentifier("tabLayout", "id", this.context.getPackageName());
+
+		tabLayout = (TabLayout) activity.findViewById(tabLayoutId);
+		tabLayout.addTab(tabLayout.newTab().setText("Exception"));
+		tabLayout.addTab(tabLayout.newTab().setText("Logcat"));
+		tabLayout.setTabGravity(TabLayout.GRAVITY_FILL);
+
+		int pagerId = this.context.getResources().getIdentifier("pager", "id", this.context.getPackageName());
+
+		viewPager = (ViewPager) activity.findViewById(pagerId);
+
+		Pager adapter = new Pager(activity.getSupportFragmentManager(), tabLayout.getTabCount());
+
+		viewPager.setAdapter(adapter);
+
+		tabLayout.setOnTabSelectedListener(this);
 	}
 
-	private static void createErrorFile(final Context context)
-	{
-		try
-		{
+	private static void createErrorFile(final Context context) {
+		try {
 			File errFile = new File(context.getFilesDir(), ERROR_FILE_NAME);
 			errFile.createNewFile();
-		}
-		catch (IOException e)
-		{
+		} catch (IOException e) {
 			Log.d("ErrorReport", e.getMessage());
+		}
+	}
+
+	@Override
+	public void onTabSelected(TabLayout.Tab tab) {
+		viewPager.setCurrentItem(tab.getPosition());
+	}
+
+	@Override
+	public void onTabUnselected(TabLayout.Tab tab) {
+
+	}
+
+	@Override
+	public void onTabReselected(TabLayout.Tab tab) {
+		viewPager.setCurrentItem(tab.getPosition());
+	}
+
+	private class Pager extends FragmentStatePagerAdapter {
+
+		int tabCount;
+
+		public Pager(FragmentManager fm, int tabCount) {
+			super(fm);
+			this.tabCount = tabCount;
+		}
+
+		@Override
+		public Fragment getItem(int position) {
+			switch (position) {
+				case 0:
+					return new ExceptionTab();
+				case 1:
+					return new LogcatTab();
+				default:
+					return null;
+			}
+		}
+
+		@Override
+		public int getCount() {
+			return tabCount;
+		}
+	}
+
+	public static class ExceptionTab extends Fragment {
+		@Override
+		public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+			int exceptionTabId = this.getContext().getResources().getIdentifier("exception_tab", "layout", this.getContext().getPackageName());
+			View view = inflater.inflate(exceptionTabId, container, false);
+
+			int txtViewId = this.getContext().getResources().getIdentifier("txtErrorMsg", "id", this.getContext().getPackageName());
+			TextView txtErrorMsg = (TextView) view.findViewById(txtViewId);
+			txtErrorMsg.setText(exceptionMsg);
+			txtErrorMsg.setMovementMethod(new ScrollingMovementMethod());
+
+			int btnCopyExceptionId = this.getContext().getResources().getIdentifier("btnCopyException", "id", this.getContext().getPackageName());
+			Button copyToClipboard = (Button) view.findViewById(btnCopyExceptionId);
+			copyToClipboard.setOnClickListener(new View.OnClickListener()
+			{
+				@Override
+				public void onClick(View v)
+				{
+					ClipboardManager clipboard = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
+					ClipData clip = ClipData.newPlainText("nsError", exceptionMsg);
+					clipboard.setPrimaryClip(clip);
+				}
+			});
+
+			return view;
+		}
+	}
+
+	public static class LogcatTab extends Fragment {
+		@Override
+		public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+			int logcatTabId = this.getContext().getResources().getIdentifier("logcat_tab", "layout", this.getContext().getPackageName());
+			View view = inflater.inflate(logcatTabId, container, false);
+
+			int textViewId = this.getContext().getResources().getIdentifier("logcatMsg", "id", this.getContext().getPackageName());
+			TextView txtlogcatMsg = (TextView) view.findViewById(textViewId);
+			txtlogcatMsg.setText(logcatMsg);
+
+			txtlogcatMsg.setMovementMethod(new ScrollingMovementMethod());
+
+			final String logName = "Log-" + new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss").format(new Date());
+
+			int btnCopyLogcatId = this.getContext().getResources().getIdentifier("btnCopyLogcat", "id", this.getContext().getPackageName());
+			Button copyToClipboard = (Button) view.findViewById(btnCopyLogcatId);
+			copyToClipboard.setOnClickListener(new View.OnClickListener()
+			{
+				@Override
+				public void onClick(View v)
+				{
+					verifyStoragePermissions(activity);
+
+					try {
+						File dir = new File(Environment.getExternalStorageDirectory().getPath()+ "/logcat-reports/");
+						dir.mkdirs();
+
+						File logcatReportFile = new File(dir, logName);
+						FileOutputStream stream = new FileOutputStream(logcatReportFile);
+						OutputStreamWriter writer = new OutputStreamWriter(stream, "UTF-8");
+						writer.write(logcatMsg);
+						writer.close();
+
+						String logPath = dir.getPath() + "/" + logName;
+
+						ClipboardManager clipboard = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
+						ClipData clip = ClipData.newPlainText("logPath", logPath);
+						clipboard.setPrimaryClip(clip);
+
+						Toast.makeText(activity, "Path copied to clipboard: " + logPath, Toast.LENGTH_LONG).show();
+					} catch (Exception e) {
+						String err = "Could not write logcat report to sdcard. Make sure you have allowed access to external storage!";
+						Toast.makeText(activity, err, Toast.LENGTH_LONG).show();
+						Log.d("ErrorReport", err);
+					}
+				}
+			});
+
+			return view;
 		}
 	}
 }

--- a/build-artifacts/project-template-gradle/src/main/java/com/tns/ErrorReportActivity.java
+++ b/build-artifacts/project-template-gradle/src/main/java/com/tns/ErrorReportActivity.java
@@ -7,7 +7,7 @@ import android.support.v7.app.AppCompatActivity;
 public class ErrorReportActivity extends AppCompatActivity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        new ErrorReport(this).buildUI(this);
+        new ErrorReport(this).buildUI();
     }
 
     @Override

--- a/build-artifacts/project-template-gradle/src/main/java/com/tns/ErrorReportActivity.java
+++ b/build-artifacts/project-template-gradle/src/main/java/com/tns/ErrorReportActivity.java
@@ -1,21 +1,24 @@
 package com.tns;
 
-import android.app.Activity;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatActivity;
 
-public class ErrorReportActivity extends Activity
-{
-	public void onCreate(Bundle savedInstanceState)
-	{
-		super.onCreate(savedInstanceState);
-		new ErrorReport(this).buildUI();
-	}
+public class ErrorReportActivity extends AppCompatActivity {
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        new ErrorReport(this).buildUI(this);
+    }
 
-	@Override
-	protected void onPause()
-	{
-		// the moment the error activity is not in the foreground we want to kill the process
-		super.onPause();
-		ErrorReport.killProcess(this);
-	}
+    @Override
+    protected void onPause() {
+        // the moment the error activity is not in the foreground we want to kill the process
+        super.onPause();
+        ErrorReport.killProcess(this);
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        //        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+    }
 }

--- a/build-artifacts/project-template-gradle/src/main/java/com/tns/NativeScriptUncaughtExceptionHandler.java
+++ b/build-artifacts/project-template-gradle/src/main/java/com/tns/NativeScriptUncaughtExceptionHandler.java
@@ -30,7 +30,8 @@ public class NativeScriptUncaughtExceptionHandler implements UncaughtExceptionHa
 	public void uncaughtException(Thread thread, Throwable ex)
 	{
 		String errorMessage = ErrorReport.getErrorMessage(ex);
-		
+		String logcatMessage = ErrorReport.getLogcat();
+
 		if (Runtime.isInitialized())
 		{
 			try
@@ -57,7 +58,7 @@ public class NativeScriptUncaughtExceptionHandler implements UncaughtExceptionHa
 			logger.write("Uncaught Exception Message=" + errorMessage);
 		}
 
-		if (!ErrorReport.startActivity(context, errorMessage) && defaultHandler != null)
+		if (!ErrorReport.startActivity(context, errorMessage, logcatMessage) && defaultHandler != null)
 		{
 			defaultHandler.uncaughtException(thread, ex);
 		}

--- a/build-artifacts/project-template-gradle/src/main/java/com/tns/NativeScriptUncaughtExceptionHandler.java
+++ b/build-artifacts/project-template-gradle/src/main/java/com/tns/NativeScriptUncaughtExceptionHandler.java
@@ -30,7 +30,6 @@ public class NativeScriptUncaughtExceptionHandler implements UncaughtExceptionHa
 	public void uncaughtException(Thread thread, Throwable ex)
 	{
 		String errorMessage = ErrorReport.getErrorMessage(ex);
-		String logcatMessage = ErrorReport.getLogcat();
 
 		if (Runtime.isInitialized())
 		{
@@ -58,7 +57,7 @@ public class NativeScriptUncaughtExceptionHandler implements UncaughtExceptionHa
 			logger.write("Uncaught Exception Message=" + errorMessage);
 		}
 
-		if (!ErrorReport.startActivity(context, errorMessage, logcatMessage) && defaultHandler != null)
+		if (!ErrorReport.startActivity(context, errorMessage) && defaultHandler != null)
 		{
 			defaultHandler.uncaughtException(thread, ex);
 		}

--- a/build-artifacts/project-template-gradle/src/main/res/layout/error_activity.xml
+++ b/build-artifacts/project-template-gradle/src/main/res/layout/error_activity.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:tools="http://schemas.android.com/tools"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                xmlns:app="http://schemas.android.com/apk/res-auto"
+                tools:context="com.tns.ErrorReportActivity"
+                android:theme="@style/ExceptionActionBar">
+
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="?attr/actionBarSize"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+        app:popupTheme="@style/ThemeOverlay.AppCompat.Dark"/>
+
+    <android.support.design.widget.TabLayout
+        android:id="@+id/tabLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimary"
+        android:minHeight="?attr/actionBarSize"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"/>
+
+    <android.support.v4.view.ViewPager
+        android:id="@+id/pager"
+        android:layout_width="match_parent"
+        android:layout_height="fill_parent"
+        android:layout_below="@+id/toolbar" />
+</RelativeLayout>

--- a/build-artifacts/project-template-gradle/src/main/res/layout/exception_tab.xml
+++ b/build-artifacts/project-template-gradle/src/main/res/layout/exception_tab.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical">
+
+    <LinearLayout
+        android:id="@+id/linearLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:weightSum="100">
+
+        <LinearLayout
+            android:layout_width="fill_parent"
+            android:layout_height="0dp"
+            android:layout_weight="80">
+
+            <TextView
+                android:id="@+id/txtErrorMsg"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_centerInParent="true"
+                android:text=""
+                android:textAppearance="?android:attr/textAppearanceSmall" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="20">
+
+            <Button
+                android:id="@+id/btnCopyException"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_alignParentBottom="true"
+                android:text="Copy to clipboard" />
+        </LinearLayout>
+    </LinearLayout>
+
+
+</RelativeLayout>

--- a/build-artifacts/project-template-gradle/src/main/res/layout/logcat_tab.xml
+++ b/build-artifacts/project-template-gradle/src/main/res/layout/logcat_tab.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical">
+
+    <LinearLayout
+        android:id="@+id/logcatLinearLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:weightSum="100">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="80">
+
+            <TextView
+                android:id="@+id/logcatMsg"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_centerInParent="true"
+                android:text=""
+                android:textAppearance="?android:attr/textAppearanceSmall" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="20">
+
+            <Button
+                android:id="@+id/btnCopyLogcat"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_alignParentBottom="true"
+                android:text="Copy to sdcard" />
+        </LinearLayout>
+    </LinearLayout>
+
+
+</RelativeLayout>

--- a/build-artifacts/project-template-gradle/src/main/res/values/styles.xml
+++ b/build-artifacts/project-template-gradle/src/main/res/values/styles.xml
@@ -19,4 +19,9 @@
     
 	<style name="NativeScriptToolbarStyle" parent="NativeScriptToolbarStyleBase">
     </style>
+
+    <style name="NoActionBar" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:windowActionBar">false</item>
+        <item name="android:windowNoTitle">true</item>
+    </style>
 </resources> 

--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -44,8 +44,14 @@ model {
 }
 
 dependencies {
+	def supportVer = "23.3.0"
 	compile project(':runtime')
 	compile fileTree(include: ['*.jar'], dir: 'libs')
+
+	compile "com.android.support:support-v4:$supportVer"
+	compile "com.android.support:appcompat-v7:$supportVer"
+	compile "com.android.support:design:$supportVer"
+
 	testCompile 'junit:junit:4.12'
 }
 

--- a/test-app/app/src/main/AndroidManifest.xml
+++ b/test-app/app/src/main/AndroidManifest.xml
@@ -26,7 +26,8 @@
         </activity>
         <activity
             android:name="com.tns.ErrorReportActivity"
-            android:label="TestApp">
+            android:label="ErrorActivity"
+            android:theme="@style/NoActionBar">
         </activity>
     </application>
     

--- a/test-app/app/src/main/java/com/tns/ErrorReport.java
+++ b/test-app/app/src/main/java/com/tns/ErrorReport.java
@@ -51,10 +51,10 @@ class ErrorReport implements TabLayout.OnTabSelectedListener {
 
 	private static String exceptionMsg;
 	private static String logcatMsg;
+	private static String pID;
 
 	private final static String EXTRA_NATIVESCRIPT_ERROR_REPORT = "NativeScriptErrorMessage";
 	private final static String EXTRA_ERROR_REPORT_MSG = "msg";
-	private final static String EXTRA_LOGCAT_MSG = "logcat";
 	private final static int EXTRA_ERROR_REPORT_VALUE = 1;
 
 	private static final int REQUEST_EXTERNAL_STORAGE = 1;
@@ -82,14 +82,16 @@ class ErrorReport implements TabLayout.OnTabSelectedListener {
 		this.context = activity.getApplicationContext();
 	}
 
-	static boolean startActivity(final Context context, String errorMessage, String logcatMessage) {
+	static boolean startActivity(final Context context, String errorMessage) {
 		final Intent intent = getIntent(context);
 		if (intent == null) {
 			return false; // (if in release mode) don't do anything
 		}
 
 		intent.putExtra(EXTRA_ERROR_REPORT_MSG, errorMessage);
-		intent.putExtra(EXTRA_LOGCAT_MSG, logcatMessage);
+
+		String PID = Integer.toString(android.os.Process.myPid());
+		intent.putExtra(pID, PID);
 
 		createErrorFile(context);
 
@@ -146,9 +148,8 @@ class ErrorReport implements TabLayout.OnTabSelectedListener {
 	* Gets the process Id of the running app and filters all
 	* output that doesn't belong to that process
 	* */
-	static String getLogcat() {
+	public static String getLogcat(String pId) {
 		String content;
-		String pId = Integer.toString(android.os.Process.myPid());
 
 		try {
 			String logcatCommand = "logcat -d";
@@ -193,11 +194,13 @@ class ErrorReport implements TabLayout.OnTabSelectedListener {
 		return value == EXTRA_ERROR_REPORT_VALUE;
 	}
 
-	void buildUI(AppCompatActivity activity) {
+	void buildUI() {
 		Intent intent = activity.getIntent();
 
 		exceptionMsg = intent.getStringExtra(EXTRA_ERROR_REPORT_MSG);
-		logcatMsg = intent.getStringExtra(EXTRA_LOGCAT_MSG);
+
+		String processId = intent.getStringExtra(pID);
+		logcatMsg = getLogcat(processId);
 
 		int errActivityId = this.context.getResources().getIdentifier("error_activity", "layout", this.context.getPackageName());
 

--- a/test-app/app/src/main/java/com/tns/ErrorReport.java
+++ b/test-app/app/src/main/java/com/tns/ErrorReport.java
@@ -78,7 +78,7 @@ class ErrorReport implements TabLayout.OnTabSelectedListener {
 	}
 
 	public ErrorReport(AppCompatActivity activity) {
-		this.activity = activity;
+		ErrorReport.activity = activity;
 		this.context = activity.getApplicationContext();
 	}
 
@@ -142,6 +142,10 @@ class ErrorReport implements TabLayout.OnTabSelectedListener {
 		return content;
 	}
 
+	/*
+	* Gets the process Id of the running app and filters all
+	* output that doesn't belong to that process
+	* */
 	static String getLogcat() {
 		String content;
 		String pId = Integer.toString(android.os.Process.myPid());
@@ -189,8 +193,7 @@ class ErrorReport implements TabLayout.OnTabSelectedListener {
 		return value == EXTRA_ERROR_REPORT_VALUE;
 	}
 
-	void buildUI() {
-		Context context = activity;
+	void buildUI(AppCompatActivity activity) {
 		Intent intent = activity.getIntent();
 
 		exceptionMsg = intent.getStringExtra(EXTRA_ERROR_REPORT_MSG);

--- a/test-app/app/src/main/java/com/tns/ErrorReport.java
+++ b/test-app/app/src/main/java/com/tns/ErrorReport.java
@@ -9,38 +9,46 @@ import java.io.UnsupportedEncodingException;
 import android.app.Activity;
 import android.app.PendingIntent;
 import android.app.PendingIntent.CanceledException;
-import android.content.ClipData;
-import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
-import android.graphics.drawable.GradientDrawable;
+import android.os.Bundle;
+import android.support.design.widget.TabLayout;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentStatePagerAdapter;
+import android.support.v4.view.ViewPager;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
 import android.text.method.ScrollingMovementMethod;
 import android.util.Log;
+import android.view.LayoutInflater;
 import android.view.View;
-import android.view.View.OnClickListener;
-import android.widget.Button;
-import android.widget.LinearLayout;
+import android.view.ViewGroup;
 import android.widget.TextView;
 
-class ErrorReport
-{
+
+class ErrorReport implements TabLayout.OnTabSelectedListener {
 	public static final String ERROR_FILE_NAME = "hasError";
-	private final Activity activity;
+	private final AppCompatActivity activity;
+
+	private TabLayout tabLayout;
+	private ViewPager viewPager;
+	private Context context;
+	private static String exceptionMsg;
 
 	private final static String EXTRA_NATIVESCRIPT_ERROR_REPORT = "NativeScriptErrorMessage";
 	private final static String EXTRA_ERROR_REPORT_MSG = "msg";
 	private final static int EXTRA_ERROR_REPORT_VALUE = 1;
 
-	public ErrorReport(Activity activity)
-	{
+	public ErrorReport(AppCompatActivity activity) {
 		this.activity = activity;
+		this.context = activity.getApplicationContext();
 	}
 
-	static boolean startActivity(final Context context, String errorMessage)
-	{
+	static boolean startActivity(final Context context, String errorMessage) {
 		final Intent intent = getIntent(context);
-		if (intent == null)
-		{
+
+		if (intent == null) {
 			return false; // (if in release mode) don't do anything
 		}
 
@@ -48,12 +56,9 @@ class ErrorReport
 
 		createErrorFile(context);
 
-		try
-		{
+		try {
 			startPendingErrorActivity(context, intent);
-		}
-		catch (CanceledException e)
-		{
+		} catch (CanceledException e) {
 			Log.d("ErrorReport", "Couldn't send pending intent! Exception: " + e.getMessage());
 		}
 
@@ -62,11 +67,9 @@ class ErrorReport
 		return true;
 	}
 
-	static void killProcess(Context context)
-	{
+	static void killProcess(Context context) {
 		// finish current activity and all below it first
-		if (context instanceof Activity)
-		{
+		if (context instanceof Activity) {
 			((Activity) context).finishAffinity();
 		}
 
@@ -74,35 +77,27 @@ class ErrorReport
 		android.os.Process.killProcess(android.os.Process.myPid());
 	}
 
-	static void startPendingErrorActivity(Context context, Intent intent) throws CanceledException
-	{
+	static void startPendingErrorActivity(Context context, Intent intent) throws CanceledException {
 		PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
 
 		pendingIntent.send(context, 0, intent);
 	}
 
-	static String getErrorMessage(Throwable ex)
-	{
+	static String getErrorMessage(Throwable ex) {
 		String content;
 		PrintStream ps = null;
 
-		try
-		{
+		try {
 			ByteArrayOutputStream baos = new ByteArrayOutputStream();
 			ps = new PrintStream(baos);
 			ex.printStackTrace(ps);
 
-			try
-			{
+			try {
 				content = baos.toString("US-ASCII");
-			}
-			catch (UnsupportedEncodingException e)
-			{
+			} catch (UnsupportedEncodingException e) {
 				content = e.getMessage();
 			}
-		}
-		finally
-		{
+		} finally {
 			if (ps != null)
 				ps.close();
 		}
@@ -110,18 +105,9 @@ class ErrorReport
 		return content;
 	}
 
-	static Intent getIntent(Context context)
-	{
+	static Intent getIntent(Context context) {
 		Class<?> errorActivityClass = ErrorReportActivity.class;
 
-		if (AndroidJsDebugger.isDebuggableApp(context))		
-		{		
-			errorActivityClass = ErrorReportActivity.class;
-		}
-		else {
-			return null;
-		}
-		
 		Intent intent = new Intent(context, errorActivityClass);
 
 		intent.putExtra(EXTRA_NATIVESCRIPT_ERROR_REPORT, EXTRA_ERROR_REPORT_VALUE);
@@ -130,64 +116,116 @@ class ErrorReport
 		return intent;
 	}
 
-	static boolean hasIntent(Intent intent)
-	{
+	static boolean hasIntent(Intent intent) {
 		int value = intent.getIntExtra(EXTRA_NATIVESCRIPT_ERROR_REPORT, 0);
 
 		return value == EXTRA_ERROR_REPORT_VALUE;
 	}
 
-	void buildUI()
-	{
+	void buildUI() {
 		Context context = activity;
 		Intent intent = activity.getIntent();
 		final String msg = intent.getStringExtra(EXTRA_ERROR_REPORT_MSG);
 
-		// container
-		LinearLayout layout = new LinearLayout(context);
-		layout.setOrientation(LinearLayout.VERTICAL);
-		activity.setContentView(layout);
+		exceptionMsg = msg;
 
-		// header
-		TextView txtHeader = new TextView(context);
-		txtHeader.setText("Unhandled Exception");
+		int errActivityId = this.context.getResources().getIdentifier("error_activity", "layout", this.context.getPackageName());
 
-		// error + stacktrace
-		TextView txtErrorMsg = new TextView(context);
-		txtErrorMsg.setText(msg);
-		txtErrorMsg.setHeight(1000);
-		txtErrorMsg.setMovementMethod(new ScrollingMovementMethod());
+		activity.setContentView(errActivityId);
 
-		// copy button
-		Button copyToClipboard = new Button(context);
-		copyToClipboard.setText("Copy to clipboard");
-		copyToClipboard.setOnClickListener(new OnClickListener()
-		{
-			@Override
-			public void onClick(View v)
-			{
+		int toolBarId = this.context.getResources().getIdentifier("toolbar", "id", this.context.getPackageName());
 
-				ClipboardManager clipboard = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
-				ClipData clip = ClipData.newPlainText("nsError", msg);
-				clipboard.setPrimaryClip(clip);
-			}
-		});
+		Toolbar toolbar = (Toolbar) activity.findViewById(toolBarId);
+		activity.setSupportActionBar(toolbar);
 
-		layout.addView(txtHeader);
-		layout.addView(txtErrorMsg);
-		layout.addView(copyToClipboard);
+		int tabLayoutId = this.context.getResources().getIdentifier("tabLayout", "id", this.context.getPackageName());
+
+		tabLayout = (TabLayout) activity.findViewById(tabLayoutId);
+		tabLayout.addTab(tabLayout.newTab().setText("Exception"));
+		tabLayout.addTab(tabLayout.newTab().setText("Logcat"));
+		tabLayout.setTabGravity(TabLayout.GRAVITY_FILL);
+
+		int pagerId = this.context.getResources().getIdentifier("pager", "id", this.context.getPackageName());
+
+		viewPager = (ViewPager) activity.findViewById(pagerId);
+
+		Pager adapter = new Pager(activity.getSupportFragmentManager(), tabLayout.getTabCount());
+
+		viewPager.setAdapter(adapter);
+
+		tabLayout.setOnTabSelectedListener(this);
 	}
 
-	private static void createErrorFile(final Context context)
-	{
-		try
-		{
+	private static void createErrorFile(final Context context) {
+		try {
 			File errFile = new File(context.getFilesDir(), ERROR_FILE_NAME);
 			errFile.createNewFile();
-		}
-		catch (IOException e)
-		{
+		} catch (IOException e) {
 			Log.d("ErrorReport", e.getMessage());
+		}
+	}
+
+	@Override
+	public void onTabSelected(TabLayout.Tab tab) {
+		viewPager.setCurrentItem(tab.getPosition());
+	}
+
+	@Override
+	public void onTabUnselected(TabLayout.Tab tab) {
+
+	}
+
+	@Override
+	public void onTabReselected(TabLayout.Tab tab) {
+		viewPager.setCurrentItem(tab.getPosition());
+	}
+
+	private class Pager extends FragmentStatePagerAdapter {
+
+		int tabCount;
+
+		public Pager(FragmentManager fm, int tabCount) {
+			super(fm);
+			this.tabCount = tabCount;
+		}
+
+		@Override
+		public Fragment getItem(int position) {
+			switch (position) {
+				case 0:
+					return new ExceptionTab();
+				case 1:
+					return new LogcatTab();
+				default:
+					return null;
+			}
+		}
+
+		@Override
+		public int getCount() {
+			return tabCount;
+		}
+	}
+
+	public static class ExceptionTab extends Fragment {
+		@Override
+		public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+			int exceptionTabId = this.getContext().getResources().getIdentifier("exception_tab", "layout", this.getContext().getPackageName());
+			View view = inflater.inflate(exceptionTabId, container, false);
+			int txtViewId = this.getContext().getResources().getIdentifier("txtErrorMsg", "id", this.getContext().getPackageName());
+			TextView txtErrorMsg = (TextView) view.findViewById(txtViewId);
+			txtErrorMsg.setText(exceptionMsg);
+			txtErrorMsg.setMovementMethod(new ScrollingMovementMethod());
+			return view;
+		}
+	}
+
+	public static class LogcatTab extends Fragment {
+		@Override
+		public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+			int logcatTabId = this.getContext().getResources().getIdentifier("logcat_tab", "layout", this.getContext().getPackageName());
+			View view = inflater.inflate(logcatTabId, container, false);
+			return view;
 		}
 	}
 }

--- a/test-app/app/src/main/java/com/tns/ErrorReportActivity.java
+++ b/test-app/app/src/main/java/com/tns/ErrorReportActivity.java
@@ -1,21 +1,24 @@
 package com.tns;
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
 
-public class ErrorReportActivity extends AppCompatActivity
-{
-	public void onCreate(Bundle savedInstanceState)
-	{
-		super.onCreate(savedInstanceState);
-		new ErrorReport(this).buildUI();
-	}
+public class ErrorReportActivity extends AppCompatActivity {
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        new ErrorReport(this).buildUI();
+    }
 
-	@Override
-	protected void onPause()
-	{
-		// the moment the error activity is not in the foreground we want to kill the process
-		super.onPause();
-		ErrorReport.killProcess(this);
-	}
+    @Override
+    protected void onPause() {
+        // the moment the error activity is not in the foreground we want to kill the process
+        super.onPause();
+        ErrorReport.killProcess(this);
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        //        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+    }
 }

--- a/test-app/app/src/main/java/com/tns/ErrorReportActivity.java
+++ b/test-app/app/src/main/java/com/tns/ErrorReportActivity.java
@@ -1,9 +1,9 @@
 package com.tns;
 
-import android.app.Activity;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
 
-public class ErrorReportActivity extends Activity
+public class ErrorReportActivity extends AppCompatActivity
 {
 	public void onCreate(Bundle savedInstanceState)
 	{

--- a/test-app/app/src/main/java/com/tns/ErrorReportActivity.java
+++ b/test-app/app/src/main/java/com/tns/ErrorReportActivity.java
@@ -7,7 +7,7 @@ import android.support.v7.app.AppCompatActivity;
 public class ErrorReportActivity extends AppCompatActivity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        new ErrorReport(this).buildUI(this);
+        new ErrorReport(this).buildUI();
     }
 
     @Override

--- a/test-app/app/src/main/java/com/tns/ErrorReportActivity.java
+++ b/test-app/app/src/main/java/com/tns/ErrorReportActivity.java
@@ -7,7 +7,7 @@ import android.support.v7.app.AppCompatActivity;
 public class ErrorReportActivity extends AppCompatActivity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        new ErrorReport(this).buildUI();
+        new ErrorReport(this).buildUI(this);
     }
 
     @Override

--- a/test-app/app/src/main/java/com/tns/NativeScriptUncaughtExceptionHandler.java
+++ b/test-app/app/src/main/java/com/tns/NativeScriptUncaughtExceptionHandler.java
@@ -30,7 +30,8 @@ public class NativeScriptUncaughtExceptionHandler implements UncaughtExceptionHa
 	public void uncaughtException(Thread thread, Throwable ex)
 	{
 		String errorMessage = ErrorReport.getErrorMessage(ex);
-		
+		String logcatMessage = ErrorReport.getLogcat();
+
 		if (Runtime.isInitialized())
 		{
 			try
@@ -57,7 +58,7 @@ public class NativeScriptUncaughtExceptionHandler implements UncaughtExceptionHa
 			logger.write("Uncaught Exception Message=" + errorMessage);
 		}
 
-		if (!ErrorReport.startActivity(context, errorMessage) && defaultHandler != null)
+		if (!ErrorReport.startActivity(context, errorMessage, logcatMessage) && defaultHandler != null)
 		{
 			defaultHandler.uncaughtException(thread, ex);
 		}

--- a/test-app/app/src/main/java/com/tns/NativeScriptUncaughtExceptionHandler.java
+++ b/test-app/app/src/main/java/com/tns/NativeScriptUncaughtExceptionHandler.java
@@ -30,7 +30,6 @@ public class NativeScriptUncaughtExceptionHandler implements UncaughtExceptionHa
 	public void uncaughtException(Thread thread, Throwable ex)
 	{
 		String errorMessage = ErrorReport.getErrorMessage(ex);
-		String logcatMessage = ErrorReport.getLogcat();
 
 		if (Runtime.isInitialized())
 		{
@@ -58,7 +57,7 @@ public class NativeScriptUncaughtExceptionHandler implements UncaughtExceptionHa
 			logger.write("Uncaught Exception Message=" + errorMessage);
 		}
 
-		if (!ErrorReport.startActivity(context, errorMessage, logcatMessage) && defaultHandler != null)
+		if (!ErrorReport.startActivity(context, errorMessage) && defaultHandler != null)
 		{
 			defaultHandler.uncaughtException(thread, ex);
 		}

--- a/test-app/app/src/main/res/layout/error_activity.xml
+++ b/test-app/app/src/main/res/layout/error_activity.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:tools="http://schemas.android.com/tools"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                xmlns:app="http://schemas.android.com/apk/res-auto"
+                tools:context="com.tns.ErrorReportActivity">
+
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="?attr/actionBarSize"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+        app:popupTheme="@style/ThemeOverlay.AppCompat.Dark"/>
+
+    <android.support.design.widget.TabLayout
+        android:id="@+id/tabLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimary"
+        android:minHeight="?attr/actionBarSize"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"/>
+
+    <android.support.v4.view.ViewPager
+        android:id="@+id/pager"
+        android:layout_width="match_parent"
+        android:layout_height="fill_parent"
+        android:layout_below="@+id/toolbar" />
+</RelativeLayout>

--- a/test-app/app/src/main/res/layout/error_activity.xml
+++ b/test-app/app/src/main/res/layout/error_activity.xml
@@ -4,7 +4,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 xmlns:app="http://schemas.android.com/apk/res-auto"
-                tools:context="com.tns.ErrorReportActivity">
+                tools:context="com.tns.ErrorReportActivity"
+                android:theme="@style/ExceptionActionBar">
 
     <android.support.v7.widget.Toolbar
         android:id="@+id/toolbar"

--- a/test-app/app/src/main/res/layout/exception_tab.xml
+++ b/test-app/app/src/main/res/layout/exception_tab.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:id="@+id/linearLayout">
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:text="Unhandled Exception"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:layout_gravity="center_horizontal"
+            android:textAlignment="center"/>
+        <TextView
+            android:id="@+id/txtErrorMsg"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:text="."
+            android:textAppearance="?android:attr/textAppearanceSmall"/>
+
+        <Button
+            android:id="@+id/btnCopyException"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Copy to clipboard"
+            android:layout_alignParentBottom="true"/>
+    </LinearLayout>
+
+
+</RelativeLayout>

--- a/test-app/app/src/main/res/layout/exception_tab.xml
+++ b/test-app/app/src/main/res/layout/exception_tab.xml
@@ -5,32 +5,38 @@
                 android:orientation="vertical">
 
     <LinearLayout
+        android:id="@+id/linearLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:id="@+id/linearLayout">
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:text="Unhandled Exception"
-            android:textAppearance="?android:attr/textAppearanceSmall"
-            android:layout_gravity="center_horizontal"
-            android:textAlignment="center"/>
-        <TextView
-            android:id="@+id/txtErrorMsg"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:text="."
-            android:textAppearance="?android:attr/textAppearanceSmall"/>
+        android:weightSum="100">
 
-        <Button
-            android:id="@+id/btnCopyException"
+        <LinearLayout
+            android:layout_width="fill_parent"
+            android:layout_height="0dp"
+            android:layout_weight="80">
+
+            <TextView
+                android:id="@+id/txtErrorMsg"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_centerInParent="true"
+                android:text=""
+                android:textAppearance="?android:attr/textAppearanceSmall" />
+        </LinearLayout>
+
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Copy to clipboard"
-            android:layout_alignParentBottom="true"/>
+            android:layout_height="0dp"
+            android:layout_weight="20">
+
+            <Button
+                android:id="@+id/btnCopyException"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_alignParentBottom="true"
+                android:text="Copy to clipboard" />
+        </LinearLayout>
     </LinearLayout>
 
 

--- a/test-app/app/src/main/res/layout/logcat_tab.xml
+++ b/test-app/app/src/main/res/layout/logcat_tab.xml
@@ -4,12 +4,40 @@
                 android:layout_height="match_parent"
                 android:orientation="vertical">
 
-    <TextView
-        android:id="@+id/logcattextView"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:id="@+id/logcatLinearLayout"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:text="the logcat will be contained inside!"
-        android:textAppearance="?android:attr/textAppearanceLarge"/>
+        android:orientation="vertical"
+        android:weightSum="100">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="80">
+
+            <TextView
+                android:id="@+id/logcatMsg"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_centerInParent="true"
+                android:text=""
+                android:textAppearance="?android:attr/textAppearanceSmall" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="20">
+
+            <Button
+                android:id="@+id/btnCopyLogcat"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_alignParentBottom="true"
+                android:text="Copy to sdcard" />
+        </LinearLayout>
+    </LinearLayout>
+
 
 </RelativeLayout>

--- a/test-app/app/src/main/res/layout/logcat_tab.xml
+++ b/test-app/app/src/main/res/layout/logcat_tab.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/logcattextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:text="the logcat will be contained inside!"
+        android:textAppearance="?android:attr/textAppearanceLarge"/>
+
+</RelativeLayout>

--- a/test-app/app/src/main/res/values/styles.xml
+++ b/test-app/app/src/main/res/values/styles.xml
@@ -22,4 +22,6 @@
         <item name="android:windowNoTitle">true</item>
     </style>
 
+    <style name="ExceptionActionBar" parent="Theme.AppCompat.DayNight.DarkActionBar">
+    </style>
 </resources>

--- a/test-app/app/src/main/res/values/styles.xml
+++ b/test-app/app/src/main/res/values/styles.xml
@@ -17,4 +17,9 @@
         <!-- All customizations that are NOT specific to a particular API-level can go here. -->
     </style>
 
+    <style name="NoActionBar" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:windowActionBar">false</item>
+        <item name="android:windowNoTitle">true</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
### Description
The error activity that opens up when an unhandled exception occurs now contains 2 tabs - Exception, Logcat. The full height of the screen is used to display the stack trace or the device log (if viewing Logcat tab)

Changes made to the project template
- added an additional directory to `src/main/res` - `layout` containing the 3 views necessary for displaying the activity
- added `support:design` dependency in gradle to support the TabLayout used in the ErrorActivity
- declared an additional style for the error activity in `src/main/res/values/styles.xml`

Related to issue #293 - Create a better Error Activity bootstrap

ping @Plamen5kov @NickIliev 
