### PR TITLE
Optimize package size

### DIFF
--- a/build-artifacts/project-template-gradle/build-tools/check-v8-dependants.js
+++ b/build-artifacts/project-template-gradle/build-tools/check-v8-dependants.js
@@ -1,0 +1,39 @@
+'use strict';
+
+let args = process.argv;
+let dependencies = JSON.parse(args[2]);
+let platformsDir = args[3];
+
+const path = require("path"),
+    fs = require("fs");
+
+if (dependencies) {
+    let platformDir = path.join(platformsDir, "android");
+    let buildDir = path.join(platformDir, "build-tools");
+    let useV8File = path.join(buildDir, 'useV8');
+
+    try {
+        fs.unlinkSync(useV8File);
+    } catch (e) {
+
+    }
+
+    let useV8Symbols = false;
+
+    for (let dependencyName in dependencies) {
+        let dependency = dependencies[dependencyName];
+        
+        let isPlugin = !!dependency.nativescript;
+        if (isPlugin) {
+            let consumesV8Symbols = !!dependency.nativescript.useV8symbols;
+            if (consumesV8Symbols) {
+                useV8Symbols = true;
+                break;
+            }
+        }
+    }
+
+    if (useV8Symbols) {
+        fs.writeFileSync(useV8File, "1");
+    }
+}

--- a/build-artifacts/project-template-gradle/build.gradle
+++ b/build-artifacts/project-template-gradle/build.gradle
@@ -205,10 +205,21 @@ dependencies {
 	// compile files("$rootDir/libs/aar") {
         // builtBy 'copyAarDependencies'
     // }
-	
+	copyNativeScriptAar()
+
 	compile project(':runtime')
 }
 
+
+def copyNativeScriptAar() {
+	def runtimeAarType = project.hasProperty("nooptimize") ? "regular" : "optimized";
+
+	copy {
+		from "$projectDir/libs/runtime-libs/nativescript-${runtimeAarType}.aar"
+		into "$projectDir/libs/runtime-libs/"
+		rename "nativescript-${runtimeAarType}.aar", "nativescript.aar"
+	}
+}
 
 ////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////// CONFIGURATION PHASE //////////////////////////////////

