### PR TITLE
Fix error activity permissions on devices running on Android 23+ 

### DIFF
--- a/build-artifacts/project-template-gradle/src/debug/java/com/tns/ErrorReport.java
+++ b/build-artifacts/project-template-gradle/src/debug/java/com/tns/ErrorReport.java
@@ -9,6 +9,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Method;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
@@ -20,11 +21,13 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.support.design.widget.TabLayout;
+import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentStatePagerAdapter;
@@ -42,347 +45,372 @@ import android.widget.Toast;
 
 
 class ErrorReport implements TabLayout.OnTabSelectedListener {
-	public static final String ERROR_FILE_NAME = "hasError";
-	private static AppCompatActivity activity;
-
-	private TabLayout tabLayout;
-	private ViewPager viewPager;
-	private Context context;
-
-	private static String exceptionMsg;
-	private static String logcatMsg;
-
-	private final static String EXTRA_NATIVESCRIPT_ERROR_REPORT = "NativeScriptErrorMessage";
-	private final static String EXTRA_ERROR_REPORT_MSG = "msg";
-	private final static String EXTRA_PID = "pID";
-	private final static int EXTRA_ERROR_REPORT_VALUE = 1;
-
-	private static final int REQUEST_EXTERNAL_STORAGE = 1;
-	private static String[] PERMISSIONS_STORAGE = {
-			Manifest.permission.READ_EXTERNAL_STORAGE,
-			Manifest.permission.WRITE_EXTERNAL_STORAGE
-	};
-
-	// The following will not compile if uncommented with compileSdk lower than 23
-	/*	public static void verifyStoragePermissions(Activity activity) {
-		// Check if we have write permission
-		int permission = ActivityCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE);
-
-		if (permission != PackageManager.PERMISSION_GRANTED) {
-			// We don't have permission so prompt the user
-			ActivityCompat.requestPermissions(
-					activity,
-					PERMISSIONS_STORAGE,
-					REQUEST_EXTERNAL_STORAGE
-			);
-		}
-	}*/
-
-	public ErrorReport(AppCompatActivity activity) {
-		ErrorReport.activity = activity;
-		this.context = activity.getApplicationContext();
-	}
-
-	static boolean startActivity(final Context context, String errorMessage) {
-		final Intent intent = getIntent(context);
-		if (intent == null) {
-			return false; // (if in release mode) don't do anything
-		}
-
-		intent.putExtra(EXTRA_ERROR_REPORT_MSG, errorMessage);
-
-		String PID = Integer.toString(android.os.Process.myPid());
-		intent.putExtra(EXTRA_PID, PID);
-
-		createErrorFile(context);
-
-		try {
-			startPendingErrorActivity(context, intent);
-		} catch (CanceledException e) {
-			Log.d("ErrorReport", "Couldn't send pending intent! Exception: " + e.getMessage());
-		}
-
-		killProcess(context);
-
-		return true;
-	}
-
-	static void killProcess(Context context) {
-		// finish current activity and all below it first
-		if (context instanceof Activity) {
-			((Activity) context).finishAffinity();
-		}
-
-		// kill process
-		android.os.Process.killProcess(android.os.Process.myPid());
-	}
-
-	static void startPendingErrorActivity(Context context, Intent intent) throws CanceledException {
-		PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
-
-		pendingIntent.send(context, 0, intent);
-	}
-
-	static String getErrorMessage(Throwable ex) {
-		String content;
-		PrintStream ps = null;
-
-		try {
-			ByteArrayOutputStream baos = new ByteArrayOutputStream();
-			ps = new PrintStream(baos);
-			ex.printStackTrace(ps);
-
-			try {
-				content = baos.toString("US-ASCII");
-			} catch (UnsupportedEncodingException e) {
-				content = e.getMessage();
-			}
-		} finally {
-			if (ps != null)
-				ps.close();
-		}
-
-		return content;
-	}
+    public static final String ERROR_FILE_NAME = "hasError";
+    private static AppCompatActivity activity;
+
+    private TabLayout tabLayout;
+    private ViewPager viewPager;
+    private Context context;
+
+    private static String exceptionMsg;
+    private static String logcatMsg;
+
+    private static boolean checkingForPermissions = false;
+
+    private final static String EXTRA_NATIVESCRIPT_ERROR_REPORT = "NativeScriptErrorMessage";
+    private final static String EXTRA_ERROR_REPORT_MSG = "msg";
+    private final static String EXTRA_PID = "pID";
+    private final static int EXTRA_ERROR_REPORT_VALUE = 1;
+
+    private static final int REQUEST_EXTERNAL_STORAGE = 1;
+    private static String[] PERMISSIONS_STORAGE = {
+            Manifest.permission.READ_EXTERNAL_STORAGE,
+            Manifest.permission.WRITE_EXTERNAL_STORAGE
+    };
+
+    // Will prevent error activity from killing process if permission request dialog pops up
+    public static boolean isCheckingForPermissions() {
+        return checkingForPermissions;
+    }
+
+    public static void resetCheckingForPermissions() {
+        checkingForPermissions = false;
+    }
+
+    // The following will not compile if uncommented with compileSdk lower than 23
+    public static void verifyStoragePermissions(Activity activity) {
+        // Check if we have write permission
+        final int version = Build.VERSION.SDK_INT;
+        if (version >= 23) {
+            try {
+                // Necessary to work around compile errors with compileSdk 22 and lower
+                Method checkSelfPermissionMethod;
+                try {
+                    checkSelfPermissionMethod = ActivityCompat.class.getMethod("checkSelfPermission", Context.class, String.class);
+                } catch (NoSuchMethodException e) {
+                    // method wasn't found, so there is no need to handle permissions explicitly
+                    e.printStackTrace();
+                    return;
+                }
+
+                int permission = (int) checkSelfPermissionMethod.invoke(null, activity, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+
+                if (permission != PackageManager.PERMISSION_GRANTED) {
+                    // We don't have permission so prompt the user
+                    Method requestPermissionsMethod = ActivityCompat.class.getMethod("requestPermissions", Activity.class, PERMISSIONS_STORAGE.getClass(), int.class);
+
+                    checkingForPermissions = true;
+
+                    requestPermissionsMethod.invoke(null, activity, PERMISSIONS_STORAGE, REQUEST_EXTERNAL_STORAGE);
+                }
+            } catch (Exception e) {
+                Toast.makeText(activity, "Couldn't resolve permissions", Toast.LENGTH_LONG).show();
+                e.printStackTrace();
+                return;
+            }
+        }
+    }
+
+    public ErrorReport(AppCompatActivity activity) {
+        ErrorReport.activity = activity;
+        this.context = activity.getApplicationContext();
+    }
+
+    static boolean startActivity(final Context context, String errorMessage) {
+        final Intent intent = getIntent(context);
+        if (intent == null) {
+            return false; // (if in release mode) don't do anything
+        }
+
+        intent.putExtra(EXTRA_ERROR_REPORT_MSG, errorMessage);
+
+        String PID = Integer.toString(android.os.Process.myPid());
+        intent.putExtra(EXTRA_PID, PID);
+
+        createErrorFile(context);
+
+        try {
+            startPendingErrorActivity(context, intent);
+        } catch (CanceledException e) {
+            Log.d("ErrorReport", "Couldn't send pending intent! Exception: " + e.getMessage());
+        }
+
+        killProcess(context);
+
+        return true;
+    }
+
+    static void killProcess(Context context) {
+        // finish current activity and all below it first
+        if (context instanceof Activity) {
+            ((Activity) context).finishAffinity();
+        }
+
+        // kill process
+        android.os.Process.killProcess(android.os.Process.myPid());
+    }
 
-	/*
-	* Gets the process Id of the running app and filters all
-	* output that doesn't belong to that process
-	* */
-	public static String getLogcat(String pId) {
-		String content;
+    static void startPendingErrorActivity(Context context, Intent intent) throws CanceledException {
+        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
 
-		try {
-			String logcatCommand = "logcat -d";
-			Process process = java.lang.Runtime.getRuntime().exec(logcatCommand);
+        pendingIntent.send(context, 0, intent);
+    }
 
-			BufferedReader bufferedReader = new BufferedReader(
-					new InputStreamReader(process.getInputStream()));
+    static String getErrorMessage(Throwable ex) {
+        String content;
+        PrintStream ps = null;
 
-			StringBuilder log = new StringBuilder();
-			String line = "";
-			String lineSeparator = System.getProperty("line.separator");
-			while ((line = bufferedReader.readLine()) != null) {
-				if(line.contains(pId)) {
-					log.append(line);
-					log.append(lineSeparator);
-				}
-			}
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ps = new PrintStream(baos);
+            ex.printStackTrace(ps);
 
-			content = log.toString();
-		} catch (IOException e) {
-			content = "Failed to read logcat";
-			Log.e("TNS.Android", content);
-		}
+            try {
+                content = baos.toString("US-ASCII");
+            } catch (UnsupportedEncodingException e) {
+                content = e.getMessage();
+            }
+        } finally {
+            if (ps != null)
+                ps.close();
+        }
 
-		return content;
-	}
+        return content;
+    }
 
-	static Intent getIntent(Context context) {
-		Class<?> errorActivityClass;
+    /*
+    * Gets the process Id of the running app and filters all
+    * output that doesn't belong to that process
+    * */
+    public static String getLogcat(String pId) {
+        String content;
 
-		if(AndroidJsDebugger.isDebuggableApp(context)) {
-			errorActivityClass = ErrorReportActivity.class;
-		} else {
-			return null;
-		}
+        try {
+            String logcatCommand = "logcat -d";
+            Process process = java.lang.Runtime.getRuntime().exec(logcatCommand);
 
-		Intent intent = new Intent(context, errorActivityClass);
+            BufferedReader bufferedReader = new BufferedReader(
+                    new InputStreamReader(process.getInputStream()));
 
-		intent.putExtra(EXTRA_NATIVESCRIPT_ERROR_REPORT, EXTRA_ERROR_REPORT_VALUE);
-		intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
+            StringBuilder log = new StringBuilder();
+            String line = "";
+            String lineSeparator = System.getProperty("line.separator");
+            while ((line = bufferedReader.readLine()) != null) {
+                if (line.contains(pId)) {
+                    log.append(line);
+                    log.append(lineSeparator);
+                }
+            }
 
-		return intent;
-	}
+            content = log.toString();
+        } catch (IOException e) {
+            content = "Failed to read logcat";
+            Log.e("TNS.Android", content);
+        }
 
-	static boolean hasIntent(Intent intent) {
-		int value = intent.getIntExtra(EXTRA_NATIVESCRIPT_ERROR_REPORT, 0);
+        return content;
+    }
 
-		return value == EXTRA_ERROR_REPORT_VALUE;
-	}
+    static Intent getIntent(Context context) {
+        Class<?> errorActivityClass;
 
-	void buildUI() {
-		Intent intent = activity.getIntent();
-
-		exceptionMsg = intent.getStringExtra(EXTRA_ERROR_REPORT_MSG);
+        if (AndroidJsDebugger.isDebuggableApp(context)) {
+            errorActivityClass = ErrorReportActivity.class;
+        } else {
+            return null;
+        }
 
-		String processId = intent.getStringExtra(EXTRA_PID);
-		logcatMsg = getLogcat(processId);
-
-		int errActivityId = this.context.getResources().getIdentifier("error_activity", "layout", this.context.getPackageName());
+        Intent intent = new Intent(context, errorActivityClass);
 
-		activity.setContentView(errActivityId);
-
-		int toolBarId = this.context.getResources().getIdentifier("toolbar", "id", this.context.getPackageName());
-
-		Toolbar toolbar = (Toolbar) activity.findViewById(toolBarId);
-		activity.setSupportActionBar(toolbar);
-
-		final int tabLayoutId = this.context.getResources().getIdentifier("tabLayout", "id", this.context.getPackageName());
-
-		tabLayout = (TabLayout) activity.findViewById(tabLayoutId);
-		tabLayout.addTab(tabLayout.newTab().setText("Exception"));
-		tabLayout.addTab(tabLayout.newTab().setText("Logcat"));
-		tabLayout.setTabGravity(TabLayout.GRAVITY_FILL);
-		tabLayout.setBackgroundColor(Color.parseColor("#bbbbbb"));
-		int pagerId = this.context.getResources().getIdentifier("pager", "id", this.context.getPackageName());
-
-		viewPager = (ViewPager) activity.findViewById(pagerId);
-
-		Pager adapter = new Pager(activity.getSupportFragmentManager(), tabLayout.getTabCount());
-
-		viewPager.setAdapter(adapter);
-		viewPager.addOnPageChangeListener(new ViewPager.OnPageChangeListener() {
-			@Override
-			public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
-
-			}
-
-			@Override
-			public void onPageSelected(int position) {
-				tabLayout.getTabAt(position).select();
-				viewPager.setCurrentItem(position);
-			}
-
-			@Override
-			public void onPageScrollStateChanged(int state) {
-
-			}
-		});
-
-		tabLayout.setOnTabSelectedListener(this);
-	}
-
-	private static void createErrorFile(final Context context) {
-		try {
-			File errFile = new File(context.getFilesDir(), ERROR_FILE_NAME);
-			errFile.createNewFile();
-		} catch (IOException e) {
-			Log.d("ErrorReport", e.getMessage());
-		}
-	}
-
-	@Override
-	public void onTabSelected(TabLayout.Tab tab) {
-		viewPager.setCurrentItem(tab.getPosition());
-	}
-
-	@Override
-	public void onTabUnselected(TabLayout.Tab tab) {
-
-	}
-
-	@Override
-	public void onTabReselected(TabLayout.Tab tab) {
-		viewPager.setCurrentItem(tab.getPosition());
-	}
-
-	private class Pager extends FragmentStatePagerAdapter {
-
-		int tabCount;
-
-		public Pager(FragmentManager fm, int tabCount) {
-			super(fm);
-			this.tabCount = tabCount;
-		}
-
-		@Override
-		public Fragment getItem(int position) {
-			switch (position) {
-				case 0:
-					return new ExceptionTab();
-				case 1:
-					return new LogcatTab();
-				default:
-					return null;
-			}
-		}
-
-		@Override
-		public int getCount() {
-			return tabCount;
-		}
-	}
-
-	public static class ExceptionTab extends Fragment {
-		@Override
-		public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-			int exceptionTabId = container.getContext().getResources().getIdentifier("exception_tab", "layout", container.getContext().getPackageName());
-			View view = inflater.inflate(exceptionTabId, container, false);
-
-			int txtViewId = container.getContext().getResources().getIdentifier("txtErrorMsg", "id", container.getContext().getPackageName());
-			TextView txtErrorMsg = (TextView) view.findViewById(txtViewId);
-			txtErrorMsg.setText(exceptionMsg);
-			txtErrorMsg.setMovementMethod(new ScrollingMovementMethod());
-
-			int btnCopyExceptionId = container.getContext().getResources().getIdentifier("btnCopyException", "id", container.getContext().getPackageName());
-			Button copyToClipboard = (Button) view.findViewById(btnCopyExceptionId);
-			copyToClipboard.setOnClickListener(new View.OnClickListener()
-			{
-				@Override
-				public void onClick(View v)
-				{
-					ClipboardManager clipboard = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
-					ClipData clip = ClipData.newPlainText("nsError", exceptionMsg);
-					clipboard.setPrimaryClip(clip);
-				}
-			});
-
-			return view;
-		}
-	}
-
-	public static class LogcatTab extends Fragment {
-		@Override
-		public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-			int logcatTabId = container.getContext().getResources().getIdentifier("logcat_tab", "layout", container.getContext().getPackageName());
-			View view = inflater.inflate(logcatTabId, container, false);
-
-			int textViewId = container.getContext().getResources().getIdentifier("logcatMsg", "id", container.getContext().getPackageName());
-			TextView txtlogcatMsg = (TextView) view.findViewById(textViewId);
-			txtlogcatMsg.setText(logcatMsg);
-
-			txtlogcatMsg.setMovementMethod(new ScrollingMovementMethod());
-
-			final String logName = "Log-" + new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss").format(new Date());
-
-			int btnCopyLogcatId = container.getContext().getResources().getIdentifier("btnCopyLogcat", "id", container.getContext().getPackageName());
-			Button copyToClipboard = (Button) view.findViewById(btnCopyLogcatId);
-			copyToClipboard.setOnClickListener(new View.OnClickListener()
-			{
-				@Override
-				public void onClick(View v)
-				{
-					if(Build.VERSION.SDK_INT >= 23) {
-						//verifyStoragePermissions(activity);
-					}
-
-					try {
-						File dir = new File(Environment.getExternalStorageDirectory().getPath()+ "/logcat-reports/");
-						dir.mkdirs();
-
-						File logcatReportFile = new File(dir, logName);
-						FileOutputStream stream = new FileOutputStream(logcatReportFile);
-						OutputStreamWriter writer = new OutputStreamWriter(stream, "UTF-8");
-						writer.write(logcatMsg);
-						writer.close();
-
-						String logPath = dir.getPath() + "/" + logName;
-
-						ClipboardManager clipboard = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
-						ClipData clip = ClipData.newPlainText("logPath", logPath);
-						clipboard.setPrimaryClip(clip);
-
-						Toast.makeText(activity, "Path copied to clipboard: " + logPath, Toast.LENGTH_LONG).show();
-					} catch (Exception e) {
-						String err = "Could not write logcat report to sdcard. Make sure you have allowed access to external storage!";
-						Toast.makeText(activity, err, Toast.LENGTH_LONG).show();
-						Log.d("ErrorReport", err);
-					}
-				}
-			});
-
-			return view;
-		}
-	}
+        intent.putExtra(EXTRA_NATIVESCRIPT_ERROR_REPORT, EXTRA_ERROR_REPORT_VALUE);
+        intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
+
+        return intent;
+    }
+
+    static boolean hasIntent(Intent intent) {
+        int value = intent.getIntExtra(EXTRA_NATIVESCRIPT_ERROR_REPORT, 0);
+
+        return value == EXTRA_ERROR_REPORT_VALUE;
+    }
+
+    void buildUI() {
+        Intent intent = activity.getIntent();
+
+        exceptionMsg = intent.getStringExtra(EXTRA_ERROR_REPORT_MSG);
+
+        String processId = intent.getStringExtra(EXTRA_PID);
+        logcatMsg = getLogcat(processId);
+
+        int errActivityId = this.context.getResources().getIdentifier("error_activity", "layout", this.context.getPackageName());
+
+        activity.setContentView(errActivityId);
+
+        int toolBarId = this.context.getResources().getIdentifier("toolbar", "id", this.context.getPackageName());
+
+        Toolbar toolbar = (Toolbar) activity.findViewById(toolBarId);
+        activity.setSupportActionBar(toolbar);
+
+        final int tabLayoutId = this.context.getResources().getIdentifier("tabLayout", "id", this.context.getPackageName());
+
+        tabLayout = (TabLayout) activity.findViewById(tabLayoutId);
+        tabLayout.addTab(tabLayout.newTab().setText("Exception"));
+        tabLayout.addTab(tabLayout.newTab().setText("Logcat"));
+        tabLayout.setTabGravity(TabLayout.GRAVITY_FILL);
+        int pagerId = this.context.getResources().getIdentifier("pager", "id", this.context.getPackageName());
+
+        viewPager = (ViewPager) activity.findViewById(pagerId);
+
+        Pager adapter = new Pager(activity.getSupportFragmentManager(), tabLayout.getTabCount());
+
+        viewPager.setAdapter(adapter);
+        viewPager.addOnPageChangeListener(new ViewPager.OnPageChangeListener() {
+            @Override
+            public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
+
+            }
+
+            @Override
+            public void onPageSelected(int position) {
+                tabLayout.getTabAt(position).select();
+                viewPager.setCurrentItem(position);
+            }
+
+            @Override
+            public void onPageScrollStateChanged(int state) {
+
+            }
+        });
+
+        tabLayout.setOnTabSelectedListener(this);
+    }
+
+    private static void createErrorFile(final Context context) {
+        try {
+            File errFile = new File(context.getFilesDir(), ERROR_FILE_NAME);
+            errFile.createNewFile();
+        } catch (IOException e) {
+            Log.d("ErrorReport", e.getMessage());
+        }
+    }
+
+    @Override
+    public void onTabSelected(TabLayout.Tab tab) {
+        viewPager.setCurrentItem(tab.getPosition());
+    }
+
+    @Override
+    public void onTabUnselected(TabLayout.Tab tab) {
+
+    }
+
+    @Override
+    public void onTabReselected(TabLayout.Tab tab) {
+        viewPager.setCurrentItem(tab.getPosition());
+    }
+
+    private class Pager extends FragmentStatePagerAdapter {
+
+        int tabCount;
+
+        public Pager(FragmentManager fm, int tabCount) {
+            super(fm);
+            this.tabCount = tabCount;
+        }
+
+        @Override
+        public Fragment getItem(int position) {
+            switch (position) {
+                case 0:
+                    return new ExceptionTab();
+                case 1:
+                    return new LogcatTab();
+                default:
+                    return null;
+            }
+        }
+
+        @Override
+        public int getCount() {
+            return tabCount;
+        }
+    }
+
+    public static class ExceptionTab extends Fragment {
+        @Override
+        public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+            int exceptionTabId = container.getContext().getResources().getIdentifier("exception_tab", "layout", container.getContext().getPackageName());
+            View view = inflater.inflate(exceptionTabId, container, false);
+
+            int txtViewId = container.getContext().getResources().getIdentifier("txtErrorMsg", "id", container.getContext().getPackageName());
+            TextView txtErrorMsg = (TextView) view.findViewById(txtViewId);
+            txtErrorMsg.setText(exceptionMsg);
+            txtErrorMsg.setMovementMethod(new ScrollingMovementMethod());
+
+            int btnCopyExceptionId = container.getContext().getResources().getIdentifier("btnCopyException", "id", container.getContext().getPackageName());
+            Button copyToClipboard = (Button) view.findViewById(btnCopyExceptionId);
+            copyToClipboard.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    ClipboardManager clipboard = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
+                    ClipData clip = ClipData.newPlainText("nsError", exceptionMsg);
+                    clipboard.setPrimaryClip(clip);
+                }
+            });
+
+            return view;
+        }
+    }
+
+    public static class LogcatTab extends Fragment {
+        @Override
+        public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+            int logcatTabId = container.getContext().getResources().getIdentifier("logcat_tab", "layout", container.getContext().getPackageName());
+            View view = inflater.inflate(logcatTabId, container, false);
+
+            int textViewId = container.getContext().getResources().getIdentifier("logcatMsg", "id", container.getContext().getPackageName());
+            TextView txtlogcatMsg = (TextView) view.findViewById(textViewId);
+            txtlogcatMsg.setText(logcatMsg);
+
+            txtlogcatMsg.setMovementMethod(new ScrollingMovementMethod());
+
+            final String logName = "Log-" + new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss").format(new Date());
+
+            int btnCopyLogcatId = container.getContext().getResources().getIdentifier("btnCopyLogcat", "id", container.getContext().getPackageName());
+            Button copyToClipboard = (Button) view.findViewById(btnCopyLogcatId);
+            copyToClipboard.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    verifyStoragePermissions(activity);
+
+                    if (!isCheckingForPermissions()) {
+                        try {
+                            File dir = new File(Environment.getExternalStorageDirectory().getPath() + "/logcat-reports/");
+                            dir.mkdirs();
+
+                            File logcatReportFile = new File(dir, logName);
+                            FileOutputStream stream = new FileOutputStream(logcatReportFile);
+                            OutputStreamWriter writer = new OutputStreamWriter(stream, "UTF-8");
+                            writer.write(logcatMsg);
+                            writer.close();
+
+                            String logPath = dir.getPath() + "/" + logName;
+
+                            ClipboardManager clipboard = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
+                            ClipData clip = ClipData.newPlainText("logPath", logPath);
+                            clipboard.setPrimaryClip(clip);
+
+                            Toast.makeText(activity, "Path copied to clipboard: " + logPath, Toast.LENGTH_LONG).show();
+                        } catch (Exception e) {
+                            String err = "Could not write logcat report to sdcard. Make sure you have allowed access to external storage!";
+                            Toast.makeText(activity, err, Toast.LENGTH_LONG).show();
+                            e.printStackTrace();
+                        }
+                    }
+                }
+            });
+
+            return view;
+        }
+    }
 }

