### PR TITLE
Add removal of build and configurations dirs when performing full clean

### DIFF
--- a/build-artifacts/project-template-gradle/build.gradle
+++ b/build-artifacts/project-template-gradle/build.gradle
@@ -789,7 +789,11 @@ task deleteFlavors (type: Delete){
 	}
 }
 
+task deleteConfigurations (type: Delete) {
+	delete "$projectDir/configurations"
+}
+
 deleteMetadata.dependsOn(":asbg:clean")
 deleteFlavors.dependsOn(deleteMetadata)
-clean.dependsOn(deleteFlavors)
-
+deleteConfigurations.dependsOn(deleteFlavors)
+clean.dependsOn(deleteConfigurations)


### PR DESCRIPTION
It is sometimes necessary to reset the platforms to a clean slate. It is done by deleting the `build` and plugin `configurations` directories when performing clean in addition to the flavored plugins, and the removal of the original code from `tns_modules`.

Such cases are when removing a plugin with android platform-specific libraries (jars, aars)