### PR TITLE
Follow-up fixes for error-activity

### DIFF
--- a/build-artifacts/project-template-gradle/src/main/java/com/tns/ErrorReportActivity.java
+++ b/build-artifacts/project-template-gradle/src/main/java/com/tns/ErrorReportActivity.java
@@ -17,8 +17,8 @@ public class ErrorReportActivity extends AppCompatActivity {
         ErrorReport.killProcess(this);
     }
 
-    @Override
+    // @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        //        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        // super.onRequestPermissionsResult(requestCode, permissions, grantResults);
     }
 }

--- a/build-artifacts/project-template-gradle/src/main/res/layout/error_activity.xml
+++ b/build-artifacts/project-template-gradle/src/main/res/layout/error_activity.xml
@@ -5,14 +5,13 @@
                 android:layout_height="match_parent"
                 xmlns:app="http://schemas.android.com/apk/res-auto"
                 tools:context="com.tns.ErrorReportActivity"
-                android:theme="@style/ExceptionActionBar">
+                android:theme="@style/Widget.AppCompat.Light.ActionBar">
 
     <android.support.v7.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="?attr/actionBarSize"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         app:popupTheme="@style/ThemeOverlay.AppCompat.Dark"/>
 
     <android.support.design.widget.TabLayout
@@ -20,12 +19,13 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?attr/colorPrimary"
-        android:minHeight="?attr/actionBarSize"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"/>
+        android:minHeight="?attr/actionBarSize"/>
 
     <android.support.v4.view.ViewPager
         android:id="@+id/pager"
         android:layout_width="match_parent"
         android:layout_height="fill_parent"
-        android:layout_below="@+id/toolbar" />
+        android:layout_below="@+id/toolbar">
+
+    </android.support.v4.view.ViewPager>
 </RelativeLayout>

--- a/build-artifacts/project-template-gradle/src/main/res/values/errorstyles.xml
+++ b/build-artifacts/project-template-gradle/src/main/res/values/errorstyles.xml
@@ -4,7 +4,4 @@
         <item name="android:windowActionBar">false</item>
         <item name="android:windowNoTitle">true</item>
     </style>
-
-    <style name="ExceptionActionBar" parent="Theme.AppCompat.DayNight.DarkActionBar">
-    </style>
 </resources> 

--- a/test-app/app/src/main/java/com/tns/ErrorReportActivity.java
+++ b/test-app/app/src/main/java/com/tns/ErrorReportActivity.java
@@ -17,8 +17,8 @@ public class ErrorReportActivity extends AppCompatActivity {
         ErrorReport.killProcess(this);
     }
 
-    @Override
+    // @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        //        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        // super.onRequestPermissionsResult(requestCode, permissions, grantResults);
     }
 }

--- a/test-app/app/src/main/res/layout/error_activity.xml
+++ b/test-app/app/src/main/res/layout/error_activity.xml
@@ -5,14 +5,13 @@
                 android:layout_height="match_parent"
                 xmlns:app="http://schemas.android.com/apk/res-auto"
                 tools:context="com.tns.ErrorReportActivity"
-                android:theme="@style/ExceptionActionBar">
+                android:theme="@style/Widget.AppCompat.Light.ActionBar">
 
     <android.support.v7.widget.Toolbar
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="?attr/actionBarSize"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         app:popupTheme="@style/ThemeOverlay.AppCompat.Dark"/>
 
     <android.support.design.widget.TabLayout
@@ -20,12 +19,13 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?attr/colorPrimary"
-        android:minHeight="?attr/actionBarSize"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"/>
+        android:minHeight="?attr/actionBarSize"/>
 
     <android.support.v4.view.ViewPager
         android:id="@+id/pager"
         android:layout_width="match_parent"
         android:layout_height="fill_parent"
-        android:layout_below="@+id/toolbar" />
+        android:layout_below="@+id/toolbar">
+
+    </android.support.v4.view.ViewPager>
 </RelativeLayout>

--- a/test-app/app/src/main/res/values/styles.xml
+++ b/test-app/app/src/main/res/values/styles.xml
@@ -21,7 +21,4 @@
         <item name="android:windowActionBar">false</item>
         <item name="android:windowNoTitle">true</item>
     </style>
-
-    <style name="ExceptionActionBar" parent="Theme.AppCompat.DayNight.DarkActionBar">
-    </style>
 </resources>


### PR DESCRIPTION
Fixes error activity showing on crash when the app has been built in release;

Removed conflicting styles requiring min compileSdk of 23;

Fixed a visual bug where tabs of the TabLayout would not update to active when the content in the ViewPager was scrolled horizontally (change pages)

@NativeScript/android-runtime @dtopuzov 