### PR TITLE
Fix js debugger not attaching on app start

### DIFF
--- a/runtime/src/main/java/com/tns/Runtime.java
+++ b/runtime/src/main/java/com/tns/Runtime.java
@@ -452,14 +452,16 @@ public class Runtime {
             throw new RuntimeException("Fail to initialize Require class", ex);
         }
 
-        if (debugger != null) {
+        // TODO: Pete: this.runtimeId == 0 is a temporary patching of jsDebugger not attaching on app start
+        // TODO: Pete: Debugger should not be created when a worker is created
+        if (debugger != null && this.runtimeId == 0) {
             jsDebugger = new JsDebugger(debugger, threadScheduler);
         }
 
         initNativeScript(getRuntimeId(), Module.getApplicationFilesPath(), logger.isEnabled(), appName, v8Config, callingJsDir, jsDebugger);
 
-        if (jsDebugger != null) {
-            // jsDebugger.start();
+        if (jsDebugger != null && this.runtimeId == 0) {
+             jsDebugger.start();
         }
 
         clearStartupData(getRuntimeId()); // It's safe to delete the data after the V8 debugger is initialized


### PR DESCRIPTION
Javascript debugger didn't attach at all as it was disabled during runtime object refactoring.

Debugger will now start when runtime is initialized on the main thread.

@NativeScript/android-runtime @pkoleva 