### PR TITLE
expand max jvm memory

### DIFF
--- a/build-artifacts/project-template-gradle/gradle.properties
+++ b/build-artifacts/project-template-gradle/gradle.properties
@@ -1,2 +1,2 @@
 android.useDeprecatedNdk = true
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx16384M


### PR DESCRIPTION
Put max memory to 16gb to enable gradle to take as much space as it needs to build fast. Gradle message gives warning with recommendation for 1.5 gb max memory, but CI can take advantage of gradle daemon.
