### PR TITLE
Patch devtools console crash

### DIFF
--- a/runtime/src/main/jni/v8_inspector/src/inspector/v8-debugger.cc
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/v8-debugger.cc
@@ -894,7 +894,7 @@ std::unique_ptr<V8StackTraceImpl> V8Debugger::createStackTrace(
     v8::Local<v8::StackTrace> stackTrace) {
   int contextGroupId =
       m_isolate->InContext() ? getGroupId(m_isolate->GetCurrentContext()) : 0;
-  return V8StackTraceImpl::create(this, contextGroupId, stackTrace,
+  return V8StackTraceImpl::create(m_isolate, this, contextGroupId, stackTrace,
                                   V8StackTraceImpl::maxCallStackSizeToCapture);
 }
 

--- a/runtime/src/main/jni/v8_inspector/src/inspector/v8-stack-trace-impl.cc
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/v8-stack-trace-impl.cc
@@ -105,11 +105,11 @@ void V8StackTraceImpl::setCaptureStackTraceForUncaughtExceptions(
 }
 
 // static
-std::unique_ptr<V8StackTraceImpl> V8StackTraceImpl::create(
+std::unique_ptr<V8StackTraceImpl> V8StackTraceImpl::create(v8::Isolate *isolate,
     V8Debugger* debugger, int contextGroupId,
     v8::Local<v8::StackTrace> stackTrace, size_t maxStackSize,
     const String16& description) {
-  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+
   v8::HandleScope scope(isolate);
   std::vector<V8StackTraceImpl::Frame> frames;
   if (!stackTrace.IsEmpty())
@@ -170,7 +170,7 @@ std::unique_ptr<V8StackTraceImpl> V8StackTraceImpl::capture(
     stackTrace = v8::StackTrace::CurrentStackTrace(
         isolate, static_cast<int>(maxStackSize), stackTraceOptions);
   }
-  return V8StackTraceImpl::create(debugger, contextGroupId, stackTrace,
+  return V8StackTraceImpl::create(isolate, debugger, contextGroupId, stackTrace,
                                   maxStackSize, description);
 }
 
@@ -247,7 +247,7 @@ V8StackTraceImpl::buildInspectorObjectForTail(V8Debugger* debugger) const {
   v8::HandleScope handleScope(v8::Isolate::GetCurrent());
   // Next call collapses possible empty stack and ensures
   // maxAsyncCallChainDepth.
-  std::unique_ptr<V8StackTraceImpl> fullChain = V8StackTraceImpl::create(
+  std::unique_ptr<V8StackTraceImpl> fullChain = V8StackTraceImpl::create(v8::Isolate::GetCurrent(),
       debugger, m_contextGroupId, v8::Local<v8::StackTrace>(),
       V8StackTraceImpl::maxCallStackSizeToCapture);
   if (!fullChain || !fullChain->m_parent) return nullptr;

--- a/runtime/src/main/jni/v8_inspector/src/inspector/v8-stack-trace-impl.h
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/v8-stack-trace-impl.h
@@ -54,7 +54,7 @@ class V8StackTraceImpl final : public V8StackTrace {
 
   static void setCaptureStackTraceForUncaughtExceptions(v8::Isolate*,
                                                         bool capture);
-  static std::unique_ptr<V8StackTraceImpl> create(
+  static std::unique_ptr<V8StackTraceImpl> create(v8::Isolate* isolate,
       V8Debugger*, int contextGroupId, v8::Local<v8::StackTrace>,
       size_t maxStackSize, const String16& description = String16());
   static std::unique_ptr<V8StackTraceImpl> capture(

--- a/tools/astyle.js
+++ b/tools/astyle.js
@@ -8,7 +8,7 @@ const validFiles = ['c', 'cpp', 'h', 'java'];
 // let dateString = `${date.getDay() + 1}-${date.getMonth() + 1}-${date.getFullYear()}--${date.getHours()}:${date.getMinutes()}`
 // let backupDir = `formatbackup-${dateString}`;
 
-let astyleOptions = "--style=java -H -k1 -j -C -s4 -xi -n" // "--options=tools\\.astyle"
+let astyleOptions = "--style=java -H -k1 -j -C -s4 -xi -n --exclude=\"runtime/src/main/jni/include\" --exclude=\"runtime/src/main/jni/v8_inspector\"" // "--options=tools\\.astyle"
 let astyle = "astyle";
 
 if (process.platform.indexOf("win") === 0) {


### PR DESCRIPTION
Patch the inspector stack-trace implementation to not crash when an exception is thrown during script evaluation in the Chrome DevTools console. 

Opened related issue with suggestions in the v8 bug tracker - https://bugs.chromium.org/p/v8/issues/detail?id=5907

Addresses #695 

Tested in both Chrome DevTools and the official VSCode extension.