### PR TITLE
updated root build gradle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
   - echo no | android create avd --force -n Arm21 -t android-21 -b armeabi-v7a -c 12M
   - emulator -avd Arm21 -no-skin -no-audio -no-window &
   - android-wait-for-emulator
-  - "./gradlew runTest Arm21"
+  - "./gradlew runTest -PemulatorName=Arm21"
   - adb -e logcat -d 300
 before_deploy:
   - FULL_PACKAGE_VERSION=`sed -n 's/\s*"version":\s*"\([a-zA-Z0-9\.]*\)"\s*,*/\1/p' dist/package.json`

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,6 @@ cache:
   - "$HOME/.gradle/caches/"
   - "$HOME/.gradle/wrapper/"
 before_install:
-  - curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
-  - sudo apt-get install git-lfs
-  - git lfs install
   - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
   - git submodule update --init --recursive
   - wget http://dl.google.com/android/repository/android-ndk-$NDK_VERSION-linux-x86_64.zip
@@ -39,14 +36,12 @@ before_install:
   - export ANDROID_NDK_HOME=`pwd`/android-ndk-$NDK_VERSION
   - export PATH=${PATH}:${ANDROID_NDK_HOME}
 script:
-  - git lfs pull
   - "./gradlew createPackage -i -PpreReleaseVersion=$PACKAGE_VERSION -PgitCommitVersion=$TRAVIS_COMMIT --stacktrace"
   - echo no | android create avd --force -n Arm21 -t android-21 -b armeabi-v7a -c 12M
   - emulator -avd Arm21 -no-skin -no-audio -no-window &
   - android-wait-for-emulator
-  - "cd test-app && ./gradlew assembleDebug runtests -PembedBindingGenerator=true --stacktrace"
+  - "./gradlew runTest Arm21"
   - adb -e logcat -d 300
-  - cd ..
 before_deploy:
   - FULL_PACKAGE_VERSION=`sed -n 's/\s*"version":\s*"\([a-zA-Z0-9\.]*\)"\s*,*/\1/p' dist/package.json`
   - ls -la dist

