### PR TITLE
Worker API logic fixes

### DIFF
--- a/runtime/src/main/java/com/tns/Runtime.java
+++ b/runtime/src/main/java/com/tns/Runtime.java
@@ -246,7 +246,7 @@ public class Runtime {
                 msgToMain.arg1 = MessageType.CloseWorker;
                 msgToMain.arg2 = currentRuntime.workerId;
 
-                currentRuntime.mainThreadHandler.sendMessageAtFrontOfQueue(msgToMain);
+                currentRuntime.mainThreadHandler.sendMessage(msgToMain);
 
                 currentRuntime.isTerminating = true;
 
@@ -1137,6 +1137,10 @@ public class Runtime {
             Queue<Message> messages = pendingWorkerMessages.get(workerId);
             messages.add(msg);
 
+            return;
+        }
+
+        if(!workerHandler.getLooper().getThread().isAlive()) {
             return;
         }
 

--- a/runtime/src/main/jni/V8GlobalHelpers.cpp
+++ b/runtime/src/main/jni/V8GlobalHelpers.cpp
@@ -9,7 +9,7 @@
 using namespace v8;
 using namespace std;
 
-string tns::ConvertToString(const v8::Local<String> &s) {
+string tns::ConvertToString(const Local<v8::String> &s) {
     if (s.IsEmpty())
     {
         return string();


### PR DESCRIPTION
This PR includes propagation for script errors thrown in `onerror` handler inside a Worker scope, and a fix for workers' scope `close` swallowing up all calls in the current function.

All tests in common-runtime-tests pass