--- a/build-artifacts/project-template-gradle/src/debug/res/layout/error_activity.xml
+++ b/build-artifacts/project-template-gradle/src/debug/res/layout/error_activity.xml
@@ -12,20 +12,30 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="?attr/actionBarSize"
-        app:popupTheme="@style/ThemeOverlay.AppCompat.Dark"/>
+        app:popupTheme="?android:attr/statusBarColor"/>
+
+    <android.support.v4.view.ViewPager
+        android:id="@+id/pager"
+        android:layout_width="match_parent"
+        android:layout_height="fill_parent"
+        android:layout_below="@+id/toolbar"
+        android:scrollbarAlwaysDrawVerticalTrack="false">
+
+    </android.support.v4.view.ViewPager>
 
     <android.support.design.widget.TabLayout
         android:id="@+id/tabLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?attr/colorPrimary"
-        android:minHeight="?attr/actionBarSize"/>
-
-    <android.support.v4.view.ViewPager
-        android:id="@+id/pager"
-        android:layout_width="match_parent"
-        android:layout_height="fill_parent"
-        android:layout_below="@+id/toolbar">
-
-    </android.support.v4.view.ViewPager>
+        android:minHeight="?attr/actionBarSize"
+        app:tabIndicatorColor="@color/nativescript_blue"
+        app:tabBackground="?android:attr/statusBarColor"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentStart="true"
+        android:scrollbarStyle="insideOverlay"
+        android:scrollbars="vertical"
+        tools:tabBackground="@android:color/darker_gray"
+        android:scrollbarAlwaysDrawVerticalTrack="false"
+        />
 </RelativeLayout>

