### PR TITLE
when root level clean is called, :asbg:clean is called too

### DIFF
--- a/android-static-binding-generator/project/build.gradle
+++ b/android-static-binding-generator/project/build.gradle
@@ -268,3 +268,8 @@ task generateBindings() {
 traverseJsFiles.dependsOn(generateInterfaceNamesList)
 runAstParser.dependsOn(traverseJsFiles)
 generateBindings.dependsOn(runAstParser)
+
+///////// CUSTOM CLEAN ////////////
+task clean(type: Delete) {
+	delete files(["$projectDir/bindings.txt", "$projectDir/cached.txt", "$projectDir/interfaces-names.txt", "$projectDir/jsFilesParameters.txt"])
+}

--- a/build-artifacts/project-template-gradle/build.gradle
+++ b/build-artifacts/project-template-gradle/build.gradle
@@ -725,6 +725,7 @@ task deleteFlavors (type: Delete){
 	}
 }
 
+deleteMetadata.dependsOn(":asbg:clean")
 deleteFlavors.dependsOn(deleteMetadata)
 clean.dependsOn(deleteFlavors)
 


### PR DESCRIPTION
Resolving problem declared in [this PR](https://github.com/NativeScript/android-runtime/pull/595#issuecomment-255344953).

When clean is called there will no longer be left over files.

@hdeshev check if this PR solves your problem.