### PR TITLE
Fix issue #665

### DIFF
--- a/android-static-binding-generator/project/staticbindinggenerator/build.gradle
+++ b/android-static-binding-generator/project/staticbindinggenerator/build.gradle
@@ -13,6 +13,9 @@ allprojects {
 }
 
 dependencies {
+    sourceCompatibility = 1.7
+    targetCompatibility = 1.7
+
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.+'
     testCompile 'commons-io:commons-io:2.5'

--- a/android-static-binding-generator/project/staticbindinggenerator/src/main/java/org/nativescript/staticbindinggenerator/ClassInfo.java
+++ b/android-static-binding-generator/project/staticbindinggenerator/src/main/java/org/nativescript/staticbindinggenerator/ClassInfo.java
@@ -129,7 +129,10 @@ class ClassInfo implements com.tns.bindings.desc.ClassDescriptor {
     public ClassDescriptor getSuperclass() {
         ClassDescriptor superClass = null;
         if (!isArray() && !isPrimitive() && !getName().equals("java.lang.Object")) {
-            superClass = new ClassInfo(generator.getClasses().get(clazz.getSuperclassName()), generator);
+            String javaClassName = clazz.getSuperclassName().replace('$', '.');
+            JavaClass javaClass = generator.getClasses().get(javaClassName);
+
+            superClass = new ClassInfo(javaClass, generator);
         }
         return superClass;
     }


### PR DESCRIPTION
`getSuperclass()` would cause the binding-generator to crash when the super class of the current class is inner or static as the class entries are recorded in a Map object with a `.` class separator, and not a `$`

Addresses #665 