### PR TITLE
Fix debugger not breaking on devices

### DIFF
--- a/runtime/src/main/jni/JsV8InspectorClient.cpp
+++ b/runtime/src/main/jni/JsV8InspectorClient.cpp
@@ -23,7 +23,8 @@ JsV8InspectorClient::JsV8InspectorClient(v8::Isolate *isolate)
           inspector_(nullptr),
           session_(nullptr),
           connection(nullptr),
-          context_()
+          context_(),
+          running_nested_loop_(false)
 {
     JEnv env;
 


### PR DESCRIPTION
A boolean flag used in our debugger client implementation wasn't being initialized properly and as a result the debugger didn't work consistently.

ping @pkoleva 