### PR TITLE
Fix problematic error activity style for devices <21

### DIFF
--- a/build-artifacts/project-template-gradle/src/debug/res/layout/error_activity.xml
+++ b/build-artifacts/project-template-gradle/src/debug/res/layout/error_activity.xml
@@ -11,8 +11,7 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:minHeight="?attr/actionBarSize"
-        app:popupTheme="?android:attr/statusBarColor"/>
+        android:minHeight="?attr/actionBarSize"/>
 
     <android.support.v4.view.ViewPager
         android:id="@+id/pager"
@@ -30,7 +29,6 @@
         android:background="?attr/colorPrimary"
         android:minHeight="?attr/actionBarSize"
         app:tabIndicatorColor="@color/nativescript_blue"
-        app:tabBackground="?android:attr/statusBarColor"
         android:layout_alignParentTop="true"
         android:layout_alignParentStart="true"
         android:scrollbarStyle="insideOverlay"

--- a/test-app/app/src/main/res/layout/error_activity.xml
+++ b/test-app/app/src/main/res/layout/error_activity.xml
@@ -12,7 +12,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="?attr/actionBarSize"
-        android:background="?android:attr/statusBarColor"
         android:layout_alignBottom="@+id/tabLayout"/>
 
     <android.support.v4.view.ViewPager
@@ -31,7 +30,6 @@
         android:background="?attr/colorPrimary"
         android:minHeight="?attr/actionBarSize"
         app:tabIndicatorColor="@color/nativescript_blue"
-        app:tabBackground="?android:attr/statusBarColor"
         android:layout_alignParentTop="true"
         android:layout_alignParentStart="true"
         android:scrollbarStyle="insideOverlay"


### PR DESCRIPTION
At some occasions when inflating the error activity with data that caused the crash, the error activity itself would crash on devices with older versions of android, because the style used for some of the UI components is available only 21 and up.