--- a/build.gradle
+++ b/build.gradle
@@ -358,10 +358,14 @@ task testStaticBindingGenerator (type: Exec){
 
 task runTests (type: Exec){
         workingDir "$projectDir/test-app"
+	def emulator = ""
+	if(project.hasProperty("emulatorName")){
+		emulator = emulatorName
+	}
         if (isWinOs) {
-            commandLine "cmd", "/c", "gradlew.bat", "assembleDebug", "runtest", "--rerun-tasks", "-PembedBindingGenerator=true"
+            commandLine "cmd", "/c", "gradlew.bat", "assembleDebug", "runtest", "--rerun-tasks", "-PembedBindingGenerator=true", "-PemulatorName=$emulator"
         } else {
-            commandLine "./gradlew", "assembleDebug", "runtest", "--rerun-tasks", "-PembedBindingGenerator=true"
+            commandLine "./gradlew", "assembleDebug", "runtest", "--rerun-tasks", "-PembedBindingGenerator=true", "-PemulatorName=$emulator"
         }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -230,7 +230,51 @@ task copyReadme (type: Copy) {
 	into "$rootDir/dist"
 }
 
-//clean and set up dirs
+
+task cleanTestApp (type: Exec){
+	workingDir "$projectDir/test-app"
+        if (isWinOs) {
+            commandLine "cmd", "/c", "gradlew.bat", "clean"
+        } else {
+            commandLine "./gradlew", "clean"
+        }
+}
+
+task cleanBindingGenerator (type: Exec){
+        workingDir "$projectDir/binding-generator"
+        if (isWinOs) {
+            commandLine "cmd", "/c", "gradlew.bat", "clean"
+        } else {
+            commandLine "./gradlew", "clean"
+        }
+}
+
+task cleanStaticBindingGenerator (type: Exec){
+        workingDir "$projectDir/android-static-binding-generator/project/staticbindinggenerator"
+        if (isWinOs) {
+            commandLine "cmd", "/c", "gradlew.bat", "clean"
+        } else {
+            commandLine "./gradlew", "clean"
+        }
+}
+
+task deleteFlavors (type: Delete){
+	doLast {
+		def srcDir = new File("$projectDir/src")
+		srcDir.listFiles().each({ f ->
+			if(!f.getName().equals("main") &&
+				!f.getName().equals("debug") &&
+				!f.getName().equals("release"))	{
+				delete f
+			}
+		})
+	}
+}
+
+// run clean commands
+cleanBindingGenerator.dependsOn(cleanTestApp)
+cleanStaticBindingGenerator.dependsOn(cleanBindingGenerator)
+cleanDistDir.dependsOn(cleanStaticBindingGenerator)
 createDistDir.dependsOn(cleanDistDir)
 
 //copy framework structure
@@ -275,28 +319,51 @@ createNpmPackage.dependsOn(copyReadme, setPackageVersionInPackageJsonFile)
 task createPackage {
 	description "Builds the NativeScript Android App Package using an application project template."
 	dependsOn cleanDistDir,
-            createDistDir,
+	createDistDir,
+	copyProjectTemplate,
+	copyPackageJson,
+	copyStaticBindingGeneratorProject,
+	generateStaticBindingGeneratorJar,
+	copyGeneratedStaticBindingGeneratorJar,
+	getPackageVersion,
+	getCommitVersion,
+	generateRuntime,
+	setPackageVersionInPackageJsonFile,
+	copyGeneratedRuntime,
+	generateMetadataGeneratorJar,
+	copyGeneratedMetadataGeneratorJar,
+	copyReadme,
+	createNpmPackage
 
-            copyProjectTemplate,
-
-            copyPackageJson,
-
-			copyStaticBindingGeneratorProject,
-			generateStaticBindingGeneratorJar,
-			copyGeneratedStaticBindingGeneratorJar,
-
-            getPackageVersion,
-            getCommitVersion,
-			
-            generateRuntime,
-
-			setPackageVersionInPackageJsonFile,
-
-            copyGeneratedRuntime,
-            generateMetadataGeneratorJar,
-            copyGeneratedMetadataGeneratorJar,
-            copyReadme,
-            createNpmPackage
-
-	println "Creating NativeScript Android Package"			
+	println "Creating NativeScript Android Package"
 }
+
+task testBindingGenerator (type: Exec){
+        workingDir "$projectDir/binding-generator"
+        if (isWinOs) {
+            commandLine "cmd", "/c", "gradlew.bat", "test"
+        } else {
+            commandLine "./gradlew", "test"
+        }
+}
+
+task testStaticBindingGenerator (type: Exec){
+        workingDir "$projectDir/android-static-binding-generator/project/staticbindinggenerator"
+        if (isWinOs) {
+            commandLine "cmd", "/c", "gradlew.bat", "test"
+        } else {
+            commandLine "./gradlew", "test"
+        }
+}
+
+task runTests (type: Exec){
+        workingDir "$projectDir/test-app"
+        if (isWinOs) {
+            commandLine "cmd", "/c", "gradlew.bat", "assembleDebug", "runtest", "--rerun-tasks", "-PembedBindingGenerator=true"
+        } else {
+            commandLine "./gradlew", "assembleDebug", "runtest", "--rerun-tasks", "-PembedBindingGenerator=true"
+        }
+}
+
+testStaticBindingGenerator.dependsOn(testBindingGenerator)
+runTests.dependsOn(testStaticBindingGenerator)

--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -99,10 +99,10 @@ task deletePreviousResultXml (type: Exec) {
 		println "Removing previous android_unit_test_results.xml"
 
 		if(isWinOs) {
-		    commandLine "cmd", "/c", "%ANDROID_HOME%/platform-tools/adb", runOnDeviceOrEmulator , "shell", "rm", "-rf", "/sdcard/android_unit_test_results.xml"
+		    commandLine "cmd", "/c", "$System.env.ANDROID_HOME/platform-tools/adb", runOnDeviceOrEmulator , "shell", "rm", "-rf", "/sdcard/android_unit_test_results.xml"
 		}
 		else {
-		    commandLine "$ANDROID_HOME/platform-tools/adb", runOnDeviceOrEmulator, "shell", "rm", "-rf", "/sdcard/android_unit_test_results.xml"
+		    commandLine "$System.env.ANDROID_HOME/platform-tools/adb", runOnDeviceOrEmulator, "shell", "rm", "-rf", "/sdcard/android_unit_test_results.xml"
 		}
 	}
 }

--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -2,6 +2,7 @@
 * run from dir: test-app/
 * 	run on emulator: ./gradlew runtests //default
 * 	run on device: ./gradlew runtests -PrunOnDevice
+*	emulatorName: -PemulatorName
 *
 */
 
@@ -55,9 +56,24 @@ dependencies {
 	testCompile 'junit:junit:4.12'
 }
 
+task startEmulator(type: Exec) {
+	doFirst {
+		def emulator = "";
+		if(project.hasProperty("emulatorName")) {
+			emulator = emulatorName
+		}
+		if(isWinOs) {
+			commandLine "cmd", "/c", "node", "$rootDir\\tools\\start-kill-emulator.js", "start", emulator
+		}
+		else {
+			commandLine "node", "$rootDir/tools/start-kill-emulator.js", "start", emulator
+		}
+	}
+}
+
 task deleteDist (type: Delete) {
 	doFirst {
-        delete "$rootDir/dist"
+		delete "$rootDir/dist"
 	}
 }
 
@@ -80,15 +96,15 @@ task installApk (type: Exec) {
 
 task deletePreviousResultXml (type: Exec) {
 	doFirst {
-        println "Removing previous android_unit_test_results.xml"
+		println "Removing previous android_unit_test_results.xml"
 
-        if(isWinOs) {
-            commandLine "cmd", "/c", "adb", runOnDeviceOrEmulator , "shell", "rm", "-rf", "/sdcard/android_unit_test_results.xml"
-        }
-        else {
-            commandLine "adb", runOnDeviceOrEmulator, "shell", "rm", "-rf", "/sdcard/android_unit_test_results.xml"
-        }
-    }
+		if(isWinOs) {
+		    commandLine "cmd", "/c", "adb", runOnDeviceOrEmulator , "shell", "rm", "-rf", "/sdcard/android_unit_test_results.xml"
+		}
+		else {
+		    commandLine "adb", runOnDeviceOrEmulator, "shell", "rm", "-rf", "/sdcard/android_unit_test_results.xml"
+		}
+	}
 }
 
 task startInstalledApk (type: Exec) {
@@ -96,10 +112,10 @@ task startInstalledApk (type: Exec) {
 		println "Starting test application"
 		
 		if(isWinOs) {
-			commandLine "cmd", "/c", "adb", runOnDeviceOrEmulator, "shell", "am", "start", "-n", "com.tns.android_runtime_testapp/com.tns.NativeScriptActivity", "-a", "android.intent.action.MAIN", "-c", "android.intent.category.LAUNCHER"
+			commandLine "node", "$rootDir\\tools\\start-installed-apk.js"
 		}
 		else {
-			commandLine "adb", runOnDeviceOrEmulator, "shell", "am", "start", "-n", "com.tns.android_runtime_testapp/com.tns.NativeScriptActivity", "-a", "android.intent.action.MAIN", "-c", "android.intent.category.LAUNCHER"
+			commandLine "node", "$rootDir/tools/start-installed-apk.js"
 		}
 	}
 }
@@ -133,6 +149,18 @@ task deleteRootLevelResult (type: Delete) {
 	delete "$rootDir/app/android_unit_test_results.xml"
 }
 
+task killEmulators(type: Exec) {
+	doFirst {
+		if(isWinOs) {
+			commandLine "cmd", "/c", "node", "$rootDir\\tools\\start-kill-emulator.js", "kill"
+		}
+		else {
+			commandLine "node", "$rootDir/tools/start-kill-emulator.js", "kill"
+		}
+	}
+}
+
+deleteDist.dependsOn(startEmulator)
 deletePreviousResultXml.dependsOn(deleteDist)
 installApk.dependsOn(deletePreviousResultXml)
 startInstalledApk.dependsOn(installApk)
@@ -140,9 +168,10 @@ createDistFolder.dependsOn(startInstalledApk)
 waitForUnitTestResultFile.dependsOn(createDistFolder)
 copyResultToDist.dependsOn(waitForUnitTestResultFile)
 deleteRootLevelResult.dependsOn(copyResultToDist)
+killEmulators.dependsOn(deleteRootLevelResult)
 
 task runtests {
-	dependsOn deleteRootLevelResult
+	dependsOn killEmulators
 }
 
 tasks.whenTaskAdded { task ->

--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -6,13 +6,9 @@
 *
 */
 
-
 def isWinOs = System.properties['os.name'].toLowerCase().contains('windows')
 
 apply plugin: 'com.android.model.application'
-
-def runOnDevice = project.hasProperty("runOnDevice");
-def runOnDeviceOrEmulator = runOnDevice ? "-d" : "-e";
 
 model {
     android {
@@ -82,10 +78,10 @@ task installApk (type: Exec) {
 		println "Attempting to install buit apk"
 
 		if(isWinOs) {
-			commandLine "cmd", "/c", "node", "$rootDir\\tools\\deploy-apk.js", "$rootDir\\app\\build\\outputs\\apk\\app-debug.apk", runOnDeviceOrEmulator
+			commandLine "cmd", "/c", "node", "$rootDir\\tools\\deploy-apk.js", "$rootDir\\app\\build\\outputs\\apk\\app-debug.apk"
 		}
 		else {
-			commandLine "node", "$rootDir/tools/deploy-apk.js", "$rootDir/app/build/outputs/apk/app-debug.apk", runOnDeviceOrEmulator
+			commandLine "node", "$rootDir/tools/deploy-apk.js", "$rootDir/app/build/outputs/apk/app-debug.apk"
 		}
 	}
     
@@ -97,12 +93,11 @@ task installApk (type: Exec) {
 task deletePreviousResultXml (type: Exec) {
 	doFirst {
 		println "Removing previous android_unit_test_results.xml"
-
 		if(isWinOs) {
-		    commandLine "cmd", "/c", "$System.env.ANDROID_HOME/platform-tools/adb", runOnDeviceOrEmulator , "shell", "rm", "-rf", "/sdcard/android_unit_test_results.xml"
+			commandLine "cmd", "/c", "node", "$rootDir\\tools\\delete-previous-results.js"
 		}
 		else {
-		    commandLine "$System.env.ANDROID_HOME/platform-tools/adb", runOnDeviceOrEmulator, "shell", "rm", "-rf", "/sdcard/android_unit_test_results.xml"
+			commandLine "node", "$rootDir/tools/delete-previous-results.js"
 		}
 	}
 }
@@ -132,10 +127,10 @@ task waitForUnitTestResultFile (type: Exec) {
 		println "Waiting for tests to finish..."
 		
 		if(isWinOs) {
-			commandLine "cmd", "/c", "node", "$rootDir\\tools\\try_to_find_test_result_file.js", runOnDeviceOrEmulator
+			commandLine "cmd", "/c", "node", "$rootDir\\tools\\try_to_find_test_result_file.js"
 		}
 		else {
-			commandLine "node", "$rootDir/tools/try_to_find_test_result_file.js", runOnDeviceOrEmulator
+			commandLine "node", "$rootDir/tools/try_to_find_test_result_file.js"
 		}
 	}
 }

--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -99,10 +99,10 @@ task deletePreviousResultXml (type: Exec) {
 		println "Removing previous android_unit_test_results.xml"
 
 		if(isWinOs) {
-		    commandLine "cmd", "/c", "adb", runOnDeviceOrEmulator , "shell", "rm", "-rf", "/sdcard/android_unit_test_results.xml"
+		    commandLine "cmd", "/c", "%ANDROID_HOME%/platform-tools/adb", runOnDeviceOrEmulator , "shell", "rm", "-rf", "/sdcard/android_unit_test_results.xml"
 		}
 		else {
-		    commandLine "adb", runOnDeviceOrEmulator, "shell", "rm", "-rf", "/sdcard/android_unit_test_results.xml"
+		    commandLine "$ANDROID_HOME/platform-tools/adb", runOnDeviceOrEmulator, "shell", "rm", "-rf", "/sdcard/android_unit_test_results.xml"
 		}
 	}
 }

--- a/test-app/tools/config.json
+++ b/test-app/tools/config.json
@@ -1,0 +1,4 @@
+{
+	"emulator-port": "5586",
+	"default-timeout": 180000
+}

--- a/test-app/tools/delete-previous-results.js
+++ b/test-app/tools/delete-previous-results.js
@@ -1,0 +1,22 @@
+var runner = require("./interval-runner-with-timeout.js"),
+    exec = require('child_process').exec,
+    adb = process.env.ANDROID_HOME + "/platform-tools/adb ",
+    defaultPort = require("./config.json")["emulator-port"],
+    emulatorName = "emulator-" + defaultPort + " ",
+    xmlName = "android_unit_test_results.xml";
+
+
+runner.runFunctionWithIntervalAndTimeout(removePreviousXml, 1000, 10 * 1000);
+
+function removePreviousXml() {
+    var out = exec(adb + "-s " + emulatorName + " shell rm -rf /sdcard/" + xmlName, function (err, stdout, stderr) {
+        if(stderr) {
+            console.log("Couldn't delete :" + xmlName);
+            if(stderr.indexOf(xmlName + "' does not exist")) {
+                process.exit(0);
+            }
+            process.exit(-1);
+        }
+        process.exit(0);
+    })
+}

--- a/test-app/tools/deploy-apk.js
+++ b/test-app/tools/deploy-apk.js
@@ -4,11 +4,11 @@
 //  - runOnDevice flag (optional)
 
 var apk = process.argv[2],
-    runOnDeviceOrEmulator = process.argv[3],
     exec = require('child_process').exec,
     deployTimeout = 3 * 60 * 1000, // 3 minutes to deploy and launch.
+    defaultPort = require("./config.json")["emulator-port"],
+    emulatorName = "emulator-" + defaultPort + " ",
     adb = process.env.ANDROID_HOME + "/platform-tools/adb ",
-    cmd = adb + runOnDeviceOrEmulator  +' install -r ' + apk,
     runner = require("./interval-runner-with-timeout.js");
 
 if (process.argv.length < 2) {
@@ -19,7 +19,7 @@ if (process.argv.length < 2) {
 runner.runFunctionWithIntervalAndTimeout(checkIfEmulatorFullyStarted, 10 * 1000, 60 * 10 * 1000)
 
 function checkIfEmulatorFullyStarted() {
-    var res = exec(adb + " shell getprop init.svc.bootanim");
+    var res = exec(adb + "-s " + emulatorName + " shell getprop init.svc.bootanim");
     res.stdout.on("data", function (data) {
         if(data.indexOf("stopped") !== -1) {
             console.log("emulator annimation has stopped");
@@ -36,8 +36,8 @@ function timeoutFunction(msg) {
 
 
 function installApk() {
-    console.log("Executing adb install: " + cmd);
-    var testrun = exec(cmd, function (error, stdout, stderr) {
+    console.log("Executing adb install");
+    var testrun = exec(adb + "-s " + emulatorName + " install -r " + apk, function (error, stdout, stderr) {
             if (error) {
                 console.error("Deply apk failed: " + error);
                 process.exit(-2);

--- a/test-app/tools/deploy-apk.js
+++ b/test-app/tools/deploy-apk.js
@@ -7,7 +7,8 @@ var apk = process.argv[2],
     runOnDeviceOrEmulator = process.argv[3],
     exec = require('child_process').exec,
     deployTimeout = 3 * 60 * 1000, // 3 minutes to deploy and launch.
-    cmd = '$ANDROID_HOME/platform-tools/adb '+ runOnDeviceOrEmulator  +' install -r ' + apk,
+    adb = process.env.ANDROID_HOME + "/platform-tools/adb ",
+    cmd = adb + runOnDeviceOrEmulator  +' install -r ' + apk,
     runner = require("./interval-runner-with-timeout.js");
 
 if (process.argv.length < 2) {
@@ -18,7 +19,7 @@ if (process.argv.length < 2) {
 runner.runFunctionWithIntervalAndTimeout(checkIfEmulatorFullyStarted, 10 * 1000, 60 * 10 * 1000)
 
 function checkIfEmulatorFullyStarted() {
-    var res = exec("$ANDROID_HOME/platform-tools/adb shell getprop init.svc.bootanim");
+    var res = exec(adb + " shell getprop init.svc.bootanim");
     res.stdout.on("data", function (data) {
         if(data.indexOf("stopped") !== -1) {
             console.log("emulator annimation has stopped");
@@ -41,6 +42,7 @@ function installApk() {
                 console.error("Deply apk failed: " + error);
                 process.exit(-2);
             }
+            process.exit(0);
         });
     testrun.stdout.pipe(process.stdout, { end: false });
     testrun.stderr.pipe(process.stderr, { end: false });

--- a/test-app/tools/deploy-apk.js
+++ b/test-app/tools/deploy-apk.js
@@ -7,7 +7,7 @@ var apk = process.argv[2],
     runOnDeviceOrEmulator = process.argv[3],
     exec = require('child_process').exec,
     deployTimeout = 3 * 60 * 1000, // 3 minutes to deploy and launch.
-    cmd = 'adb '+ runOnDeviceOrEmulator  +' install -r ' + apk,
+    cmd = '$ANDROID_HOME/platform-tools/adb '+ runOnDeviceOrEmulator  +' install -r ' + apk,
     runner = require("./interval-runner-with-timeout.js");
 
 if (process.argv.length < 2) {
@@ -18,7 +18,7 @@ if (process.argv.length < 2) {
 runner.runFunctionWithIntervalAndTimeout(checkIfEmulatorFullyStarted, 10 * 1000, 60 * 10 * 1000)
 
 function checkIfEmulatorFullyStarted() {
-    var res = exec("adb shell getprop init.svc.bootanim");
+    var res = exec("$ANDROID_HOME/platform-tools/adb shell getprop init.svc.bootanim");
     res.stdout.on("data", function (data) {
         if(data.indexOf("stopped") !== -1) {
             console.log("emulator annimation has stopped");

--- a/test-app/tools/deploy-apk.js
+++ b/test-app/tools/deploy-apk.js
@@ -1,20 +1,31 @@
 // This node app deploys apk file on device
 // Parameters:
 //  - Path to APK to deploy
+//  - runOnDevice flag (optional)
+
+var apk = process.argv[2],
+    runOnDeviceOrEmulator = process.argv[3],
+    exec = require('child_process').exec,
+    deployTimeout = 3 * 60 * 1000, // 3 minutes to deploy and launch.
+    cmd = 'adb '+ runOnDeviceOrEmulator  +' install -r ' + apk,
+    runner = require("./interval-runner-with-timeout.js");
 
 if (process.argv.length < 2) {
     console.error('Expect path to apk file to install');
     process.exit(1);
 }
 
-var apk = process.argv[2];
-var runOnDeviceOrEmulator = process.argv[3];
+runner.runFunctionWithIntervalAndTimeout(checkIfEmulatorFullyStarted, 10 * 1000, 60 * 10 * 1000)
 
-var proc = require('child_process');
-
-var deployTimeout = 3 * 60 * 1000; // 3 minutes to deploy and launch.
-
-var cmd = 'adb '+ runOnDeviceOrEmulator  +' install -r ' + apk;
+function checkIfEmulatorFullyStarted() {
+    var res = exec("adb shell getprop init.svc.bootanim");
+    res.stdout.on("data", function (data) {
+        if(data.indexOf("stopped") !== -1) {
+            console.log("emulator annimation has stopped");
+            installApk()
+        }
+    })
+}
 
 function timeoutFunction(msg) {
     console.error(msg);
@@ -22,17 +33,15 @@ function timeoutFunction(msg) {
     process.exit(-1);
 };
 
-var timeout = setTimeout(function () { timeoutFunction("ERROR: Deploy timeout!"); }, deployTimeout);
 
-console.log("Executing adb install: " + cmd);
-var testrun = proc.exec(cmd, function (error, stdout, stderr) {
-    // If the process exits prematurely kill the timer anyway...
-    clearTimeout(timeout);
-
-    if (error) {
-        console.error("Deply apk failed: " + error);
-        process.exit(-2);
-    }
-});
-testrun.stdout.pipe(process.stdout, { end: false });
-testrun.stderr.pipe(process.stderr, { end: false });
+function installApk() {
+    console.log("Executing adb install: " + cmd);
+    var testrun = exec(cmd, function (error, stdout, stderr) {
+            if (error) {
+                console.error("Deply apk failed: " + error);
+                process.exit(-2);
+            }
+        });
+    testrun.stdout.pipe(process.stdout, { end: false });
+    testrun.stderr.pipe(process.stderr, { end: false });
+}

--- a/test-app/tools/interval-runner-with-timeout.js
+++ b/test-app/tools/interval-runner-with-timeout.js
@@ -1,0 +1,35 @@
+var exec = require("child_process").exec;
+
+var runner = (function () {
+    var isTimeToExit = false;
+    var defaultInterval =  1000; //1sec
+    var defaultTimeout =  10 * 1000; //10sec
+
+    function closeProcessAfter(timeout) {
+        setTimeout(function () { isTimeToExit = true; }, timeout);
+    }
+    function runWithInterval(commandCallback, interval) {
+        if(isTimeToExit) {
+            process.exit(1);
+        }
+        commandCallback();
+        setInterval(commandCallback, interval);
+    }
+
+    function runFunctionWithIntervalAndTimeout(commandCallback, interval, timeout) {
+        if(!interval) {
+            console.log("Setting default interval: " + defaultInterval);
+            interval = defaultInterval;
+        }
+        if(!timeout) {
+            console.log("Setting default timeout: " + defaultTimeout);
+            timeout = defaultTimeout;
+        }
+        closeProcessAfter(timeout);
+        runWithInterval(commandCallback, interval);
+    }
+    return {
+        runFunctionWithIntervalAndTimeout: runFunctionWithIntervalAndTimeout
+    }
+})();
+module.exports = runner;

--- a/test-app/tools/start-installed-apk.js
+++ b/test-app/tools/start-installed-apk.js
@@ -1,16 +1,18 @@
 var runner = require("./interval-runner-with-timeout.js"),
     exec = require('child_process').exec,
-    runOnDeviceOrEmulator = "-e";
+    runOnDeviceOrEmulator = "-e",
+    adb = process.env.ANDROID_HOME + "/platform-tools/adb ";
 
 if(process.argv[2]) {
-	runOnDeviceOrEmulator = process.argv[2];  
+	runOnDeviceOrEmulator = process.argv[2];
 }
 
 runner.runFunctionWithIntervalAndTimeout(startApk, 10 * 1000, 60 * 1000);
 
 function startApk() {
     console.log("starting application")
-    var res = exec("$ANDROID_HOME/platform-tools/adb " + runOnDeviceOrEmulator + " shell am start -n com.tns.android_runtime_testapp/com.tns.NativeScriptActivity -a android.intent.action.MAIN -c android.intent.category.LAUNCHER", function (error, stdout, stderr) {
+
+    var res = exec(adb + runOnDeviceOrEmulator + " shell am start -n com.tns.android_runtime_testapp/com.tns.NativeScriptActivity -a android.intent.action.MAIN -c android.intent.category.LAUNCHER", function (error, stdout, stderr) {
             if (error) {
                 console.error("Starting application failed: " + error);
                 process.exit(-2);

--- a/test-app/tools/start-installed-apk.js
+++ b/test-app/tools/start-installed-apk.js
@@ -1,0 +1,23 @@
+var runner = require("./interval-runner-with-timeout.js"),
+    exec = require('child_process').exec,
+    runOnDeviceOrEmulator = "-e";
+
+if(process.argv[2]) {
+	runOnDeviceOrEmulator = process.argv[2];  
+}
+
+runner.runFunctionWithIntervalAndTimeout(startApk, 10 * 1000, 60 * 1000);
+
+function startApk() {
+    console.log("starting application")
+    var res = exec("adb " + runOnDeviceOrEmulator + " shell am start -n com.tns.android_runtime_testapp/com.tns.NativeScriptActivity -a android.intent.action.MAIN -c android.intent.category.LAUNCHER", function (error, stdout, stderr) {
+            if (error) {
+                console.error("Starting application failed: " + error);
+                process.exit(-2);
+            }
+        });
+    res.stdout.on("data", function (data) {
+        console.log("Started application successfully");
+        process.exit(0);
+    })
+}

--- a/test-app/tools/start-installed-apk.js
+++ b/test-app/tools/start-installed-apk.js
@@ -1,18 +1,15 @@
 var runner = require("./interval-runner-with-timeout.js"),
     exec = require('child_process').exec,
-    runOnDeviceOrEmulator = "-e",
+    defaultPort = require("./config.json")["emulator-port"],
+    emulatorName = "emulator-" + defaultPort + " ",
     adb = process.env.ANDROID_HOME + "/platform-tools/adb ";
-
-if(process.argv[2]) {
-	runOnDeviceOrEmulator = process.argv[2];
-}
 
 runner.runFunctionWithIntervalAndTimeout(startApk, 10 * 1000, 60 * 1000);
 
 function startApk() {
     console.log("starting application")
 
-    var res = exec(adb + runOnDeviceOrEmulator + " shell am start -n com.tns.android_runtime_testapp/com.tns.NativeScriptActivity -a android.intent.action.MAIN -c android.intent.category.LAUNCHER", function (error, stdout, stderr) {
+    var res = exec(adb + "-s " + emulatorName + " shell am start -n com.tns.android_runtime_testapp/com.tns.NativeScriptActivity -a android.intent.action.MAIN -c android.intent.category.LAUNCHER", function (error, stdout, stderr) {
             if (error) {
                 console.error("Starting application failed: " + error);
                 process.exit(-2);

--- a/test-app/tools/start-installed-apk.js
+++ b/test-app/tools/start-installed-apk.js
@@ -10,7 +10,7 @@ runner.runFunctionWithIntervalAndTimeout(startApk, 10 * 1000, 60 * 1000);
 
 function startApk() {
     console.log("starting application")
-    var res = exec("adb " + runOnDeviceOrEmulator + " shell am start -n com.tns.android_runtime_testapp/com.tns.NativeScriptActivity -a android.intent.action.MAIN -c android.intent.category.LAUNCHER", function (error, stdout, stderr) {
+    var res = exec("$ANDROID_HOME/platform-tools/adb " + runOnDeviceOrEmulator + " shell am start -n com.tns.android_runtime_testapp/com.tns.NativeScriptActivity -a android.intent.action.MAIN -c android.intent.category.LAUNCHER", function (error, stdout, stderr) {
             if (error) {
                 console.error("Starting application failed: " + error);
                 process.exit(-2);

--- a/test-app/tools/start-kill-emulator.js
+++ b/test-app/tools/start-kill-emulator.js
@@ -56,7 +56,11 @@ function stopEmulatorsAndExit() {
 
 function stopEmulators() {
     // var out = wrapedExec(adb + " devices | grep emulator | cut -f1 | while read line; do " + adb + " -s $line emu kill; done"); //kill all emulators
-    var out = wrapedExec(adb + " -s " + emulatorName + " emu kill"); //kill default emulator
+    var out = wrapedExec(adb + " -s " + emulatorName + " emu kill", function (err) {
+        if(err.toString().indexOf("Connection refused") !== -1) {
+            console.log("No emulators to kill");
+        }
+    }); //kill default emulator
     if(out && !out.stderr) {
         console.log("Killed emulator: " + emulatorName)
     }
@@ -73,10 +77,11 @@ function checkAvailable() {
     })
 }
 
-function wrapedExec(command) {
+function wrapedExec(command, errMessageCallback) {
     try {
         return execSync(command);
     } catch(e) {
+        errMessageCallback(e);
         console.log("err: " + e);
     }
 }

--- a/test-app/tools/start-kill-emulator.js
+++ b/test-app/tools/start-kill-emulator.js
@@ -46,14 +46,14 @@ function stopEmulatorsAndExit() {
 }
 
 function stopEmulators() {
-    var out = wrapedExec("adb devices | grep emulator | cut -f1 | while read line; do adb -s $line emu kill; done");
+    var out = wrapedExec("$ANDROID_HOME/platform-tools/adb devices | grep emulator | cut -f1 | while read line; do $ANDROID_HOME/platform-tools/adb -s $line emu kill; done");
     if(!out.stderr) {
         console.log("Killed emulators!")
     }
 }
 
 function checkAvailable() {
-    var out = exec("adb devices")
+    var out = exec("$ANDROID_HOME/platform-tools/adb devices")
     out.stdout.on("data", function (data) {
         if(data.indexOf("offline") === -1) {
             console.log("Emulator is online")

--- a/test-app/tools/start-kill-emulator.js
+++ b/test-app/tools/start-kill-emulator.js
@@ -1,0 +1,72 @@
+var runner = require("./interval-runner-with-timeout.js")
+
+var	execSync = require('child_process').execSync,
+    exec = require('child_process').exec;
+
+if(process.argv.length <= 2) {
+    console.log("You need to pass 'kill' or 'start'");
+    process.exit(1);
+}
+var action = process.argv[2];
+if(action === "kill") {
+    runner.runFunctionWithIntervalAndTimeout(stopEmulatorsAndExit, 1000, 10 * 1000);
+}
+else if(action === "start") {
+    //try starting emulator every 10 seconds, but try maximum of 60 seconds
+    startEmulator();
+}
+else {
+    console.log("You need to pass an action. Possible actions are 'start' and 'kill'");
+    process.exit(1);
+}
+
+function startEmulator() {
+    console.log("Stopping previous emulators if any")
+    stopEmulators();
+
+    wrapedExec("$ANDROID_HOME/platform-tools/adb start-server");
+    var emulator = "Emulator-Api19-Default"
+    if(process.argv.length < 4) {
+        console.log("You didn't specify emulator so we'll start the default one: " + emulator)
+    }
+    else {
+        emulator = process.argv[3];
+    }
+    console.log("Starting emulator " + emulator)
+    var out = exec("$ANDROID_HOME/tools/emulator -avd " + emulator + " -wipe-data -gpu on -no-window &")
+    out.stdout.on("data", function (data) {
+        console.log(data)
+        runner.runFunctionWithIntervalAndTimeout(checkAvailable, 1000, 10 * 1000);
+    })
+}
+
+function stopEmulatorsAndExit() {
+    stopEmulators();
+    process.exit(0);
+}
+
+function stopEmulators() {
+    var out = wrapedExec("adb devices | grep emulator | cut -f1 | while read line; do adb -s $line emu kill; done");
+    if(!out.stderr) {
+        console.log("Killed emulators!")
+    }
+}
+
+function checkAvailable() {
+    var out = exec("adb devices")
+    out.stdout.on("data", function (data) {
+        if(data.indexOf("offline") === -1) {
+            console.log("Emulator is online")
+            process.exit(0);
+        }
+        console.log(data)
+    })
+}
+
+function wrapedExec(command) {
+    try {
+        return execSync(command);
+    } catch(e) {
+        console.log("err: " + e);
+    }
+}

--- a/test-app/tools/start-kill-emulator.js
+++ b/test-app/tools/start-kill-emulator.js
@@ -57,7 +57,7 @@ function stopEmulatorsAndExit() {
 function stopEmulators() {
     // var out = wrapedExec(adb + " devices | grep emulator | cut -f1 | while read line; do " + adb + " -s $line emu kill; done"); //kill all emulators
     var out = wrapedExec(adb + " -s " + emulatorName + " emu kill"); //kill default emulator
-    if(!out.stderr) {
+    if(out && !out.stderr) {
         console.log("Killed emulator: " + emulatorName)
     }
 }

--- a/test-app/tools/start-kill-emulator.js
+++ b/test-app/tools/start-kill-emulator.js
@@ -26,11 +26,11 @@ function startEmulator() {
 
     wrapedExec(adb + " start-server");
     var emulator = "Emulator-Api19-Default"
-    if(process.argv.length < 4) {
+    if(!process.argv[3]) {
         console.log("You didn't specify emulator so we'll start the default one: " + emulator)
     }
     else {
-        emulator = process.argv[3];
+        emulator = process.argv[3].trim();
     }
     console.log("Starting emulator " + emulator)
     var out = exec("$ANDROID_HOME/tools/emulator -avd " + emulator + " -wipe-data -gpu on -no-window &")

--- a/test-app/tools/try_to_find_test_result_file.js
+++ b/test-app/tools/try_to_find_test_result_file.js
@@ -15,7 +15,7 @@ runner.runFunctionWithIntervalAndTimeout(checkIfAppIsRunning, searchInterval, pr
 runner.runFunctionWithIntervalAndTimeout(tryToGetFile, searchInterval, processTimeout);
 
 function checkIfAppIsRunning() {
-	exec("adb " + runOnDeviceOrEmulator + " shell \"ps | grep com.tns.android_runtime_testapp\"", checkIfProcessIsRunning);
+	exec("$ANDROID_HOME/platform-tools/adb " + runOnDeviceOrEmulator + " shell \"ps | grep com.tns.android_runtime_testapp\"", checkIfProcessIsRunning);
 }
 
 function checkIfProcessIsRunning(err, stdout, stderr) {
@@ -29,7 +29,7 @@ function checkIfProcessIsRunning(err, stdout, stderr) {
 }
 
 function tryToGetFile() {
-	pullfile = execFindFile("adb " + runOnDeviceOrEmulator + " pull /sdcard/android_unit_test_results.xml", checkIfFileExists);
+	pullfile = execFindFile("$ANDROID_HOME/platform-tools/adb " + runOnDeviceOrEmulator + " pull /sdcard/android_unit_test_results.xml", checkIfFileExists);
 	pullfile.stdout.pipe(process.stdout, { end: false });
 	pullfile.stderr.pipe(process.stderr, { end: false });
 }

--- a/test-app/tools/try_to_find_test_result_file.js
+++ b/test-app/tools/try_to_find_test_result_file.js
@@ -3,6 +3,7 @@ var execFindFile = require('child_process').exec,
 	exec = require('child_process').exec,
 	fs = require('fs'),
 	pullfile,
+	adb = process.env.ANDROID_HOME + "/platform-tools/adb ",
 	processTimeout = 20 * 60 * 1000, // 20 minutes timeout (empirical constant :)) 
 	searchInterval = 10 * 1000;
 
@@ -15,7 +16,7 @@ runner.runFunctionWithIntervalAndTimeout(checkIfAppIsRunning, searchInterval, pr
 runner.runFunctionWithIntervalAndTimeout(tryToGetFile, searchInterval, processTimeout);
 
 function checkIfAppIsRunning() {
-	exec("$ANDROID_HOME/platform-tools/adb " + runOnDeviceOrEmulator + " shell \"ps | grep com.tns.android_runtime_testapp\"", checkIfProcessIsRunning);
+	exec(adb + runOnDeviceOrEmulator + " shell \"ps | grep com.tns.android_runtime_testapp\"", checkIfProcessIsRunning);
 }
 
 function checkIfProcessIsRunning(err, stdout, stderr) {
@@ -29,7 +30,7 @@ function checkIfProcessIsRunning(err, stdout, stderr) {
 }
 
 function tryToGetFile() {
-	pullfile = execFindFile("$ANDROID_HOME/platform-tools/adb " + runOnDeviceOrEmulator + " pull /sdcard/android_unit_test_results.xml", checkIfFileExists);
+	pullfile = execFindFile(adb + runOnDeviceOrEmulator + " pull /sdcard/android_unit_test_results.xml", checkIfFileExists);
 	pullfile.stdout.pipe(process.stdout, { end: false });
 	pullfile.stderr.pipe(process.stderr, { end: false });
 }

--- a/test-app/tools/try_to_find_test_result_file.js
+++ b/test-app/tools/try_to_find_test_result_file.js
@@ -1,22 +1,19 @@
 var execFindFile = require('child_process').exec,
 	runner = require("./interval-runner-with-timeout.js"),
 	exec = require('child_process').exec,
+	defaultPort = require("./config.json")["emulator-port"],
+    emulatorName = "emulator-" + defaultPort + " ",
 	fs = require('fs'),
 	pullfile,
 	adb = process.env.ANDROID_HOME + "/platform-tools/adb ",
 	processTimeout = 20 * 60 * 1000, // 20 minutes timeout (empirical constant :)) 
 	searchInterval = 10 * 1000;
 
-var runOnDeviceOrEmulator = "-e";
-if(process.argv[2]) {
-	runOnDeviceOrEmulator = process.argv[2];
-}
-
 runner.runFunctionWithIntervalAndTimeout(checkIfAppIsRunning, searchInterval, processTimeout);
 runner.runFunctionWithIntervalAndTimeout(tryToGetFile, searchInterval, processTimeout);
 
 function checkIfAppIsRunning() {
-	exec(adb + runOnDeviceOrEmulator + " shell \"ps | grep com.tns.android_runtime_testapp\"", checkIfProcessIsRunning);
+	exec(adb + "-s " + emulatorName + " shell \"ps | grep com.tns.android_runtime_testapp\"", checkIfProcessIsRunning);
 }
 
 function checkIfProcessIsRunning(err, stdout, stderr) {
@@ -30,13 +27,12 @@ function checkIfProcessIsRunning(err, stdout, stderr) {
 }
 
 function tryToGetFile() {
-	pullfile = execFindFile(adb + runOnDeviceOrEmulator + " pull /sdcard/android_unit_test_results.xml", checkIfFileExists);
+	pullfile = execFindFile(adb + "-s " + emulatorName + " pull /sdcard/android_unit_test_results.xml", checkIfFileExists);
 	pullfile.stdout.pipe(process.stdout, { end: false });
 	pullfile.stderr.pipe(process.stderr, { end: false });
 }
 
 function checkIfFileExists(err, stout, stderr) {
-
 	//if you find file in sdcard exit process
 	if (!err) {
 		console.log('Tests results file found file!');


### PR DESCRIPTION
_New behavior_
* cleans environment before every build
* the `runTests` command depends that the default command was ran before starting the tests and can now be started from the root build.gradle

_Usage_
`cd android-runtime`

To build: run `./gradlew` or `gradlew.bat` for windows (this will clean all project and delete the `dist` folder where some artifacts and the `tns-android.tgz` is generated)

To run tests: run `./gradlew runTests` (this command will run all projects tests and will expect an emulator to be running)

_Edit_:
automized running tests                  
* if no emulator is passed to `runTests` command with `-PemulatorName=<emulator_name>` the build runs the default emulator which is `Emulator-Api19-Default`
* the runTests command is now responsible for running the emulator and stopping it after all tests are finished; this includes timeouts for each command concerning the emulators;
* if a a timeout is reached we exit the process with exit code different than 0 and the build faiils

Ping: @pkoleva 