### PR TITLE
runtime embeds binding generator

### DIFF
--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -173,14 +173,9 @@ model {
     }
 }
 
-if (project.hasProperty("embedBindingGenerator")) {
-    dependencies {
-        compile fileTree(dir: (project(':binding-generator').buildDir.toString() + "/libs"), include: ['*.jar'])
-    }
-} else {
-    dependencies {
-        compile project(':binding-generator')
-    }
+dependencies {
+    def bindingGeneratorJarPath = new File(project(':binding-generator').project.projectDir, "build/libs/binding-generator.jar");
+    compile files(bindingGeneratorJarPath);
 }
 
 task setPackageVersion {

--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -45,6 +45,7 @@ model {
 
 dependencies {
 	def supportVer = "23.3.0"
+	compile project(':binding-generator')
 	compile project(':runtime')
 	compile fileTree(include: ['*.jar'], dir: 'libs')
 


### PR DESCRIPTION
Both the runtime and the pack build need to take care of building the binding generator, so when the runtime build runs, it can find an already generated binding-generator.jar. This is done so publishing the generated nativescript.aar file, will be easier.
Currently it's difficult to publish a generated `.aar` file with Android Studio, while using the experimental android plugin for gradle.

ping: @NativeScript/android-runtime 