### PR TITLE
moved runtime initialization to Runtime.java

### DIFF
--- a/build-artifacts/project-template-gradle/src/main/java/com/tns/RuntimeHelper.java
+++ b/build-artifacts/project-template-gradle/src/main/java/com/tns/RuntimeHelper.java
@@ -104,13 +104,15 @@ public final class RuntimeHelper {
 					logger.write("Error while getting current proxy thumb");
 				e.printStackTrace();
 			}
-			ThreadScheduler workThreadScheduler = new WorkThreadScheduler(new Handler(Looper.getMainLooper()));
-			Configuration config = new Configuration(workThreadScheduler, logger, debugger, appName, null, rootDir,
+
+			Configuration config = new Configuration(logger, debugger, appName, null, rootDir,
 					appDir, classLoader, dexDir, dexThumb, v8Config);
-			runtime = new Runtime(config);
+
+			runtime = Runtime.initializeRuntimeWithConfiguration(config);
 
 			exHandler.setRuntime(runtime);
 
+			// runtime needs to be initialized before the NativeScriptSyncService is enabled because it uses runtime.runScript(...)
 			if (NativeScriptSyncService.isSyncEnabled(app)) {
 				NativeScriptSyncService syncService = new NativeScriptSyncService(runtime, logger, app);
 
@@ -128,7 +130,7 @@ public final class RuntimeHelper {
 				}
 			}
 
-			runtime.init();
+
 			runtime.runScript(new File(appDir, "internal/ts_helpers.js"));
 
 			File javaClassesModule = new File(appDir, "app/tns-java-classes.js");

--- a/runtime/src/main/java/com/tns/Configuration.java
+++ b/runtime/src/main/java/com/tns/Configuration.java
@@ -6,7 +6,6 @@ import android.app.Application;
 
 public class Configuration
 {
-	public final ThreadScheduler threadScheduler;
 	public final Logger logger;
 	public final Debugger debugger;
 	public final String appName;
@@ -18,11 +17,10 @@ public class Configuration
 	public final String dexThumb;
 	public final Object[] v8Config;
 	
-	public Configuration(ThreadScheduler threadScheduler, Logger logger,  Debugger debugger,
+	public Configuration(Logger logger,  Debugger debugger,
 			String appName, File runtimeLibPath, File rootDir, File appDir, ClassLoader classLoader,
 			File dexDir, String dexThumb, Object[] v8Config)
 	{
-		this.threadScheduler = threadScheduler;
 		this.logger = logger;
 		this.debugger = debugger;
 		this.appName = appName;

--- a/runtime/src/main/java/com/tns/Runtime.java
+++ b/runtime/src/main/java/com/tns/Runtime.java
@@ -162,9 +162,9 @@ public class Runtime
 		This method initializes the runtime and should always be called first and through the main thread
 		in order to set static configuration that all following workers can use
 	 */
-	public static Runtime initializeRuntimeWithConfiguration(Configuration config) {
+	public static Runtime initializeWithConfiguration(Configuration config) {
 		staticConfiguration = config;
-		Runtime runtime = initRuntime();
+		Runtime runtime = initialize();
 		return runtime;
 	}
 
@@ -173,7 +173,7 @@ public class Runtime
 		It will use the static configuration for all following calls to initialize a new runtime.
 	 */
 	@RuntimeCallable
-	public static Runtime initRuntime() {
+	public static Runtime initialize() {
 
 		//setting handler operation needs to happen in Runtime.java
 		ThreadScheduler workThreadScheduler = new WorkThreadScheduler(new Handler(Looper.myLooper()));

--- a/runtime/src/main/java/com/tns/Runtime.java
+++ b/runtime/src/main/java/com/tns/Runtime.java
@@ -116,6 +116,7 @@ public class Runtime
 			}
 			this.runtimeId = nextRuntimeId++;
 			this.config = config;
+			this.threadScheduler = threadScheduler;
 			classResolver = new ClassResolver(this);
 			currentRuntime.set(this);
 			runtimeCache.put(this.runtimeId, this);
@@ -199,8 +200,6 @@ public class Runtime
 		{
 			throw new RuntimeException("NativeScriptApplication already initialized");
 		}
-
-		this.threadScheduler = threadScheduler;
 
 		this.logger = logger;
 

--- a/runtime/src/main/java/com/tns/Runtime.java
+++ b/runtime/src/main/java/com/tns/Runtime.java
@@ -17,7 +17,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 
-import android.app.Application;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.SparseArray;

--- a/runtime/src/main/java/com/tns/ThreadScheduler.java
+++ b/runtime/src/main/java/com/tns/ThreadScheduler.java
@@ -1,5 +1,7 @@
 package com.tns;
 
+import android.os.Handler;
+
 public interface ThreadScheduler
 {
 	boolean post(Runnable r);

--- a/runtime/src/main/java/com/tns/ThreadScheduler.java
+++ b/runtime/src/main/java/com/tns/ThreadScheduler.java
@@ -1,7 +1,5 @@
 package com.tns;
 
-import android.os.Handler;
-
 public interface ThreadScheduler
 {
 	boolean post(Runnable r);

--- a/runtime/src/main/java/com/tns/WorkThreadScheduler.java
+++ b/runtime/src/main/java/com/tns/WorkThreadScheduler.java
@@ -6,9 +6,9 @@ public final class WorkThreadScheduler implements ThreadScheduler
 {
 	private final Handler threadHandler;
 
-	public WorkThreadScheduler(Handler threadHandler)
+	public WorkThreadScheduler(Handler handler)
 	{
-		this.threadHandler = threadHandler;
+		this.threadHandler = handler;
 	}
 
 	@Override

--- a/test-app/app/src/main/java/com/tns/RuntimeHelper.java
+++ b/test-app/app/src/main/java/com/tns/RuntimeHelper.java
@@ -105,13 +105,15 @@ public final class RuntimeHelper {
 					logger.write("Error while getting current proxy thumb");
 				e.printStackTrace();
 			}
-			ThreadScheduler workThreadScheduler = new WorkThreadScheduler(new Handler(Looper.getMainLooper()));
-			Configuration config = new Configuration(workThreadScheduler, logger, debugger, appName, null, rootDir,
+
+			Configuration config = new Configuration(logger, debugger, appName, null, rootDir,
 					appDir, classLoader, dexDir, dexThumb, v8Config);
-			runtime = new Runtime(config);
+
+			runtime = Runtime.initializeRuntimeWithConfiguration(config);
 
 			exHandler.setRuntime(runtime);
 
+			// runtime needs to be initialized before the NativeScriptSyncService is enabled because it uses runtime.runScript(...)
 			if (NativeScriptSyncService.isSyncEnabled(app)) {
 				NativeScriptSyncService syncService = new NativeScriptSyncService(runtime, logger, app);
 
@@ -129,7 +131,7 @@ public final class RuntimeHelper {
 				}
 			}
 
-			runtime.init();
+
 			runtime.runScript(new File(appDir, "internal/ts_helpers.js"));
 
 			File javaClassesModule = new File(appDir, "app/tns-java-classes.js");

--- a/test-app/app/src/main/java/com/tns/RuntimeHelper.java
+++ b/test-app/app/src/main/java/com/tns/RuntimeHelper.java
@@ -107,7 +107,7 @@ public final class RuntimeHelper {
 			Configuration config = new Configuration(logger, debugger, appName, null, rootDir,
 					appDir, classLoader, dexDir, dexThumb, v8Config);
 
-			runtime = Runtime.initializeRuntimeWithConfiguration(config);
+			runtime = Runtime.initializeWithConfiguration(config);
 
 			exHandler.setRuntime(runtime);
 

--- a/test-app/app/src/main/java/com/tns/RuntimeHelper.java
+++ b/test-app/app/src/main/java/com/tns/RuntimeHelper.java
@@ -5,8 +5,6 @@ import java.io.File;
 import android.app.Application;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.os.Build;
-import android.os.Handler;
-import android.os.Looper;
 import android.util.Log;
 import java.io.IOException;
 


### PR DESCRIPTION
This refactoring is in preparation for the multithreaded implementation.

Changed runtime initialization so it happens in `Runtime.java` only and hid WorkThreadScheduler initialization also in `Runtime.java`.

ping @NativeScript/android-runtime 