### PR TITLE
Plamen5kov/incremental build

### DIFF
--- a/android-static-binding-generator/project/build.gradle
+++ b/android-static-binding-generator/project/build.gradle
@@ -2,21 +2,35 @@
 *	The android static binding generator will generate bindings for the Javascript code you specify.
 */
 
+import groovy.json.JsonSlurper
+import groovy.io.FileType
+
 def isWinOs = System.properties['os.name'].toLowerCase().contains('windows')
 
 def astParserDir = "$projectDir/parser"
-def interfaceNamesFilePath = "$projectDir/interfaces-names.txt"
-def bindingsFilePath = "$projectDir/bindings.txt"
+def interfaceNamesFileP = "$projectDir/interfaces-names.txt"
+def bindingsFileP = "$projectDir/bindings.txt"
 def cachedJarsFilePath = "$projectDir/cached.txt"
+def jsParserP = "$projectDir/parser/js_parser.js"
 
-def shouldRun = true
+
+
+//def absoluteOutDir = new File("./outDir")//project.outDir
+
 def absoluteOutDir = project.outDir
 if (!absoluteOutDir.exists()) {
 	absoluteOutDir.mkdirs()
 }
+
+// def absoluteJsCodeDir = new File("./jsCodeDir").getAbsolutePath()//project.jsCodeDir
 def absoluteJsCodeDir = project.jsCodeDir
+def jsCodeAbsolutePath = absoluteJsCodeDir.getAbsolutePath()
 def utf8 = java.nio.charset.StandardCharsets.UTF_8
 def current = ""
+
+def shouldRun = true
+def rootTraversed = false;
+def inputJsFiles = new LinkedList <String> ();
 
 // depends on passed jars and generated interface-names
 task generateInterfaceNamesList() {
@@ -47,32 +61,132 @@ task generateInterfaceNamesList() {
 	}
 }
 
