### PR TITLE
fix too many arguments bug

### DIFF
--- a/android-static-binding-generator/project/build.gradle
+++ b/android-static-binding-generator/project/build.gradle
@@ -12,6 +12,7 @@ def interfaceNamesFileP = "$projectDir/interfaces-names.txt"
 def bindingsFileP = "$projectDir/bindings.txt"
 def cachedJarsFilePath = "$projectDir/cached.txt"
 def jsParserP = "$projectDir/parser/js_parser.js"
+def jsFilesParametersP = "$projectDir/jsFilesParameters.txt"
 
 
 
@@ -126,6 +127,7 @@ task runAstParser(type: RunAstParserTask) {
 	jsCodeDir = jsCodeAbsolutePath
 	bindingsFilePath = bindingsFileP
 	interfaceNamesFilePath = interfaceNamesFileP
+	jsFilesParametersPath = jsFilesParametersP
 
 }
 
@@ -149,6 +151,9 @@ class RunAstParserTask extends DefaultTask {
 	@Input
 	def interfaceNamesFilePath
 
+	@Input
+	jsFilesParametersPath
+
 	@TaskAction
 	void execute(IncrementalTaskInputs inputs) {
 		println inputs.incremental ? "Running incremental build" : "Running full build"
@@ -166,17 +171,24 @@ class RunAstParserTask extends DefaultTask {
 			}
 			// assert !proc.exitValue()
 		}
+
+		def jarDependencies = new ArrayList<String>();
+		inputs.outOfDate { change ->
+			jarDependencies.add(change.getFile().getAbsolutePath())
+			// println change.getFile();
+		}
+		new File(jsFilesParametersPath).withWriter { out ->
+			jarDependencies.each {out.println it}
+		}
+
 		def list = new ArrayList<String>();
 		list.add("node")
 		list.add(jsParserPath)
 		list.add(jsCodeDir)
 		list.add(bindingsFilePath)
 		list.add(interfaceNamesFilePath)
+		list.add(jsFilesParametersPath)
 
-		inputs.outOfDate { change ->
-			list.add(change.getFile().getAbsolutePath())
-			// println change.getFile();
-		}
 
 		runCommand(list)
 

--- a/android-static-binding-generator/project/parser/js_parser.js
+++ b/android-static-binding-generator/project/parser/js_parser.js
@@ -59,34 +59,55 @@ if (process.env.AST_PARSER_INTERFACE_FILE_PATH) {
 //console variables have priority
 if (arguments && arguments.length >= 3) {
 	inputDir = arguments[2]
-	console.log("inputDir: " + inputDir)
+	// console.log("inputDir: " + inputDir)
 }
 if (arguments && arguments.length >= 4) {
 	outFile = arguments[3]
-	console.log("outFile: " + outFile)
+	// console.log("outFile: " + outFile)
 }
 if (arguments && arguments.length >= 5) {
 	interfacesNamesFilePath = arguments[4]
-	console.log("interfacesNamesFilePath: " + interfacesNamesFilePath)
+	// console.log("interfacesNamesFilePath: " + interfacesNamesFilePath)
 }
 if (arguments && arguments.length >= 6) {
-	for(var i = 5; i < arguments.length; i += 1) {
-		inputFiles.push(arguments[i])
-	}
+	inputFilesPath = arguments[5]
 }
+
+
 
 /////////////// PREPARATION ////////////////
 // fileHelpers.createFile(outFile)
 
 /////////////// EXECUTE ////////////////
+var tsHelpersFilePath = path.join(inputDir, "..", "internal", "ts_helpers.js");
 
 // ENTRY POINT!
-var tsHelpersFilePath = path.join(inputDir, "..", "internal", "ts_helpers.js");
-getFileAst(tsHelpersFilePath)
+readLinesFromFile(inputFilesPath, inputFiles, tsHelpersFilePath)
+	.then(getFileAst)
 	.then(getExtendsLineColumn) //config
 	.then(readInterfaceNames) //config
 	.then(traverseAndAnalyseFilesDir) //start
 	.catch(exceptionHandler);
+
+/*
+*	Get's the javascript files that need traversing
+*/
+function readLinesFromFile(filePath, outArr, resolveParameter) {
+	return new Promise(function (resolve, reject) {
+		new lazy(fs.createReadStream(filePath))
+			.lines
+			.forEach(function (line) {
+				outArr.push(line.toString());
+			}).on('pipe', function (err) {
+				if (err) {
+					return reject(err);
+				}
+				console.log("finished with reading lines with js files")
+
+				return resolve(resolveParameter)
+			});
+	});
+}
 
 
 /*


### PR DESCRIPTION
_Problem_:
Although I couldn't reproduce the problem java crashes with:
```
Execution failed for task ':asbg:runAstParser'.
java.io.IOException: Cannot run program "node": error=7, Argument list too long
```

_Solution_:
We now save all javascript files that need to be analyzed in a file and pass the file instead of the files, so this should be a sufficient fix.

_Related issue_: https://github.com/NativeScript/android-runtime/issues/572