--- a/build-artifacts/project-template-gradle/src/debug/res/layout/exception_tab.xml
+++ b/build-artifacts/project-template-gradle/src/debug/res/layout/exception_tab.xml
@@ -1,42 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:tools="http://schemas.android.com/tools"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:orientation="vertical">
+                android:orientation="vertical"
+                android:paddingBottom="10dp"
+                android:paddingLeft="16dp"
+                android:paddingRight="16dp"
+                android:paddingTop="10dp">
+
+    <Button
+        android:id="@+id/btnCopyException"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:background="@color/nativescript_blue"
+        android:paddingLeft="20dp"
+        android:paddingRight="20dp"
+        android:text="Copy to clipboard"
+        android:textAlignment="textStart"
+        android:textColor="@android:color/white"
+        tools:layout_width="match_parent"/>
 
     <LinearLayout
         android:id="@+id/linearLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_above="@+id/btnCopyException"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentTop="true"
         android:orientation="vertical"
+        android:paddingBottom="10dp"
         android:weightSum="100">
 
-        <LinearLayout
-            android:layout_width="fill_parent"
-            android:layout_height="0dp"
-            android:layout_weight="80">
-
-            <TextView
-                android:id="@+id/txtErrorMsg"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_centerInParent="true"
-                android:text=""
-                android:textAppearance="?android:attr/textAppearanceSmall" />
-        </LinearLayout>
-
-        <LinearLayout
+        <TextView
+            android:id="@+id/txtErrorMsg"
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="20">
+            android:layout_height="wrap_content"
+            android:text=""
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:paddingLeft="2dp"
+            android:paddingRight="2dp"
+            android:scrollbars="vertical"
+            android:scrollbarStyle="outsideOverlay"
+            android:scrollbarAlwaysDrawVerticalTrack="true"/>
 
