### PR TITLE
Fix(project template) Force bindings regen, if out dir empty.

### DIFF
--- a/android-static-binding-generator/project/build.gradle
+++ b/android-static-binding-generator/project/build.gradle
@@ -56,6 +56,11 @@ task generateInterfaceNamesList() {
 				shouldRun = !contents.equals(current.toString())
 			}
 
+			if (!shouldRun) {
+				//Force regeneration if the output dir contains no files
+				shouldRun = project.outDir.listFiles().length == 0
+			}
+
 			if (shouldRun) {
 				javaexec {
 					main "-jar"


### PR DESCRIPTION
Running `tns build ... --bundle` runs the `clean` gradle target and
we can end up deleting bindings *.dex files while the presence of
*.txt files in the generator dir will prevent us from regenerating
them.

The fix checks the output dir and forces regeneration if it has no
files.