--- a/build-artifacts/project-template-gradle/build.gradle
+++ b/build-artifacts/project-template-gradle/build.gradle
@@ -212,7 +212,12 @@ dependencies {
 
 
 def copyNativeScriptAar() {
-	def runtimeAarType = project.hasProperty("nooptimize") ? "regular" : "optimized";
+	def useV8SymbolsFlag = new File("$projectDir/build-tools/useV8");
+	def runtimeAarType = "optimized";
+	if (useV8SymbolsFlag.exists() && !useV8SymbolsFlag.isDirectory()) {
+		println "Using less-optimized runtime bundle.";
+		runtimeAarType = "regular";
+	}
 
 	copy {
 		from "$projectDir/libs/runtime-libs/nativescript-${runtimeAarType}.aar"

--- a/build.gradle
+++ b/build.gradle
@@ -141,9 +141,9 @@ task generateRuntimeAar(type: Exec) {
 
 task copyGeneratedRuntime << {
 	copy {
-		from "$rootDir/runtime/build/outputs/aar/runtime-release.aar"
+		from "$rootDir/runtime/build/outputs/aar/runtime-regular-release.aar"
 		into "$rootDir/dist/framework/libs/runtime-libs/"
-		rename "runtime-release.aar", "nativescript.aar"
+		rename "runtime-regular-release.aar", "nativescript-regular.aar"
 	}
 
 	copy {

--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,26 @@ task generateBindingGenerator (type: Exec)   {
 	}
 }
 
-task generateRuntime (type: Exec)   {
+task generateRuntime {
+	doFirst {
+		tasks.generateOptimizedRuntimeAar.execute();
+		tasks.generateRuntimeAar.execute();
+	}
+}
+
+task generateOptimizedRuntimeAar(type: Exec) {
+	doFirst {
+		workingDir "$rootDir/runtime"
+		if(isWinOs) {
+			commandLine "cmd", "/c", "gradlew", "assembleRelease", "-PpackageVersion=${pVersion}", "-PgitCommitVersion=${arVersion}", "-PembedBindingGenerator=true", "-Poptimized"
+		}
+		else {
+			commandLine "./gradlew", "assembleRelease", "-PpackageVersion=${pVersion}", "-PgitCommitVersion=${arVersion}", "-PembedBindingGenerator=true", "-Poptimized"
+		}
+	}
+}
+
+task generateRuntimeAar(type: Exec) {
 	doFirst {
 		workingDir "$rootDir/runtime"
 		if(isWinOs) {
@@ -116,7 +135,7 @@ task generateRuntime (type: Exec)   {
 		}
 		else {
 			commandLine "./gradlew", "assembleRelease", "-PpackageVersion=${pVersion}", "-PgitCommitVersion=${arVersion}", "-PembedBindingGenerator=true"
-		}
+		}	
 	}
 }
 
@@ -125,6 +144,12 @@ task copyGeneratedRuntime << {
 		from "$rootDir/runtime/build/outputs/aar/runtime-release.aar"
 		into "$rootDir/dist/framework/libs/runtime-libs/"
 		rename "runtime-release.aar", "nativescript.aar"
+	}
+
+	copy {
+		from "$rootDir/runtime/build/outputs/aar/runtime-optimized-release.aar"
+		into "$rootDir/dist/framework/libs/runtime-libs/"
+		rename "runtime-optimized-release.aar", "nativescript-optimized.aar"
 	}
 }
 

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -20,7 +20,11 @@ allprojects {
 }
 
 def ndkDebuggable = false;
+def optimized = project.hasProperty("optimized")
 
+if(optimized) {
+    println "Optimized build triggered."
+}
 
 List<String> runTasks = gradle.startParameter.getTaskNames();
 for (String runTask : runTasks) {
@@ -196,6 +200,10 @@ model {
         buildToolsVersion = project.ext._buildToolsVersion
 
         defaultConfig.with {
+            if(optimized) {
+                project.archivesBaseName = "${archivesBaseName}-optimized"
+            }
+
             minSdkVersion.apiLevel = 17
             targetSdkVersion.apiLevel = 22
         }
@@ -218,6 +226,10 @@ model {
         CFlags.addAll(["-Wno-error=format-security", "-g", "-fno-builtin-stpcpy"])
 
         ldLibs.addAll(["android", "dl", "log", "atomic", "z"])
+
+        if(optimized) {
+            ldFlags.addAll(["-Wl,--exclude-libs=ALL", "-Wl,--gc-sections"])
+        }
 
         stl = "c++_static"
 
@@ -253,8 +265,17 @@ model {
             minifyEnabled = false
             proguardFiles.add(file('proguard-rules.txt'))
 
+            if(optimized) {
+                versionNameSuffix '-optimized'
+            }
+
             ndk {
                 debuggable = ndkDebuggable
+
+                if (optimized) {
+                    cppFlags.addAll(["-O3", "-fvisibility=hidden", "-ffunction-sections", "-fno-data-sections", "-Wl,--exclude-libs=ALL", "-Wl,--gc-sections"])
+                    CFlags.addAll(["-O3", "-fvisibility=hidden", "-ffunction-sections", "-fno-data-sections", "-Wl,--exclude-libs=ALL", "--Wl,-gc-sections"])
+                }
             }
 
             setRuntimeCommit.dependsOn(setPackageVersion)

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -202,6 +202,8 @@ model {
         defaultConfig.with {
             if(optimized) {
                 project.archivesBaseName = "${archivesBaseName}-optimized"
+            } else {
+                project.archivesBaseName = "${archivesBaseName}-regular"
             }
 
             minSdkVersion.apiLevel = 17
@@ -264,10 +266,6 @@ model {
         release {
             minifyEnabled = false
             proguardFiles.add(file('proguard-rules.txt'))
-
-            if(optimized) {
-                versionNameSuffix '-optimized'
-            }
 
             ndk {
                 debuggable = ndkDebuggable

--- a/runtime/src/main/jni/com_tns_AssetExtractor.cpp
+++ b/runtime/src/main/jni/com_tns_AssetExtractor.cpp
@@ -7,7 +7,7 @@
 using namespace tns;
 using namespace std;
 
-extern "C" void Java_com_tns_AssetExtractor_extractAssets(JNIEnv *env, jobject obj, jstring apk, jstring inputDir, jstring outputDir, jboolean _forceOverwrite)
+extern "C" JNIEXPORT void Java_com_tns_AssetExtractor_extractAssets(JNIEnv *env, jobject obj, jstring apk, jstring inputDir, jstring outputDir, jboolean _forceOverwrite)
 {
 	try
 	{

--- a/runtime/src/main/jni/com_tns_JsDebugger.cpp
+++ b/runtime/src/main/jni/com_tns_JsDebugger.cpp
@@ -6,7 +6,7 @@
 using namespace tns;
 using namespace std;
 
-extern "C" void Java_com_tns_JsDebugger_processDebugMessages(JNIEnv *env, jobject obj)
+extern "C" JNIEXPORT void Java_com_tns_JsDebugger_processDebugMessages(JNIEnv *env, jobject obj)
 {
 	try
 	{
@@ -28,7 +28,7 @@ extern "C" void Java_com_tns_JsDebugger_processDebugMessages(JNIEnv *env, jobjec
 	}
 }
 
-extern "C" void Java_com_tns_JsDebugger_enable(JNIEnv *env, jobject obj)
+extern "C" JNIEXPORT void Java_com_tns_JsDebugger_enable(JNIEnv *env, jobject obj)
 {
 	try
 	{
@@ -50,7 +50,7 @@ extern "C" void Java_com_tns_JsDebugger_enable(JNIEnv *env, jobject obj)
 	}
 }
 
-extern "C" void Java_com_tns_JsDebugger_disable(JNIEnv *env, jobject obj)
+extern "C" JNIEXPORT void Java_com_tns_JsDebugger_disable(JNIEnv *env, jobject obj)
 {
 	try
 	{
@@ -72,7 +72,7 @@ extern "C" void Java_com_tns_JsDebugger_disable(JNIEnv *env, jobject obj)
 	}
 }
 
-extern "C" void Java_com_tns_JsDebugger_debugBreak(JNIEnv *env, jobject obj)
+extern "C" JNIEXPORT void Java_com_tns_JsDebugger_debugBreak(JNIEnv *env, jobject obj)
 {
 	try
 	{
@@ -94,7 +94,7 @@ extern "C" void Java_com_tns_JsDebugger_debugBreak(JNIEnv *env, jobject obj)
 	}
 }
 
-extern "C" jboolean Java_com_tns_JsDebugger_isDebuggerActive(JNIEnv *env, jobject obj)
+extern "C" JNIEXPORT jboolean Java_com_tns_JsDebugger_isDebuggerActive(JNIEnv *env, jobject obj)
 {
 	try
 	{
@@ -116,7 +116,7 @@ extern "C" jboolean Java_com_tns_JsDebugger_isDebuggerActive(JNIEnv *env, jobjec
 	}
 }
 
-extern "C" void Java_com_tns_JsDebugger_sendCommand(JNIEnv *_env, jobject obj, jbyteArray command, jint length)
+extern "C" JNIEXPORT void Java_com_tns_JsDebugger_sendCommand(JNIEnv *_env, jobject obj, jbyteArray command, jint length)
 {
 	try
 	{

--- a/runtime/src/main/jni/com_tns_Runtime.cpp
+++ b/runtime/src/main/jni/com_tns_Runtime.cpp
@@ -31,7 +31,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 	return JNI_VERSION_1_6;
 }
 
-extern "C" void Java_com_tns_Runtime_initNativeScript(JNIEnv *_env, jobject obj, jint runtimeId, jstring filesPath, jboolean verboseLoggingEnabled, jstring packageName, jobjectArray args, jstring callingDir, jobject jsDebugger)
+extern "C" JNIEXPORT void Java_com_tns_Runtime_initNativeScript(JNIEnv *_env, jobject obj, jint runtimeId, jstring filesPath, jboolean verboseLoggingEnabled, jstring packageName, jobjectArray args, jstring callingDir, jobject jsDebugger)
 {
 	try
 	{
@@ -77,7 +77,7 @@ Runtime* TryGetRuntime(int runtimeId)
 	return runtime;
 }
 
-extern "C" void Java_com_tns_Runtime_runModule(JNIEnv *_env, jobject obj, jint runtimeId, jstring scriptFile)
+extern "C" JNIEXPORT void Java_com_tns_Runtime_runModule(JNIEnv *_env, jobject obj, jint runtimeId, jstring scriptFile)
 {
 	auto runtime = TryGetRuntime(runtimeId);
 	if (runtime == nullptr)
@@ -109,7 +109,7 @@ extern "C" void Java_com_tns_Runtime_runModule(JNIEnv *_env, jobject obj, jint r
 	}
 }
 
-extern "C" void Java_com_tns_Runtime_runWorker(JNIEnv *_env, jobject obj, jint runtimeId, jstring scriptFile)
+extern "C" JNIEXPORT void Java_com_tns_Runtime_runWorker(JNIEnv *_env, jobject obj, jint runtimeId, jstring scriptFile)
 {
 	auto runtime = TryGetRuntime(runtimeId);
 	if (runtime == nullptr)
@@ -141,7 +141,7 @@ extern "C" void Java_com_tns_Runtime_runWorker(JNIEnv *_env, jobject obj, jint r
 	}
 }
 
-extern "C" jobject Java_com_tns_Runtime_runScript(JNIEnv *_env, jobject obj, jint runtimeId, jstring scriptFile)
+extern "C" JNIEXPORT jobject Java_com_tns_Runtime_runScript(JNIEnv *_env, jobject obj, jint runtimeId, jstring scriptFile)
 {
 	jobject result = nullptr;
 
@@ -176,7 +176,7 @@ extern "C" jobject Java_com_tns_Runtime_runScript(JNIEnv *_env, jobject obj, jin
 	return result;
 }
 
-extern "C" jobject Java_com_tns_Runtime_callJSMethodNative(JNIEnv *_env, jobject obj, jint runtimeId, jint javaObjectID, jstring methodName, jint retType, jboolean isConstructor, jobjectArray packagedArgs)
+extern "C" JNIEXPORT jobject Java_com_tns_Runtime_callJSMethodNative(JNIEnv *_env, jobject obj, jint runtimeId, jint javaObjectID, jstring methodName, jint retType, jboolean isConstructor, jobjectArray packagedArgs)
 {
 	jobject result = nullptr;
 
@@ -211,7 +211,7 @@ extern "C" jobject Java_com_tns_Runtime_callJSMethodNative(JNIEnv *_env, jobject
 	return result;
 }
 
-extern "C" void Java_com_tns_Runtime_createJSInstanceNative(JNIEnv *_env, jobject obj, jint runtimeId, jobject javaObject, jint javaObjectID, jstring className)
+extern "C" JNIEXPORT void Java_com_tns_Runtime_createJSInstanceNative(JNIEnv *_env, jobject obj, jint runtimeId, jobject javaObject, jint javaObjectID, jstring className)
 {
 	auto runtime = TryGetRuntime(runtimeId);
 	if (runtime == nullptr)
@@ -243,7 +243,7 @@ extern "C" void Java_com_tns_Runtime_createJSInstanceNative(JNIEnv *_env, jobjec
 	}
 }
 
-extern "C" jint Java_com_tns_Runtime_generateNewObjectId(JNIEnv *env, jobject obj, jint runtimeId)
+extern "C" JNIEXPORT jint Java_com_tns_Runtime_generateNewObjectId(JNIEnv *env, jobject obj, jint runtimeId)
 {
 	try
 	{
@@ -270,7 +270,7 @@ extern "C" jint Java_com_tns_Runtime_generateNewObjectId(JNIEnv *env, jobject ob
 	}
 }
 
-extern "C" jboolean Java_com_tns_Runtime_notifyGc(JNIEnv *env, jobject obj, jint runtimeId)
+extern "C" JNIEXPORT jboolean Java_com_tns_Runtime_notifyGc(JNIEnv *env, jobject obj, jint runtimeId)
 {
 	auto runtime = TryGetRuntime(runtimeId);
 	if (runtime == nullptr) {
@@ -281,7 +281,7 @@ extern "C" jboolean Java_com_tns_Runtime_notifyGc(JNIEnv *env, jobject obj, jint
 	return success;
 }
 
-extern "C" void Java_com_tns_Runtime_passUncaughtExceptionToJsNative(JNIEnv *env, jobject obj, jint runtimeId, jthrowable exception, jstring stackTrace)
+extern "C" JNIEXPORT void Java_com_tns_Runtime_passUncaughtExceptionToJsNative(JNIEnv *env, jobject obj, jint runtimeId, jthrowable exception, jstring stackTrace)
 {
 	auto runtime = TryGetRuntime(runtimeId);
 	if (runtime == nullptr)
@@ -313,7 +313,7 @@ extern "C" void Java_com_tns_Runtime_passUncaughtExceptionToJsNative(JNIEnv *env
 	}
 }
 
-extern "C" void Java_com_tns_Runtime_clearStartupData(JNIEnv *env, jobject obj, jint runtimeId)
+extern "C" JNIEXPORT void Java_com_tns_Runtime_clearStartupData(JNIEnv *env, jobject obj, jint runtimeId)
 {
 	auto runtime = TryGetRuntime(runtimeId);
 	if (runtime == nullptr)
@@ -324,12 +324,12 @@ extern "C" void Java_com_tns_Runtime_clearStartupData(JNIEnv *env, jobject obj, 
 	runtime->ClearStartupData(env, obj);
 }
 
-extern "C" jint Java_com_tns_Runtime_getPointerSize(JNIEnv *env, jobject obj)
+extern "C" JNIEXPORT jint Java_com_tns_Runtime_getPointerSize(JNIEnv *env, jobject obj)
 {
 	return sizeof(void *);
 }
 
-extern "C" void Java_com_tns_Runtime_WorkerGlobalOnMessageCallback(JNIEnv *env, jobject obj, jint runtimeId, jstring msg)
+extern "C" JNIEXPORT void Java_com_tns_Runtime_WorkerGlobalOnMessageCallback(JNIEnv *env, jobject obj, jint runtimeId, jstring msg)
 {
 	// Worker Thread runtime
 	auto runtime = TryGetRuntime(runtimeId);
@@ -346,7 +346,7 @@ extern "C" void Java_com_tns_Runtime_WorkerGlobalOnMessageCallback(JNIEnv *env, 
 	CallbackHandlers::WorkerGlobalOnMessageCallback(isolate, msg);
 }
 
-extern "C" void Java_com_tns_Runtime_WorkerObjectOnMessageCallback(JNIEnv *env, jobject obj, jint runtimeId, jint workerId, jstring msg)
+extern "C" JNIEXPORT void Java_com_tns_Runtime_WorkerObjectOnMessageCallback(JNIEnv *env, jobject obj, jint runtimeId, jint workerId, jstring msg)
 {
 	// Main Thread runtime
 	auto runtime = TryGetRuntime(runtimeId);
@@ -363,7 +363,7 @@ extern "C" void Java_com_tns_Runtime_WorkerObjectOnMessageCallback(JNIEnv *env, 
 	CallbackHandlers::WorkerObjectOnMessageCallback(isolate, workerId, msg);
 }
 
-extern "C" void Java_com_tns_Runtime_TerminateWorkerCallback(JNIEnv *env, jobject obj, jint runtimeId)
+extern "C" JNIEXPORT void Java_com_tns_Runtime_TerminateWorkerCallback(JNIEnv *env, jobject obj, jint runtimeId)
 {
 	// Worker Thread runtime
 	auto runtime = TryGetRuntime(runtimeId);
@@ -382,7 +382,7 @@ extern "C" void Java_com_tns_Runtime_TerminateWorkerCallback(JNIEnv *env, jobjec
 	runtime->DestroyRuntime();
 }
 
-extern "C" void Java_com_tns_Runtime_ClearWorkerPersistent(JNIEnv *env, jobject obj, jint runtimeId, jint workerId)
+extern "C" JNIEXPORT void Java_com_tns_Runtime_ClearWorkerPersistent(JNIEnv *env, jobject obj, jint runtimeId, jint workerId)
 {
 	// Worker Thread runtime
 	auto runtime = TryGetRuntime(runtimeId);
@@ -399,7 +399,7 @@ extern "C" void Java_com_tns_Runtime_ClearWorkerPersistent(JNIEnv *env, jobject 
 	CallbackHandlers::ClearWorkerPersistent(workerId);
 }
 
-extern "C" void Java_com_tns_Runtime_CallWorkerObjectOnErrorHandleMain(JNIEnv *env, jobject obj, jint runtimeId, jint workerId, jstring message, jstring filename, jint lineno, jstring threadName)
+extern "C" JNIEXPORT void Java_com_tns_Runtime_CallWorkerObjectOnErrorHandleMain(JNIEnv *env, jobject obj, jint runtimeId, jint workerId, jstring message, jstring filename, jint lineno, jstring threadName)
 {
 	// Main Thread runtime
 	auto runtime = TryGetRuntime(runtimeId);


### PR DESCRIPTION
Based on work previously done in #522 , this PR aims to build and distribute a reduced in size runtime package when a project dependency does not explicitly state that it consumes API exposed by the JavaScript engine (V8) 

The optimizations come mostly from stripping the V8 symbol table, and account for about 3MB reduction in package size, combined, when all 3 supported android architectures are packed.

The optimized android runtime package will be used by default on android projects unless a dependency (nativescript plugin) has the `useV8symbols: true` key (subject to approval) inside their package.json's nativescript object, in which case the regular runtime distribution will be packed with the APK.


**Depends on https://github.com/NativeScript/nativescript-cli/pull/2138**

@NativeScript/android-runtime 