-            <Button
-                android:id="@+id/btnCopyException"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_alignParentBottom="true"
-                android:text="Copy to clipboard" />
-        </LinearLayout>
     </LinearLayout>
 
 

--- a/build-artifacts/project-template-gradle/src/debug/res/layout/logcat_tab.xml
+++ b/build-artifacts/project-template-gradle/src/debug/res/layout/logcat_tab.xml
@@ -1,42 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:tools="http://schemas.android.com/tools"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:orientation="vertical">
+                android:orientation="vertical"
+                android:paddingBottom="10dp"
+                android:paddingLeft="16dp"
+                android:paddingRight="16dp"
+                android:paddingTop="10dp">
+
+    <Button
+        android:id="@+id/btnCopyLogcat"
+        android:layout_height="wrap_content"
+        android:text="Copy to sdcard"
+        android:layout_width="match_parent"
+        android:background="@color/nativescript_blue"
+        android:textColor="@android:color/white"
+        android:textAlignment="textStart"
+        android:paddingLeft="20dp"
+        android:paddingRight="20dp"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        tools:layout_width="match_parent"/>
 
     <LinearLayout
         android:id="@+id/logcatLinearLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:weightSum="100">
+        android:weightSum="100"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentStart="true"
+        android:layout_above="@+id/btnCopyLogcat"
+        android:paddingBottom="10dp">
 
-        <LinearLayout
+        <TextView
+            android:id="@+id/logcatMsg"
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="80">
+            android:text=""
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:layout_height="wrap_content"
+            android:paddingLeft="2dp"
+            android:paddingRight="2dp"
+            android:scrollbars="vertical"
+            android:scrollbarStyle="outsideOverlay"
+            android:scrollbarAlwaysDrawVerticalTrack="true"/>
 
-            <TextView
-                android:id="@+id/logcatMsg"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_centerInParent="true"
-                android:text=""
-                android:textAppearance="?android:attr/textAppearanceSmall" />
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="20">
-
-            <Button
-                android:id="@+id/btnCopyLogcat"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_alignParentBottom="true"
-                android:text="Copy to sdcard" />
-        </LinearLayout>
     </LinearLayout>
 
 

--- a/build-artifacts/project-template-gradle/src/debug/res/values/colors.xml
+++ b/build-artifacts/project-template-gradle/src/debug/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="nativescript_blue">#3c5afd</color>
+</resources>

