### PR TITLE
Fix failure to open snapshot on emulator of Api level 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tns-android",
   "description": "NativeScript Runtime for Android",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "files": [
     "**/*"
   ]


### PR DESCRIPTION
`dlopen` function works differently on API Level 17 and API Levels 18+. Previous implementations of dlopen appear to work with absolute/relative paths to dynamic libraries, as opposed to internally resolving the path to the native library, as it happens on Android 18+;

@slavchev @dtopuzov 