-// if there are new dependencies the parser will run again
-task runAstParser () {
-	inputs.files fileTree(dir: absoluteJsCodeDir)
-	outputs.files(bindingsFilePath)
+task traverseJsFiles () {
+	def traverseDirectory
 
-	doFirst {
-		exec {
-			workingDir astParserDir
+	traverseDirectory = { dir, traverseExplicitly ->
 
-			if(isWinOs) {
-				commandLine "cmd", "/c", "node", "js_parser.js" , absoluteJsCodeDir, "../bindings.txt"
+		def currentDir = new File(dir)
+		def pJsonFile = false;
+
+		if (!traverseExplicitly) {
+			if (rootTraversed || !dir.equals(jsCodeAbsolutePath)) {
+				currentDir.eachFile(FileType.FILES) { File f ->
+					if (f.getName().equals("package.json")) {
+						pJsonFile = true;
+						return true; //break
+					}
+				}
 			}
-			else {
-				commandLine "node", "js_parser.js", absoluteJsCodeDir, "../bindings.txt"
+
+			if (pJsonFile) {
+				def jsonFile = new File(dir, "package.json");
+				def pjson = new JsonSlurper().parseText(jsonFile.text)
+
+				if (!pjson.nativescript) {
+					return;
+				} else {
+					// if (pjson.nativescript['recursive-static-bindings']) {
+					// 	// println "Folder will be traversed completely: " + dir
+					// }
+					traverseExplicitly = true;
+				}
 			}
 		}
+		else {
+			rootTraversed = true;
+		}
+
+		currentDir.eachFile(FileType.FILES) { File f ->
+			def file = f.getAbsolutePath();
+			if(file.substring(file.length() - 3, file.length()).equals(".js")) {
+				// println "Visiting JavaScript file: " + f.getName()
+				inputJsFiles.add(f.getAbsolutePath())
+			}
+		}
+
+		currentDir.eachFile FileType.DIRECTORIES, { d ->
+			traverseDirectory(d.getAbsolutePath(), traverseExplicitly)
+		}
+	}
+
+	traverseDirectory(jsCodeAbsolutePath, false)
+}
+
+task runAstParser(type: RunAstParserTask) {
+	outputFiles = files(bindingsFileP)
+    inputFiles = files(inputJsFiles)
+
+	//ast parser configuration
+	jsParserPath = jsParserP
+	jsCodeDir = jsCodeAbsolutePath
+	bindingsFilePath = bindingsFileP
+	interfaceNamesFilePath = interfaceNamesFileP
+
+}
+
+class RunAstParserTask extends DefaultTask {
+	@InputFiles
+	def FileCollection inputFiles
+
+	@OutputFiles
+	def FileCollection outputFiles
+
+	@Input
+	def jsParserPath
+
+	@Input
+	def jsCodeDir
+
+	@Input
+	def bindingsFilePath
+
+	@Input
+	def interfaceNamesFilePath
+
+	@TaskAction
+	void execute(IncrementalTaskInputs inputs) {
+		println inputs.incremental ? "Running incremental build" : "Running full build"
+
+		def runCommand = { strList ->
+			assert ( strList instanceof String || ( strList instanceof List && strList.each{ it instanceof String } ))
+			def proc = strList.execute()
+			proc.in.eachLine { line -> println line }
+			proc.out.close()
+			proc.waitFor()
+
+			if (proc.exitValue()) {
+				println "gave the following error: "
+				println "[ERROR] ${proc.getErrorStream()}"
+			}
+			// assert !proc.exitValue()
+		}
+		def list = new ArrayList<String>();
+		list.add("node")
+		list.add(jsParserPath)
+		list.add(jsCodeDir)
+		list.add(bindingsFilePath)
+		list.add(interfaceNamesFilePath)
+
+		inputs.outOfDate { change ->
+			list.add(change.getFile().getAbsolutePath())
+			// println change.getFile();
+		}
+
+		runCommand(list)
+
+		// inputs.removed { change ->
+		// implement later (pass information to dex generator)
+		// }
 	}
 }
+
 // run the static binding generator
 task generateBindings() {
 
-	inputs.files(bindingsFilePath)
+	def bindingsFile = new File(bindingsFileP);
 	outputs.dir(absoluteOutDir)
-	outputs.upToDateWhen({
-		return !shouldRun
-	})
+	inputs.dir (bindingsFile)
 
 	doFirst {
 		javaexec {
@@ -80,14 +194,18 @@ task generateBindings() {
 
 			def str = new LinkedList <String> ();
 			str.add("staticbindinggenerator.jar")
-			str.add(bindingsFilePath)
+			str.add(bindingsFileP)
 			str.add(absoluteOutDir)
-			str.addAll(project.jarFiles)
+
+			def jarsAsStr = current.toString();
+			def jarsArr = jarsAsStr.replaceAll(/[\[\]]/, "").split(", ")
+			str.addAll(jarsArr)
 
 			args str.toArray()
 		}
 	}
 }
 
-runAstParser.dependsOn(generateInterfaceNamesList)
+traverseJsFiles.dependsOn(generateInterfaceNamesList)
+runAstParser.dependsOn(traverseJsFiles)
 generateBindings.dependsOn(runAstParser)

--- a/android-static-binding-generator/project/build.gradle
+++ b/android-static-binding-generator/project/build.gradle
@@ -61,6 +61,9 @@ task generateInterfaceNamesList() {
 	}
 }
 
+// traverses the javascript code input directory
+// 1. traverses all root directory files
+// 2. all subdirectories that do not have a package.json containing a "nativescript" key are skipped
 task traverseJsFiles () {
 	def traverseDirectory
 
@@ -113,9 +116,10 @@ task traverseJsFiles () {
 	traverseDirectory(jsCodeAbsolutePath, false)
 }
 
+// runs the ast parser only with changed js files
 task runAstParser(type: RunAstParserTask) {
 	outputFiles = files(bindingsFileP)
-    inputFiles = files(inputJsFiles)
+    	inputFiles = files(inputJsFiles)
 
 	//ast parser configuration
 	jsParserPath = jsParserP
@@ -125,6 +129,7 @@ task runAstParser(type: RunAstParserTask) {
 
 }
 
+// custom incremental task that runs the ast parser
 class RunAstParserTask extends DefaultTask {
 	@InputFiles
 	def FileCollection inputFiles
@@ -176,7 +181,7 @@ class RunAstParserTask extends DefaultTask {
 		runCommand(list)
 
 		// inputs.removed { change ->
-		// implement later (pass information to dex generator)
+			// implement later (pass information to dex generator)
 		// }
 	}
 }


### PR DESCRIPTION
* `runAstParser` task runs only for changed input files
* `astParser` tool runs only for passed js files, instead of whole directory
* traversal of folders moved to gradle so it can be passed as incremental input
* used incubating gradle api [`Incubating Task`](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.incremental.IncrementalTaskInputs.html)

Solved Problem: 
Try to improve slow build, so the whole static javascript analysis isn't triggered for pure javascript files.

Problem that occurred:
```
:asbg:traverseJsFiles  // traverses js files
:asbg:runAstParser // only new js files are passed (all on first build)
:asbg:generateBindings UP-TO-DATE  // if pure js file generate bindings is not triggered
:mergeF0DebugShaders UP-TO-DATE
:compileF0DebugShaders UP-TO-DATE
:generateF0DebugAssets UP-TO-DATE
:mergeF0DebugAssets // uses same inputs dir as runAstParser (no controll here)
```
That means that when a pure js file is changed, before there were two tasks which depended on it:
* _asbg:runAstParser_ (fixed with incremental build)
* _mergeF0DebugAssets_ which is not under our control.

ping: @NativeScript/android-runtime 