--- a/test-app/app/src/main/java/com/tns/ErrorReport.java
+++ b/test-app/app/src/main/java/com/tns/ErrorReport.java
@@ -9,6 +9,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Method;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
@@ -20,11 +21,13 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.support.design.widget.TabLayout;
+import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentStatePagerAdapter;
@@ -42,347 +45,372 @@ import android.widget.Toast;
 
 
 class ErrorReport implements TabLayout.OnTabSelectedListener {
-	public static final String ERROR_FILE_NAME = "hasError";
-	private static AppCompatActivity activity;
-
-	private TabLayout tabLayout;
-	private ViewPager viewPager;
-	private Context context;
-
-	private static String exceptionMsg;
-	private static String logcatMsg;
-
-	private final static String EXTRA_NATIVESCRIPT_ERROR_REPORT = "NativeScriptErrorMessage";
-	private final static String EXTRA_ERROR_REPORT_MSG = "msg";
-	private final static String EXTRA_PID = "pID";
-	private final static int EXTRA_ERROR_REPORT_VALUE = 1;
-
-	private static final int REQUEST_EXTERNAL_STORAGE = 1;
-	private static String[] PERMISSIONS_STORAGE = {
-			Manifest.permission.READ_EXTERNAL_STORAGE,
-			Manifest.permission.WRITE_EXTERNAL_STORAGE
-	};
-
-	// The following will not compile if uncommented with compileSdk lower than 23
-	/*	public static void verifyStoragePermissions(Activity activity) {
-		// Check if we have write permission
-		int permission = ActivityCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE);
-
-		if (permission != PackageManager.PERMISSION_GRANTED) {
-			// We don't have permission so prompt the user
-			ActivityCompat.requestPermissions(
-					activity,
-					PERMISSIONS_STORAGE,
-					REQUEST_EXTERNAL_STORAGE
-			);
-		}
-	}*/
-
-	public ErrorReport(AppCompatActivity activity) {
-		ErrorReport.activity = activity;
-		this.context = activity.getApplicationContext();
-	}
-
-	static boolean startActivity(final Context context, String errorMessage) {
-		final Intent intent = getIntent(context);
-		if (intent == null) {
-			return false; // (if in release mode) don't do anything
-		}
-
-		intent.putExtra(EXTRA_ERROR_REPORT_MSG, errorMessage);
-
-		String PID = Integer.toString(android.os.Process.myPid());
-		intent.putExtra(EXTRA_PID, PID);
-
-		createErrorFile(context);
-
-		try {
-			startPendingErrorActivity(context, intent);
-		} catch (CanceledException e) {
-			Log.d("ErrorReport", "Couldn't send pending intent! Exception: " + e.getMessage());
-		}
-
-		killProcess(context);
-
-		return true;
-	}
-
-	static void killProcess(Context context) {
-		// finish current activity and all below it first
-		if (context instanceof Activity) {
-			((Activity) context).finishAffinity();
-		}
-
-		// kill process
-		android.os.Process.killProcess(android.os.Process.myPid());
-	}
-
-	static void startPendingErrorActivity(Context context, Intent intent) throws CanceledException {
-		PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
-
-		pendingIntent.send(context, 0, intent);
-	}
-
-	static String getErrorMessage(Throwable ex) {
-		String content;
-		PrintStream ps = null;
-
-		try {
-			ByteArrayOutputStream baos = new ByteArrayOutputStream();
-			ps = new PrintStream(baos);
-			ex.printStackTrace(ps);
-
-			try {
-				content = baos.toString("US-ASCII");
-			} catch (UnsupportedEncodingException e) {
-				content = e.getMessage();
-			}
-		} finally {
-			if (ps != null)
-				ps.close();
-		}
-
-		return content;
-	}
+    public static final String ERROR_FILE_NAME = "hasError";
+    private static AppCompatActivity activity;
+
+    private TabLayout tabLayout;
+    private ViewPager viewPager;
+    private Context context;
+
+    private static String exceptionMsg;
+    private static String logcatMsg;
+
+    private static boolean checkingForPermissions = false;
+
+    private final static String EXTRA_NATIVESCRIPT_ERROR_REPORT = "NativeScriptErrorMessage";
+    private final static String EXTRA_ERROR_REPORT_MSG = "msg";
+    private final static String EXTRA_PID = "pID";
+    private final static int EXTRA_ERROR_REPORT_VALUE = 1;
+
+    private static final int REQUEST_EXTERNAL_STORAGE = 1;
+    private static String[] PERMISSIONS_STORAGE = {
+            Manifest.permission.READ_EXTERNAL_STORAGE,
+            Manifest.permission.WRITE_EXTERNAL_STORAGE
+    };
+
+    // Will prevent error activity from killing process if permission request dialog pops up
+    public static boolean isCheckingForPermissions() {
+        return checkingForPermissions;
+    }
+
+    public static void resetCheckingForPermissions() {
+        checkingForPermissions = false;
+    }
+
+    // The following will not compile if uncommented with compileSdk lower than 23
+    public static void verifyStoragePermissions(Activity activity) {
+        // Check if we have write permission
+        final int version = Build.VERSION.SDK_INT;
+        if (version >= 23) {
+            try {
+                // Necessary to work around compile errors with compileSdk 22 and lower
+                Method checkSelfPermissionMethod;
+                try {
+                    checkSelfPermissionMethod = ActivityCompat.class.getMethod("checkSelfPermission", Context.class, String.class);
+                } catch (NoSuchMethodException e) {
+                    // method wasn't found, so there is no need to handle permissions explicitly
+                    e.printStackTrace();
+                    return;
+                }
+
+                int permission = (int) checkSelfPermissionMethod.invoke(null, activity, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+
+                if (permission != PackageManager.PERMISSION_GRANTED) {
+                    // We don't have permission so prompt the user
+                    Method requestPermissionsMethod = ActivityCompat.class.getMethod("requestPermissions", Activity.class, PERMISSIONS_STORAGE.getClass(), int.class);
+
+                    checkingForPermissions = true;
+
+                    requestPermissionsMethod.invoke(null, activity, PERMISSIONS_STORAGE, REQUEST_EXTERNAL_STORAGE);
+                }
+            } catch (Exception e) {
+                Toast.makeText(activity, "Couldn't resolve permissions", Toast.LENGTH_LONG).show();
+                e.printStackTrace();
+                return;
+            }
+        }
+    }
+
+    public ErrorReport(AppCompatActivity activity) {
+        ErrorReport.activity = activity;
+        this.context = activity.getApplicationContext();
+    }
+
+    static boolean startActivity(final Context context, String errorMessage) {
+        final Intent intent = getIntent(context);
+        if (intent == null) {
+            return false; // (if in release mode) don't do anything
+        }
+
+        intent.putExtra(EXTRA_ERROR_REPORT_MSG, errorMessage);
+
+        String PID = Integer.toString(android.os.Process.myPid());
+        intent.putExtra(EXTRA_PID, PID);
+
+        createErrorFile(context);
+
+        try {
+            startPendingErrorActivity(context, intent);
+        } catch (CanceledException e) {
+            Log.d("ErrorReport", "Couldn't send pending intent! Exception: " + e.getMessage());
+        }
+
+        killProcess(context);
+
+        return true;
+    }
+
+    static void killProcess(Context context) {
+        // finish current activity and all below it first
+        if (context instanceof Activity) {
+            ((Activity) context).finishAffinity();
+        }
+
+        // kill process
+        android.os.Process.killProcess(android.os.Process.myPid());
+    }
 
-	/*
-	* Gets the process Id of the running app and filters all
-	* output that doesn't belong to that process
-	* */
-	public static String getLogcat(String pId) {
-		String content;
+    static void startPendingErrorActivity(Context context, Intent intent) throws CanceledException {
+        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
 
-		try {
-			String logcatCommand = "logcat -d";
-			Process process = java.lang.Runtime.getRuntime().exec(logcatCommand);
+        pendingIntent.send(context, 0, intent);
+    }
 
-			BufferedReader bufferedReader = new BufferedReader(
-					new InputStreamReader(process.getInputStream()));
+    static String getErrorMessage(Throwable ex) {
+        String content;
+        PrintStream ps = null;
 
-			StringBuilder log = new StringBuilder();
-			String line = "";
-			String lineSeparator = System.getProperty("line.separator");
-			while ((line = bufferedReader.readLine()) != null) {
-				if(line.contains(pId)) {
-					log.append(line);
-					log.append(lineSeparator);
-				}
-			}
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ps = new PrintStream(baos);
+            ex.printStackTrace(ps);
 
-			content = log.toString();
-		} catch (IOException e) {
-			content = "Failed to read logcat";
-			Log.e("TNS.Android", content);
-		}
+            try {
+                content = baos.toString("US-ASCII");
+            } catch (UnsupportedEncodingException e) {
+                content = e.getMessage();
+            }
+        } finally {
+            if (ps != null)
+                ps.close();
+        }
 
-		return content;
-	}
+        return content;
+    }
 
-	static Intent getIntent(Context context) {
-		Class<?> errorActivityClass;
+    /*
+    * Gets the process Id of the running app and filters all
+    * output that doesn't belong to that process
+    * */
+    public static String getLogcat(String pId) {
+        String content;
 
-		if(AndroidJsDebugger.isDebuggableApp(context)) {
-			errorActivityClass = ErrorReportActivity.class;
-		} else {
-			return null;
-		}
+        try {
+            String logcatCommand = "logcat -d";
+            Process process = java.lang.Runtime.getRuntime().exec(logcatCommand);
 
-		Intent intent = new Intent(context, errorActivityClass);
+            BufferedReader bufferedReader = new BufferedReader(
+                    new InputStreamReader(process.getInputStream()));
 
-		intent.putExtra(EXTRA_NATIVESCRIPT_ERROR_REPORT, EXTRA_ERROR_REPORT_VALUE);
-		intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
+            StringBuilder log = new StringBuilder();
+            String line = "";
+            String lineSeparator = System.getProperty("line.separator");
+            while ((line = bufferedReader.readLine()) != null) {
+                if (line.contains(pId)) {
+                    log.append(line);
+                    log.append(lineSeparator);
+                }
+            }
 
-		return intent;
-	}
+            content = log.toString();
+        } catch (IOException e) {
+            content = "Failed to read logcat";
+            Log.e("TNS.Android", content);
+        }
 
-	static boolean hasIntent(Intent intent) {
-		int value = intent.getIntExtra(EXTRA_NATIVESCRIPT_ERROR_REPORT, 0);
+        return content;
+    }
 
-		return value == EXTRA_ERROR_REPORT_VALUE;
-	}
+    static Intent getIntent(Context context) {
+        Class<?> errorActivityClass;
 
-	void buildUI() {
-		Intent intent = activity.getIntent();
-
-		exceptionMsg = intent.getStringExtra(EXTRA_ERROR_REPORT_MSG);
+        if (AndroidJsDebugger.isDebuggableApp(context)) {
+            errorActivityClass = ErrorReportActivity.class;
+        } else {
+            return null;
+        }
 
-		String processId = intent.getStringExtra(EXTRA_PID);
-		logcatMsg = getLogcat(processId);
-
-		int errActivityId = this.context.getResources().getIdentifier("error_activity", "layout", this.context.getPackageName());
+        Intent intent = new Intent(context, errorActivityClass);
 
-		activity.setContentView(errActivityId);
-
-		int toolBarId = this.context.getResources().getIdentifier("toolbar", "id", this.context.getPackageName());
-
-		Toolbar toolbar = (Toolbar) activity.findViewById(toolBarId);
-		activity.setSupportActionBar(toolbar);
-
-		final int tabLayoutId = this.context.getResources().getIdentifier("tabLayout", "id", this.context.getPackageName());
-
-		tabLayout = (TabLayout) activity.findViewById(tabLayoutId);
-		tabLayout.addTab(tabLayout.newTab().setText("Exception"));
-		tabLayout.addTab(tabLayout.newTab().setText("Logcat"));
-		tabLayout.setTabGravity(TabLayout.GRAVITY_FILL);
-		tabLayout.setBackgroundColor(Color.parseColor("#bbbbbb"));
-		int pagerId = this.context.getResources().getIdentifier("pager", "id", this.context.getPackageName());
-
-		viewPager = (ViewPager) activity.findViewById(pagerId);
-
-		Pager adapter = new Pager(activity.getSupportFragmentManager(), tabLayout.getTabCount());
-
-		viewPager.setAdapter(adapter);
-		viewPager.addOnPageChangeListener(new ViewPager.OnPageChangeListener() {
-			@Override
-			public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
-
-			}
-
-			@Override
-			public void onPageSelected(int position) {
-				tabLayout.getTabAt(position).select();
-				viewPager.setCurrentItem(position);
-			}
-
-			@Override
-			public void onPageScrollStateChanged(int state) {
-
-			}
-		});
-
-		tabLayout.setOnTabSelectedListener(this);
-	}
-
-	private static void createErrorFile(final Context context) {
-		try {
-			File errFile = new File(context.getFilesDir(), ERROR_FILE_NAME);
-			errFile.createNewFile();
-		} catch (IOException e) {
-			Log.d("ErrorReport", e.getMessage());
-		}
-	}
-
-	@Override
-	public void onTabSelected(TabLayout.Tab tab) {
-		viewPager.setCurrentItem(tab.getPosition());
-	}
-
-	@Override
-	public void onTabUnselected(TabLayout.Tab tab) {
-
-	}
-
-	@Override
-	public void onTabReselected(TabLayout.Tab tab) {
-		viewPager.setCurrentItem(tab.getPosition());
-	}
-
-	private class Pager extends FragmentStatePagerAdapter {
-
-		int tabCount;
-
-		public Pager(FragmentManager fm, int tabCount) {
-			super(fm);
-			this.tabCount = tabCount;
-		}
-
-		@Override
-		public Fragment getItem(int position) {
-			switch (position) {
-				case 0:
-					return new ExceptionTab();
-				case 1:
-					return new LogcatTab();
-				default:
-					return null;
-			}
-		}
-
-		@Override
-		public int getCount() {
-			return tabCount;
-		}
-	}
-
-	public static class ExceptionTab extends Fragment {
-		@Override
-		public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-			int exceptionTabId = container.getContext().getResources().getIdentifier("exception_tab", "layout", container.getContext().getPackageName());
-			View view = inflater.inflate(exceptionTabId, container, false);
-
-			int txtViewId = container.getContext().getResources().getIdentifier("txtErrorMsg", "id", container.getContext().getPackageName());
-			TextView txtErrorMsg = (TextView) view.findViewById(txtViewId);
-			txtErrorMsg.setText(exceptionMsg);
-			txtErrorMsg.setMovementMethod(new ScrollingMovementMethod());
-
-			int btnCopyExceptionId = container.getContext().getResources().getIdentifier("btnCopyException", "id", container.getContext().getPackageName());
-			Button copyToClipboard = (Button) view.findViewById(btnCopyExceptionId);
-			copyToClipboard.setOnClickListener(new View.OnClickListener()
-			{
-				@Override
-				public void onClick(View v)
-				{
-					ClipboardManager clipboard = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
-					ClipData clip = ClipData.newPlainText("nsError", exceptionMsg);
-					clipboard.setPrimaryClip(clip);
-				}
-			});
-
-			return view;
-		}
-	}
-
-	public static class LogcatTab extends Fragment {
-		@Override
-		public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-			int logcatTabId = container.getContext().getResources().getIdentifier("logcat_tab", "layout", container.getContext().getPackageName());
-			View view = inflater.inflate(logcatTabId, container, false);
-
-			int textViewId = container.getContext().getResources().getIdentifier("logcatMsg", "id", container.getContext().getPackageName());
-			TextView txtlogcatMsg = (TextView) view.findViewById(textViewId);
-			txtlogcatMsg.setText(logcatMsg);
-
-			txtlogcatMsg.setMovementMethod(new ScrollingMovementMethod());
-
-			final String logName = "Log-" + new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss").format(new Date());
-
-			int btnCopyLogcatId = container.getContext().getResources().getIdentifier("btnCopyLogcat", "id", container.getContext().getPackageName());
-			Button copyToClipboard = (Button) view.findViewById(btnCopyLogcatId);
-			copyToClipboard.setOnClickListener(new View.OnClickListener()
-			{
-				@Override
-				public void onClick(View v)
-				{
-					if(Build.VERSION.SDK_INT >= 23) {
-						//verifyStoragePermissions(activity);
-					}
-
-					try {
-						File dir = new File(Environment.getExternalStorageDirectory().getPath()+ "/logcat-reports/");
-						dir.mkdirs();
-
-						File logcatReportFile = new File(dir, logName);
-						FileOutputStream stream = new FileOutputStream(logcatReportFile);
-						OutputStreamWriter writer = new OutputStreamWriter(stream, "UTF-8");
-						writer.write(logcatMsg);
-						writer.close();
-
-						String logPath = dir.getPath() + "/" + logName;
-
-						ClipboardManager clipboard = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
-						ClipData clip = ClipData.newPlainText("logPath", logPath);
-						clipboard.setPrimaryClip(clip);
-
-						Toast.makeText(activity, "Path copied to clipboard: " + logPath, Toast.LENGTH_LONG).show();
-					} catch (Exception e) {
-						String err = "Could not write logcat report to sdcard. Make sure you have allowed access to external storage!";
-						Toast.makeText(activity, err, Toast.LENGTH_LONG).show();
-						Log.d("ErrorReport", err);
-					}
-				}
-			});
-
-			return view;
-		}
-	}
+        intent.putExtra(EXTRA_NATIVESCRIPT_ERROR_REPORT, EXTRA_ERROR_REPORT_VALUE);
+        intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
+
+        return intent;
+    }
+
+    static boolean hasIntent(Intent intent) {
+        int value = intent.getIntExtra(EXTRA_NATIVESCRIPT_ERROR_REPORT, 0);
+
+        return value == EXTRA_ERROR_REPORT_VALUE;
+    }
+
+    void buildUI() {
+        Intent intent = activity.getIntent();
+
+        exceptionMsg = intent.getStringExtra(EXTRA_ERROR_REPORT_MSG);
+
+        String processId = intent.getStringExtra(EXTRA_PID);
+        logcatMsg = getLogcat(processId);
+
+        int errActivityId = this.context.getResources().getIdentifier("error_activity", "layout", this.context.getPackageName());
+
+        activity.setContentView(errActivityId);
+
+        int toolBarId = this.context.getResources().getIdentifier("toolbar", "id", this.context.getPackageName());
+
+        Toolbar toolbar = (Toolbar) activity.findViewById(toolBarId);
+        activity.setSupportActionBar(toolbar);
+
+        final int tabLayoutId = this.context.getResources().getIdentifier("tabLayout", "id", this.context.getPackageName());
+
+        tabLayout = (TabLayout) activity.findViewById(tabLayoutId);
+        tabLayout.addTab(tabLayout.newTab().setText("Exception"));
+        tabLayout.addTab(tabLayout.newTab().setText("Logcat"));
+        tabLayout.setTabGravity(TabLayout.GRAVITY_FILL);
+        int pagerId = this.context.getResources().getIdentifier("pager", "id", this.context.getPackageName());
+
+        viewPager = (ViewPager) activity.findViewById(pagerId);
+
+        Pager adapter = new Pager(activity.getSupportFragmentManager(), tabLayout.getTabCount());
+
+        viewPager.setAdapter(adapter);
+        viewPager.addOnPageChangeListener(new ViewPager.OnPageChangeListener() {
+            @Override
+            public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
+
+            }
+
+            @Override
+            public void onPageSelected(int position) {
+                tabLayout.getTabAt(position).select();
+                viewPager.setCurrentItem(position);
+            }
+
+            @Override
+            public void onPageScrollStateChanged(int state) {
+
+            }
+        });
+
+        tabLayout.setOnTabSelectedListener(this);
+    }
+
+    private static void createErrorFile(final Context context) {
+        try {
+            File errFile = new File(context.getFilesDir(), ERROR_FILE_NAME);
+            errFile.createNewFile();
+        } catch (IOException e) {
+            Log.d("ErrorReport", e.getMessage());
+        }
+    }
+
+    @Override
+    public void onTabSelected(TabLayout.Tab tab) {
+        viewPager.setCurrentItem(tab.getPosition());
+    }
+
+    @Override
+    public void onTabUnselected(TabLayout.Tab tab) {
+
+    }
+
+    @Override
+    public void onTabReselected(TabLayout.Tab tab) {
+        viewPager.setCurrentItem(tab.getPosition());
+    }
+
+    private class Pager extends FragmentStatePagerAdapter {
+
+        int tabCount;
+
+        public Pager(FragmentManager fm, int tabCount) {
+            super(fm);
+            this.tabCount = tabCount;
+        }
+
+        @Override
+        public Fragment getItem(int position) {
+            switch (position) {
+                case 0:
+                    return new ExceptionTab();
+                case 1:
+                    return new LogcatTab();
+                default:
+                    return null;
+            }
+        }
+
+        @Override
+        public int getCount() {
+            return tabCount;
+        }
+    }
+
+    public static class ExceptionTab extends Fragment {
+        @Override
+        public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+            int exceptionTabId = container.getContext().getResources().getIdentifier("exception_tab", "layout", container.getContext().getPackageName());
+            View view = inflater.inflate(exceptionTabId, container, false);
+
+            int txtViewId = container.getContext().getResources().getIdentifier("txtErrorMsg", "id", container.getContext().getPackageName());
+            TextView txtErrorMsg = (TextView) view.findViewById(txtViewId);
+            txtErrorMsg.setText(exceptionMsg);
+            txtErrorMsg.setMovementMethod(new ScrollingMovementMethod());
+
+            int btnCopyExceptionId = container.getContext().getResources().getIdentifier("btnCopyException", "id", container.getContext().getPackageName());
+            Button copyToClipboard = (Button) view.findViewById(btnCopyExceptionId);
+            copyToClipboard.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    ClipboardManager clipboard = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
+                    ClipData clip = ClipData.newPlainText("nsError", exceptionMsg);
+                    clipboard.setPrimaryClip(clip);
+                }
+            });
+
+            return view;
+        }
+    }
+
+    public static class LogcatTab extends Fragment {
+        @Override
+        public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+            int logcatTabId = container.getContext().getResources().getIdentifier("logcat_tab", "layout", container.getContext().getPackageName());
+            View view = inflater.inflate(logcatTabId, container, false);
+
+            int textViewId = container.getContext().getResources().getIdentifier("logcatMsg", "id", container.getContext().getPackageName());
+            TextView txtlogcatMsg = (TextView) view.findViewById(textViewId);
+            txtlogcatMsg.setText(logcatMsg);
+
+            txtlogcatMsg.setMovementMethod(new ScrollingMovementMethod());
+
+            final String logName = "Log-" + new SimpleDateFormat("yyyy-MM-dd-HH-mm-ss").format(new Date());
+
+            int btnCopyLogcatId = container.getContext().getResources().getIdentifier("btnCopyLogcat", "id", container.getContext().getPackageName());
+            Button copyToClipboard = (Button) view.findViewById(btnCopyLogcatId);
+            copyToClipboard.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    verifyStoragePermissions(activity);
+
+                    if (!isCheckingForPermissions()) {
+                        try {
+                            File dir = new File(Environment.getExternalStorageDirectory().getPath() + "/logcat-reports/");
+                            dir.mkdirs();
+
+                            File logcatReportFile = new File(dir, logName);
+                            FileOutputStream stream = new FileOutputStream(logcatReportFile);
+                            OutputStreamWriter writer = new OutputStreamWriter(stream, "UTF-8");
+                            writer.write(logcatMsg);
+                            writer.close();
+
+                            String logPath = dir.getPath() + "/" + logName;
+
+                            ClipboardManager clipboard = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
+                            ClipData clip = ClipData.newPlainText("logPath", logPath);
+                            clipboard.setPrimaryClip(clip);
+
+                            Toast.makeText(activity, "Path copied to clipboard: " + logPath, Toast.LENGTH_LONG).show();
+                        } catch (Exception e) {
+                            String err = "Could not write logcat report to sdcard. Make sure you have allowed access to external storage!";
+                            Toast.makeText(activity, err, Toast.LENGTH_LONG).show();
+                            e.printStackTrace();
+                        }
+                    }
+                }
+            });
+
+            return view;
+        }
+    }
 }

