### PR TITLE
Fix failure to open snapshot on emulator of Api level 17

### DIFF
--- a/build-artifacts/project-template-gradle/src/main/java/com/tns/RuntimeHelper.java
+++ b/build-artifacts/project-template-gradle/src/main/java/com/tns/RuntimeHelper.java
@@ -117,8 +117,15 @@ public final class RuntimeHelper {
 				e.printStackTrace();
 			}
 
-			StaticConfiguration config = new StaticConfiguration(logger, debugger, appName, null, rootDir,
-					appDir, classLoader, dexDir, dexThumb, appConfig);
+            String nativeLibDir = null;
+            try {
+                nativeLibDir = app.getPackageManager().getApplicationInfo(appName, 0).nativeLibraryDir;
+            } catch (android.content.pm.PackageManager.NameNotFoundException e) {
+                e.printStackTrace();
+            }
+
+            StaticConfiguration config = new StaticConfiguration(logger, debugger, appName, nativeLibDir, rootDir,
+                    appDir, classLoader, dexDir, dexThumb, appConfig);
 
 			runtime = Runtime.initializeRuntimeWithConfiguration(config);
 

--- a/runtime/src/main/java/com/tns/Runtime.java
+++ b/runtime/src/main/java/com/tns/Runtime.java
@@ -31,7 +31,7 @@ import android.util.SparseArray;
 import com.tns.bindings.ProxyGenerator;
 
 public class Runtime {
-    private native void initNativeScript(int runtimeId, String filesPath, boolean verboseLoggingEnabled, String packageName, Object[] v8Options, String callingDir, JsDebugger jsDebugger);
+    private native void initNativeScript(int runtimeId, String filesPath, String nativeLibDir, boolean verboseLoggingEnabled, String packageName, Object[] v8Options, String callingDir, JsDebugger jsDebugger);
 
     private native void runModule(int runtimeId, String filePath) throws NativeScriptException;
 
@@ -443,10 +443,10 @@ public class Runtime {
     }
 
     public void init() {
-        init(config.logger, config.debugger, config.appName, config.runtimeLibPath, config.rootDir, config.appDir, config.classLoader, config.dexDir, config.dexThumb, config.appConfig, dynamicConfig.callingJsDir);
+        init(config.logger, config.debugger, config.appName, config.nativeLibDir, config.rootDir, config.appDir, config.classLoader, config.dexDir, config.dexThumb, config.appConfig, dynamicConfig.callingJsDir);
     }
 
-    private void init(Logger logger, Debugger debugger, String appName, File runtimeLibPath, File rootDir, File appDir, ClassLoader classLoader, File dexDir, String dexThumb, AppConfig appConfig, String callingJsDir) throws RuntimeException {
+    private void init(Logger logger, Debugger debugger, String appName, String nativeLibDir, File rootDir, File appDir, ClassLoader classLoader, File dexDir, String dexThumb, AppConfig appConfig, String callingJsDir) throws RuntimeException {
         if (initialized) {
             throw new RuntimeException("NativeScriptApplication already initialized");
         }
@@ -471,7 +471,7 @@ public class Runtime {
             jsDebugger = new JsDebugger(debugger, threadScheduler);
         }
 
-        initNativeScript(getRuntimeId(), Module.getApplicationFilesPath(), logger.isEnabled(), appName, appConfig.getAsArray(), callingJsDir, jsDebugger);
+        initNativeScript(getRuntimeId(), Module.getApplicationFilesPath(), nativeLibDir, logger.isEnabled(), appName, appConfig.getAsArray(), callingJsDir, jsDebugger);
 
         if (jsDebugger != null && this.runtimeId == 0) {
              jsDebugger.start();

--- a/runtime/src/main/java/com/tns/StaticConfiguration.java
+++ b/runtime/src/main/java/com/tns/StaticConfiguration.java
@@ -7,7 +7,7 @@ public class StaticConfiguration
 	public final Logger logger;
 	public final Debugger debugger;
 	public final String appName;
-	public final File runtimeLibPath;
+	public final String nativeLibDir;
 	public final File rootDir;
 	public final File appDir;
 	public final ClassLoader classLoader;
@@ -16,12 +16,12 @@ public class StaticConfiguration
 	public final AppConfig appConfig;
 
 	public StaticConfiguration(Logger logger, Debugger debugger,
-							   String appName, File runtimeLibPath, File rootDir, File appDir, ClassLoader classLoader,
+							   String appName, String nativeLibDir, File rootDir, File appDir, ClassLoader classLoader,
 							   File dexDir, String dexThumb, AppConfig appConfig) {
 		this.logger = logger;
 		this.debugger = debugger;
 		this.appName = appName;
-		this.runtimeLibPath = runtimeLibPath;
+		this.nativeLibDir = nativeLibDir;
 		this.rootDir = rootDir;
 		this.appDir = appDir;
 		this.classLoader = classLoader;

--- a/runtime/src/main/jni/Runtime.h
+++ b/runtime/src/main/jni/Runtime.h
@@ -31,9 +31,9 @@ namespace tns
 
 			static void Init(JavaVM *vm, void *reserved);
 
-			static void Init(JNIEnv *_env, jobject obj, int runtimeId, jstring filesPath, jboolean verboseLoggingEnabled, jstring packageName, jobjectArray args, jstring callingDir, jobject jsDebugger);
+			static void Init(JNIEnv *_env, jobject obj, int runtimeId, jstring filesPath, jstring nativeLibsDir, jboolean verboseLoggingEnabled, jstring packageName, jobjectArray args, jstring callingDir, jobject jsDebugger);
 
-			void Init(jstring filesPath, bool verboseLoggingEnabled, jstring packageName, jobjectArray args, jstring callingDir, jobject jsDebugger);
+			void Init(jstring filesPath, jstring nativeLibsDir, bool verboseLoggingEnabled, jstring packageName, jobjectArray args, jstring callingDir, jobject jsDebugger);
 
 			v8::Isolate* GetIsolate() const;
 
@@ -81,7 +81,7 @@ namespace tns
 			v8::Persistent<v8::Function> *m_gcFunc;
 			volatile bool m_runGC;
 
-			v8::Isolate* PrepareV8Runtime(const std::string& filesPath, jstring packageName, jstring callingDir, jobject jsDebugger, jstring profilerOutputDir);
+			v8::Isolate* PrepareV8Runtime(const std::string& filesPath, jstring nativeLibsDir, jstring packageName, jstring callingDir, jobject jsDebugger, jstring profilerOutputDir);
 			jobject ConvertJsValueToJavaObject(JEnv& env, const v8::Local<v8::Value>& value, int classReturnType);
 
 			static std::map<int, Runtime*> s_id2RuntimeCache;

--- a/runtime/src/main/jni/com_tns_Runtime.cpp
+++ b/runtime/src/main/jni/com_tns_Runtime.cpp
@@ -31,11 +31,11 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 	return JNI_VERSION_1_6;
 }
 
-extern "C" JNIEXPORT void Java_com_tns_Runtime_initNativeScript(JNIEnv *_env, jobject obj, jint runtimeId, jstring filesPath, jboolean verboseLoggingEnabled, jstring packageName, jobjectArray args, jstring callingDir, jobject jsDebugger)
+extern "C" JNIEXPORT void Java_com_tns_Runtime_initNativeScript(JNIEnv *_env, jobject obj, jint runtimeId, jstring filesPath, jstring nativeLibDir, jboolean verboseLoggingEnabled, jstring packageName, jobjectArray args, jstring callingDir, jobject jsDebugger)
 {
 	try
 	{
-		Runtime::Init(_env, obj, runtimeId, filesPath, verboseLoggingEnabled, packageName, args, callingDir, jsDebugger);
+		Runtime::Init(_env, obj, runtimeId, filesPath, nativeLibDir, verboseLoggingEnabled, packageName, args, callingDir, jsDebugger);
 	}
 	catch (NativeScriptException& e)
 	{


### PR DESCRIPTION
dlopen function works differently on API Level 17 and API Levels 18+. Previous implementations of dlopen appear to work with absolute/relative paths to dynamic libraries, as opposed to internally resolving the path to the native library, as it happens on Android 18+;

@slavchev @dtopuzov