### PR TITLE
Check for module with .js in the name before attempting to resolve file

### DIFF
--- a/runtime/src/main/java/com/tns/Module.java
+++ b/runtime/src/main/java/com/tns/Module.java
@@ -179,6 +179,7 @@ class Module
 		File foundModule = null;
 
 		foundModule = loadAsFile(fileOrDirectory);
+
 		if(foundModule != null) {
 			return foundModule;
 		}
@@ -198,6 +199,8 @@ class Module
 		//cache resolved directory
 		if(foundModule != null) {
 			folderAsModuleCache.put(fileOrDirectory.getCanonicalPath(), foundModule.getCanonicalPath());
+
+			return foundModule;
 		}
 
 		return foundModule;
@@ -222,7 +225,8 @@ class Module
 
 		File foundFile = new File(path.getAbsolutePath() + fallbackExtension);
 		try {
-			if(foundFile.getCanonicalFile().exists()) {
+			File canonicalFile = foundFile.getCanonicalFile();
+			if (canonicalFile.exists() && canonicalFile.isFile()) {
                 return foundFile;
             }
 		} catch (IOException e) {


### PR DESCRIPTION
Moved around logic for resolving modules when requiring to first check if the resolved file is an actual file, or we are trying to load a directory.

This is necessary when dealing with folders that may contain character sequences that look like file extensions, (`hash.js` is a module, not a standalone script) while not breaking https://github.com/NativeScript/common-runtime-tests-app/blob/master/Require/index.js#L204 as resolution for directories will succeed only if they contain a `package.json` or an `index.js`

Tests added at https://github.com/NativeScript/common-runtime-tests-app/pull/21

Addresses https://github.com/NativeScript/android-runtime/issues/666