--- a/test-app/app/src/main/res/layout/error_activity.xml
+++ b/test-app/app/src/main/res/layout/error_activity.xml
@@ -12,20 +12,31 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="?attr/actionBarSize"
-        app:popupTheme="@style/ThemeOverlay.AppCompat.Dark"/>
+        android:background="?android:attr/statusBarColor"
+        android:layout_alignBottom="@+id/tabLayout"/>
+
+    <android.support.v4.view.ViewPager
+        android:id="@+id/pager"
+        android:layout_width="match_parent"
+        android:layout_height="fill_parent"
+        android:layout_below="@+id/toolbar"
+        android:scrollbarAlwaysDrawVerticalTrack="false">
+
+    </android.support.v4.view.ViewPager>
 
     <android.support.design.widget.TabLayout
         android:id="@+id/tabLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?attr/colorPrimary"
-        android:minHeight="?attr/actionBarSize"/>
-
-    <android.support.v4.view.ViewPager
-        android:id="@+id/pager"
-        android:layout_width="match_parent"
-        android:layout_height="fill_parent"
-        android:layout_below="@+id/toolbar">
-
-    </android.support.v4.view.ViewPager>
+        android:minHeight="?attr/actionBarSize"
+        app:tabIndicatorColor="@color/nativescript_blue"
+        app:tabBackground="?android:attr/statusBarColor"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentStart="true"
+        android:scrollbarStyle="insideOverlay"
+        android:scrollbars="vertical"
+        tools:tabBackground="@android:color/darker_gray"
+        android:scrollbarAlwaysDrawVerticalTrack="false"
+        />
 </RelativeLayout>

--- a/test-app/app/src/main/res/layout/exception_tab.xml
+++ b/test-app/app/src/main/res/layout/exception_tab.xml
@@ -1,42 +1,52 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:tools="http://schemas.android.com/tools"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:orientation="vertical">
+                android:orientation="vertical"
+                android:paddingBottom="10dp"
+                android:paddingLeft="16dp"
+                android:paddingRight="16dp"
+                android:paddingTop="10dp">
+
+    <Button
+        android:id="@+id/btnCopyException"
+        style="@style/Widget.AppCompat.Button.Colored"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:background="@color/nativescript_blue"
+        android:paddingLeft="20dp"
+        android:paddingRight="20dp"
+        android:text="Copy to clipboard"
+        android:textAlignment="textStart"
+        android:textColor="@android:color/white"
+        tools:layout_width="match_parent"/>
 
     <LinearLayout
         android:id="@+id/linearLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_above="@+id/btnCopyException"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentTop="true"
         android:orientation="vertical"
+        android:paddingBottom="10dp"
         android:weightSum="100">
 
-        <LinearLayout
-            android:layout_width="fill_parent"
-            android:layout_height="0dp"
-            android:layout_weight="80">
-
-            <TextView
-                android:id="@+id/txtErrorMsg"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_centerInParent="true"
-                android:text=""
-                android:textAppearance="?android:attr/textAppearanceSmall" />
-        </LinearLayout>
-
-        <LinearLayout
+        <TextView
+            android:id="@+id/txtErrorMsg"
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="20">
+            android:layout_height="wrap_content"
+            android:text=""
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:paddingLeft="2dp"
+            android:paddingRight="2dp"
+            android:scrollbars="vertical"
+            android:scrollbarStyle="outsideOverlay"
+            android:scrollbarAlwaysDrawVerticalTrack="true"/>
 
-            <Button
-                android:id="@+id/btnCopyException"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_alignParentBottom="true"
-                android:text="Copy to clipboard" />
-        </LinearLayout>
     </LinearLayout>
 
 

--- a/test-app/app/src/main/res/layout/logcat_tab.xml
+++ b/test-app/app/src/main/res/layout/logcat_tab.xml
@@ -1,42 +1,52 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:tools="http://schemas.android.com/tools"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:orientation="vertical">
+                android:orientation="vertical"
+                android:paddingBottom="10dp"
+                android:paddingLeft="16dp"
+                android:paddingRight="16dp"
+                android:paddingTop="10dp">
+
+    <Button
+        android:id="@+id/btnCopyLogcat"
+        android:layout_height="wrap_content"
+        android:text="Copy to sdcard"
+        android:layout_width="match_parent"
+        android:background="@color/nativescript_blue"
+        android:textColor="@android:color/white"
+        android:textAlignment="textStart"
+        android:paddingLeft="20dp"
+        android:paddingRight="20dp"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        tools:layout_width="match_parent"
+        style="@style/Widget.AppCompat.Button.Colored"/>
 
     <LinearLayout
         android:id="@+id/logcatLinearLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:weightSum="100">
+        android:weightSum="100"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentStart="true"
+        android:layout_above="@+id/btnCopyLogcat"
+        android:paddingBottom="10dp">
 
-        <LinearLayout
+        <TextView
+            android:id="@+id/logcatMsg"
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="80">
+            android:text=""
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:layout_height="wrap_content"
+            android:paddingLeft="2dp"
+            android:paddingRight="2dp"
+            android:scrollbars="vertical"
+            android:scrollbarStyle="outsideOverlay"
+            android:scrollbarAlwaysDrawVerticalTrack="true"/>
 
-            <TextView
-                android:id="@+id/logcatMsg"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_centerInParent="true"
-                android:text=""
-                android:textAppearance="?android:attr/textAppearanceSmall" />
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="20">
-
-            <Button
-                android:id="@+id/btnCopyLogcat"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_alignParentBottom="true"
-                android:text="Copy to sdcard" />
-        </LinearLayout>
     </LinearLayout>
 
 

--- a/test-app/app/src/main/res/values/colors.xml
+++ b/test-app/app/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="nativescript_blue">#3c5afd</color>
+</resources>


### PR DESCRIPTION
When project is built with compileSdk 23+ ask explicitly for permissions on devices running on Android 23 or more recent version of Android.

Beautify Error activity layouts, and allow orientation changing in Error Activity

@NativeScript/android-runtime 