### PR TITLE
DevTools Page Agent implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 local.properties
 
 gen/
+scratch/
 obj/
 bin/
 .svn/

--- a/runtime/src/main/java/com/tns/AndroidJsV8Inspector.java
+++ b/runtime/src/main/java/com/tns/AndroidJsV8Inspector.java
@@ -17,15 +17,13 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import fi.iki.elonen.NanoHTTPD;
 import fi.iki.elonen.NanoWSD;
 
 class AndroidJsV8Inspector {
-    private static boolean DEBUG_LOG_ENABLED = true;
+    private static boolean DEBUG_LOG_ENABLED = false;
 
     private JsV8InspectorServer server;
     private Context context;

--- a/runtime/src/main/java/com/tns/AndroidJsV8Inspector.java
+++ b/runtime/src/main/java/com/tns/AndroidJsV8Inspector.java
@@ -140,7 +140,7 @@ class AndroidJsV8Inspector {
     private static String getMimeType(String url) {
         String type = null;
         String extension = MimeTypeMap.getFileExtensionFromUrl(url);
-        if (extension != null) {
+        if (!extension.isEmpty()) {
             type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
 
             // getMimeType may sometime return incorrect results in the context of NativeScript

--- a/runtime/src/main/java/com/tns/AndroidJsV8Inspector.java
+++ b/runtime/src/main/java/com/tns/AndroidJsV8Inspector.java
@@ -3,12 +3,20 @@ package com.tns;
 import android.content.Context;
 import android.os.Handler;
 import android.util.Log;
+import android.util.Pair;
+import android.webkit.MimeTypeMap;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -16,27 +24,27 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import fi.iki.elonen.NanoHTTPD;
 import fi.iki.elonen.NanoWSD;
 
-public class AndroidJsV8Inspector {
-    private static boolean DEBUG_LOG_ENABLED = false;
+class AndroidJsV8Inspector {
+    private static boolean DEBUG_LOG_ENABLED = true;
 
     private JsV8InspectorServer server;
-    private Logger logger;
     private Context context;
+    private static String applicationDir;
 
     protected native final void init();
 
     protected native final void connect(Object connection);
 
-    protected static native final void disconnect();
+    protected static native void disconnect();
 
     protected native final void dispatchMessage(String message);
 
-    protected Handler mainHandler;
+    private Handler mainHandler;
     private LinkedBlockingQueue<String> inspectorMessages = new LinkedBlockingQueue<String>();
 
-    public AndroidJsV8Inspector(Context context, Logger logger) {
+    AndroidJsV8Inspector(Context context, Logger logger) {
         this.context = context;
-        this.logger = logger;
+        applicationDir = context.getFilesDir().getAbsolutePath();
     }
 
     public void start() throws IOException {
@@ -45,7 +53,7 @@ public class AndroidJsV8Inspector {
 
             mainHandler = currentRuntime.getHandler();
 
-            this.server = new JsV8InspectorServer(context.getPackageName() + "-inspectorServer");
+            this.server = new JsV8InspectorServer(this.context.getPackageName() + "-inspectorServer");
             this.server.start(-1);
 
             if (DEBUG_LOG_ENABLED) {
@@ -91,6 +99,75 @@ public class AndroidJsV8Inspector {
     @RuntimeCallable
     private static String getInspectorMessage(Object connection) {
         return ((JsV8InspectorWebSocket) connection).getInspectorMessage();
+    }
+
+    @RuntimeCallable
+    public static Pair<String, String>[] getPageResources() {
+        // necessary to align the data dir returned by context (emulator) and that used by the v8 inspector
+        if (applicationDir.startsWith("/data/user/0/")) {
+            applicationDir = applicationDir.replaceFirst("/data/user/0/", "/data/data/");
+        }
+
+        String dataDir = applicationDir;
+        File rootFilesDir = new File(dataDir, "app");
+
+
+        List<Pair<String, String>> resources = traverseResources(rootFilesDir);
+
+        return resources.toArray((Pair<String, String>[]) Array.newInstance(resources.get(0).getClass(), resources.size()));
+    }
+
+    private static List<Pair<String, String>> traverseResources(File dir) {
+        List<Pair<String, String>> resources = new ArrayList<>();
+
+        Queue<File> directories = new LinkedList<>();
+        directories.add(dir);
+
+        while (!directories.isEmpty()) {
+            File currentDir = directories.poll();
+
+            File[] files = currentDir.listFiles();
+            for (File file : files) {
+                if (file.isDirectory()) {
+                    directories.add(file);
+                } else {
+                    resources.add(new Pair<>("file://" + file.getAbsolutePath(), getMimeType(file.getAbsolutePath())));
+                }
+            }
+        }
+
+        return resources;
+    }
+
+    private static String getMimeType(String url) {
+        String type = null;
+        String extension = MimeTypeMap.getFileExtensionFromUrl(url);
+        if (extension != null) {
+            type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
+
+            // getMimeType may sometime return incorrect results in the context of NativeScript
+            // e.g. `.ts` returns video/MP2TS
+            switch (extension) {
+            case "js":
+                type = "text/javascript";
+                break;
+            case "json":
+                type = "application/json";
+                break;
+            case "css":
+                type = "text/css";
+                break;
+            case "ts":
+                type = "text/typescript";
+                break;
+            // handle shared libraries so they are marked properly and don't appear in the sources tab
+            case "so":
+                type = "application/binary";
+                break;
+            }
+        }
+
+        return type;
     }
 
     class JsV8InspectorServer extends NanoWSD {

--- a/runtime/src/main/jni/v8_inspector/src/inspector/js_protocol.json
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/js_protocol.json
@@ -1,997 +1,1429 @@
 {
     "version": { "major": "1", "minor": "2" },
     "domains": [
-    {
-        "domain": "Schema",
-        "description": "Provides information about the protocol schema.",
-        "types": [
-            {
-                "id": "Domain",
-                "type": "object",
-                "description": "Description of the protocol domain.",
-                "exported": true,
-                "properties": [
-                    { "name": "name", "type": "string", "description": "Domain name." },
-                    { "name": "version", "type": "string", "description": "Domain version." }
-                ]
-            }
-        ],
-        "commands": [
-            {
-                "name": "getDomains",
-                "description": "Returns supported domains.",
-                "handlers": ["browser", "renderer"],
-                "returns": [
-                    { "name": "domains", "type": "array", "items": { "$ref": "Domain" }, "description": "List of supported domains." }
-                ]
-            }
-        ]
-    },
-    {
-        "domain": "Runtime",
-        "description": "Runtime domain exposes JavaScript runtime by means of remote evaluation and mirror objects. Evaluation results are returned as mirror object that expose object type, string representation and unique identifier that can be used for further object reference. Original objects are maintained in memory unless they are either explicitly released or are released along with the other objects in their object group.",
-        "types": [
-            {
-                "id": "ScriptId",
-                "type": "string",
-                "description": "Unique script identifier."
-            },
-            {
-                "id": "RemoteObjectId",
-                "type": "string",
-                "description": "Unique object identifier."
-            },
-            {
-                "id": "UnserializableValue",
-                "type": "string",
-                "enum": ["Infinity", "NaN", "-Infinity", "-0"],
-                "description": "Primitive value which cannot be JSON-stringified."
-            },
-            {
-                "id": "RemoteObject",
-                "type": "object",
-                "description": "Mirror object referencing original JavaScript object.",
-                "exported": true,
-                "properties": [
-                    { "name": "type", "type": "string", "enum": ["object", "function", "undefined", "string", "number", "boolean", "symbol"], "description": "Object type." },
-                    { "name": "subtype", "type": "string", "optional": true, "enum": ["array", "null", "node", "regexp", "date", "map", "set", "iterator", "generator", "error", "proxy", "promise", "typedarray"], "description": "Object subtype hint. Specified for <code>object</code> type values only." },
-                    { "name": "className", "type": "string", "optional": true, "description": "Object class (constructor) name. Specified for <code>object</code> type values only." },
-                    { "name": "value", "type": "any", "optional": true, "description": "Remote object value in case of primitive values or JSON values (if it was requested)." },
-                    { "name": "unserializableValue", "$ref": "UnserializableValue", "optional": true, "description": "Primitive value which can not be JSON-stringified does not have <code>value</code>, but gets this property." },
-                    { "name": "description", "type": "string", "optional": true, "description": "String representation of the object." },
-                    { "name": "objectId", "$ref": "RemoteObjectId", "optional": true, "description": "Unique object identifier (for non-primitive values)." },
-                    { "name": "preview", "$ref": "ObjectPreview", "optional": true, "description": "Preview containing abbreviated property values. Specified for <code>object</code> type values only.", "experimental": true },
-                    { "name": "customPreview", "$ref": "CustomPreview", "optional": true, "experimental": true}
-                ]
-            },
-            {
-                "id": "CustomPreview",
-                "type": "object",
-                "experimental": true,
-                "properties": [
-                    { "name": "header", "type": "string"},
-                    { "name": "hasBody", "type": "boolean"},
-                    { "name": "formatterObjectId", "$ref": "RemoteObjectId"},
-                    { "name": "bindRemoteObjectFunctionId", "$ref": "RemoteObjectId" },
-                    { "name": "configObjectId", "$ref": "RemoteObjectId", "optional": true }
-                ]
-            },
-            {
-                "id": "ObjectPreview",
-                "type": "object",
-                "experimental": true,
-                "description": "Object containing abbreviated remote object value.",
-                "properties": [
-                    { "name": "type", "type": "string", "enum": ["object", "function", "undefined", "string", "number", "boolean", "symbol"], "description": "Object type." },
-                    { "name": "subtype", "type": "string", "optional": true, "enum": ["array", "null", "node", "regexp", "date", "map", "set", "iterator", "generator", "error"], "description": "Object subtype hint. Specified for <code>object</code> type values only." },
-                    { "name": "description", "type": "string", "optional": true, "description": "String representation of the object." },
-                    { "name": "overflow", "type": "boolean", "description": "True iff some of the properties or entries of the original object did not fit." },
-                    { "name": "properties", "type": "array", "items": { "$ref": "PropertyPreview" }, "description": "List of the properties." },
-                    { "name": "entries", "type": "array", "items": { "$ref": "EntryPreview" }, "optional": true, "description": "List of the entries. Specified for <code>map</code> and <code>set</code> subtype values only." }
-                ]
-            },
-            {
-                "id": "PropertyPreview",
-                "type": "object",
-                "experimental": true,
-                "properties": [
-                    { "name": "name", "type": "string", "description": "Property name." },
-                    { "name": "type", "type": "string", "enum": ["object", "function", "undefined", "string", "number", "boolean", "symbol", "accessor"], "description": "Object type. Accessor means that the property itself is an accessor property." },
-                    { "name": "value", "type": "string", "optional": true, "description": "User-friendly property value string." },
-                    { "name": "valuePreview", "$ref": "ObjectPreview", "optional": true, "description": "Nested value preview." },
-                    { "name": "subtype", "type": "string", "optional": true, "enum": ["array", "null", "node", "regexp", "date", "map", "set", "iterator", "generator", "error"], "description": "Object subtype hint. Specified for <code>object</code> type values only." }
-                ]
-            },
-            {
-                "id": "EntryPreview",
-                "type": "object",
-                "experimental": true,
-                "properties": [
-                    { "name": "key", "$ref": "ObjectPreview", "optional": true, "description": "Preview of the key. Specified for map-like collection entries." },
-                    { "name": "value", "$ref": "ObjectPreview", "description": "Preview of the value." }
-                ]
-            },
-            {
-                "id": "PropertyDescriptor",
-                "type": "object",
-                "description": "Object property descriptor.",
-                "properties": [
-                    { "name": "name", "type": "string", "description": "Property name or symbol description." },
-                    { "name": "value", "$ref": "RemoteObject", "optional": true, "description": "The value associated with the property." },
-                    { "name": "writable", "type": "boolean", "optional": true, "description": "True if the value associated with the property may be changed (data descriptors only)." },
-                    { "name": "get", "$ref": "RemoteObject", "optional": true, "description": "A function which serves as a getter for the property, or <code>undefined</code> if there is no getter (accessor descriptors only)." },
-                    { "name": "set", "$ref": "RemoteObject", "optional": true, "description": "A function which serves as a setter for the property, or <code>undefined</code> if there is no setter (accessor descriptors only)." },
-                    { "name": "configurable", "type": "boolean", "description": "True if the type of this property descriptor may be changed and if the property may be deleted from the corresponding object." },
-                    { "name": "enumerable", "type": "boolean", "description": "True if this property shows up during enumeration of the properties on the corresponding object." },
-                    { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." },
-                    { "name": "isOwn", "optional": true, "type": "boolean", "description": "True if the property is owned for the object." },
-                    { "name": "symbol", "$ref": "RemoteObject", "optional": true, "description": "Property symbol object, if the property is of the <code>symbol</code> type." }
-                ]
-            },
-            {
-                "id": "InternalPropertyDescriptor",
-                "type": "object",
-                "description": "Object internal property descriptor. This property isn't normally visible in JavaScript code.",
-                "properties": [
-                    { "name": "name", "type": "string", "description": "Conventional property name." },
-                    { "name": "value", "$ref": "RemoteObject", "optional": true, "description": "The value associated with the property." }
-                ]
-            },
-            {
-                "id": "CallArgument",
-                "type": "object",
-                "description": "Represents function call argument. Either remote object id <code>objectId</code>, primitive <code>value</code>, unserializable primitive value or neither of (for undefined) them should be specified.",
-                "properties": [
-                    { "name": "value", "type": "any", "optional": true, "description": "Primitive value." },
-                    { "name": "unserializableValue", "$ref": "UnserializableValue", "optional": true, "description": "Primitive value which can not be JSON-stringified." },
-                    { "name": "objectId", "$ref": "RemoteObjectId", "optional": true, "description": "Remote object handle." }
-                ]
-            },
-            {
-                "id": "ExecutionContextId",
-                "type": "integer",
-                "description": "Id of an execution context."
-            },
-            {
-                "id": "ExecutionContextDescription",
-                "type": "object",
-                "description": "Description of an isolated world.",
-                "properties": [
-                    { "name": "id", "$ref": "ExecutionContextId", "description": "Unique id of the execution context. It can be used to specify in which execution context script evaluation should be performed." },
-                    { "name": "origin", "type": "string", "description": "Execution context origin." },
-                    { "name": "name", "type": "string", "description": "Human readable name describing given context." },
-                    { "name": "auxData", "type": "object", "optional": true, "description": "Embedder-specific auxiliary data." }
-                ]
-            },
-            {
-                "id": "ExceptionDetails",
-                "type": "object",
-                "description": "Detailed information about exception (or error) that was thrown during script compilation or execution.",
-                "properties": [
-                    { "name": "exceptionId", "type": "integer", "description": "Exception id." },
-                    { "name": "text", "type": "string", "description": "Exception text, which should be used together with exception object when available." },
-                    { "name": "lineNumber", "type": "integer", "description": "Line number of the exception location (0-based)." },
-                    { "name": "columnNumber", "type": "integer", "description": "Column number of the exception location (0-based)." },
-                    { "name": "scriptId", "$ref": "ScriptId", "optional": true, "description": "Script ID of the exception location." },
-                    { "name": "url", "type": "string", "optional": true, "description": "URL of the exception location, to be used when the script was not reported." },
-                    { "name": "stackTrace", "$ref": "StackTrace", "optional": true, "description": "JavaScript stack trace if available." },
-                    { "name": "exception", "$ref": "RemoteObject", "optional": true, "description": "Exception object if available." },
-                    { "name": "executionContextId", "$ref": "ExecutionContextId", "optional": true, "description": "Identifier of the context where exception happened." }
-                ]
-            },
-            {
-                "id": "Timestamp",
-                "type": "number",
-                "description": "Number of milliseconds since epoch."
-            },
-            {
-                "id": "CallFrame",
-                "type": "object",
-                "description": "Stack entry for runtime errors and assertions.",
-                "properties": [
-                    { "name": "functionName", "type": "string", "description": "JavaScript function name." },
-                    { "name": "scriptId", "$ref": "ScriptId", "description": "JavaScript script id." },
-                    { "name": "url", "type": "string", "description": "JavaScript script name or url." },
-                    { "name": "lineNumber", "type": "integer", "description": "JavaScript script line number (0-based)." },
-                    { "name": "columnNumber", "type": "integer", "description": "JavaScript script column number (0-based)." }
-                ]
-            },
-            {
-                "id": "StackTrace",
-                "type": "object",
-                "description": "Call frames for assertions or error messages.",
-                "exported": true,
-                "properties": [
-                    { "name": "description", "type": "string", "optional": true, "description": "String label of this stack trace. For async traces this may be a name of the function that initiated the async call." },
-                    { "name": "callFrames", "type": "array", "items": { "$ref": "CallFrame" }, "description": "JavaScript function name." },
-                    { "name": "parent", "$ref": "StackTrace", "optional": true, "description": "Asynchronous JavaScript stack trace that preceded this stack, if available." }
-                ]
-            }
-        ],
-        "commands": [
-            {
-                "name": "evaluate",
-                "async": true,
-                "parameters": [
-                    { "name": "expression", "type": "string", "description": "Expression to evaluate." },
-                    { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." },
-                    { "name": "includeCommandLineAPI", "type": "boolean", "optional": true, "description": "Determines whether Command Line API should be available during the evaluation." },
-                    { "name": "silent", "type": "boolean", "optional": true, "description": "In silent mode exceptions thrown during evaluation are not reported and do not pause execution. Overrides <code>setPauseOnException</code> state." },
-                    { "name": "contextId", "$ref": "ExecutionContextId", "optional": true, "description": "Specifies in which execution context to perform evaluation. If the parameter is omitted the evaluation will be performed in the context of the inspected page." },
-                    { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object that should be sent by value." },
-                    { "name": "generatePreview", "type": "boolean", "optional": true, "experimental": true, "description": "Whether preview should be generated for the result." },
-                    { "name": "userGesture", "type": "boolean", "optional": true, "experimental": true, "description": "Whether execution should be treated as initiated by user in the UI." },
-                    { "name": "awaitPromise", "type": "boolean", "optional":true, "description": "Whether execution should wait for promise to be resolved. If the result of evaluation is not a Promise, it's considered to be an error." }
-                ],
-                "returns": [
-                    { "name": "result", "$ref": "RemoteObject", "description": "Evaluation result." },
-                    { "name": "exceptionDetails", "$ref": "ExceptionDetails", "optional": true, "description": "Exception details."}
-                ],
-                "description": "Evaluates expression on global object."
-            },
-            {
-                "name": "awaitPromise",
-                "async": true,
-                "parameters": [
-                    { "name": "promiseObjectId", "$ref": "RemoteObjectId", "description": "Identifier of the promise." },
-                    { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object that should be sent by value." },
-                    { "name": "generatePreview", "type": "boolean", "optional": true, "description": "Whether preview should be generated for the result." }
-                ],
-                "returns": [
-                    { "name": "result", "$ref": "RemoteObject", "description": "Promise result. Will contain rejected value if promise was rejected." },
-                    { "name": "exceptionDetails", "$ref": "ExceptionDetails", "optional": true, "description": "Exception details if stack strace is available."}
-                ],
-                "description": "Add handler to promise with given promise object id."
-            },
-            {
-                "name": "callFunctionOn",
-                "async": true,
-                "parameters": [
-                    { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to call function on." },
-                    { "name": "functionDeclaration", "type": "string", "description": "Declaration of the function to call." },
-                    { "name": "arguments", "type": "array", "items": { "$ref": "CallArgument", "description": "Call argument." }, "optional": true, "description": "Call arguments. All call arguments must belong to the same JavaScript world as the target object." },
-                    { "name": "silent", "type": "boolean", "optional": true, "description": "In silent mode exceptions thrown during evaluation are not reported and do not pause execution. Overrides <code>setPauseOnException</code> state." },
-                    { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object which should be sent by value." },
-                    { "name": "generatePreview", "type": "boolean", "optional": true, "experimental": true, "description": "Whether preview should be generated for the result." },
-                    { "name": "userGesture", "type": "boolean", "optional": true, "experimental": true, "description": "Whether execution should be treated as initiated by user in the UI." },
-                    { "name": "awaitPromise", "type": "boolean", "optional":true, "description": "Whether execution should wait for promise to be resolved. If the result of evaluation is not a Promise, it's considered to be an error." }
-                ],
-                "returns": [
-                    { "name": "result", "$ref": "RemoteObject", "description": "Call result." },
-                    { "name": "exceptionDetails", "$ref": "ExceptionDetails", "optional": true, "description": "Exception details."}
-                ],
-                "description": "Calls function with given declaration on the given object. Object group of the result is inherited from the target object."
-            },
-            {
-                "name": "getProperties",
-                "parameters": [
-                    { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to return properties for." },
-                    { "name": "ownProperties", "optional": true, "type": "boolean", "description": "If true, returns properties belonging only to the element itself, not to its prototype chain." },
-                    { "name": "accessorPropertiesOnly", "optional": true, "type": "boolean", "description": "If true, returns accessor properties (with getter/setter) only; internal properties are not returned either.", "experimental": true },
-                    { "name": "generatePreview", "type": "boolean", "optional": true, "experimental": true, "description": "Whether preview should be generated for the results." }
-                ],
-                "returns": [
-                    { "name": "result", "type": "array", "items": { "$ref": "PropertyDescriptor" }, "description": "Object properties." },
-                    { "name": "internalProperties", "optional": true, "type": "array", "items": { "$ref": "InternalPropertyDescriptor" }, "description": "Internal object properties (only of the element itself)." },
-                    { "name": "exceptionDetails", "$ref": "ExceptionDetails", "optional": true, "description": "Exception details."}
-                ],
-                "description": "Returns properties of a given object. Object group of the result is inherited from the target object."
-            },
-            {
-                "name": "releaseObject",
-                "parameters": [
-                    { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to release." }
-                ],
-                "description": "Releases remote object with given id."
-            },
-            {
-                "name": "releaseObjectGroup",
-                "parameters": [
-                    { "name": "objectGroup", "type": "string", "description": "Symbolic object group name." }
-                ],
-                "description": "Releases all remote objects that belong to a given group."
-            },
-            {
-                "name": "runIfWaitingForDebugger",
-                "description": "Tells inspected instance to run if it was waiting for debugger to attach."
-            },
-            {
-                "name": "enable",
-                "description": "Enables reporting of execution contexts creation by means of <code>executionContextCreated</code> event. When the reporting gets enabled the event will be sent immediately for each existing execution context."
-            },
-            {
-                "name": "disable",
-                "description": "Disables reporting of execution contexts creation."
-            },
-            {
-                "name": "discardConsoleEntries",
-                "description": "Discards collected exceptions and console API calls."
-            },
-            {
-                "name": "setCustomObjectFormatterEnabled",
-                "parameters": [
-                    {
-                        "name": "enabled",
-                        "type": "boolean"
-                    }
-                ],
-                "experimental": true
-            },
-            {
-                "name": "compileScript",
-                "parameters": [
-                    { "name": "expression", "type": "string", "description": "Expression to compile." },
-                    { "name": "sourceURL", "type": "string", "description": "Source url to be set for the script." },
-                    { "name": "persistScript", "type": "boolean", "description": "Specifies whether the compiled script should be persisted." },
-                    { "name": "executionContextId", "$ref": "ExecutionContextId", "optional": true, "description": "Specifies in which execution context to perform script run. If the parameter is omitted the evaluation will be performed in the context of the inspected page." }
-                ],
-                "returns": [
-                    { "name": "scriptId", "$ref": "ScriptId", "optional": true, "description": "Id of the script." },
-                    { "name": "exceptionDetails", "$ref": "ExceptionDetails", "optional": true, "description": "Exception details."}
-                ],
-                "description": "Compiles expression."
-            },
-            {
-                "name": "runScript",
-                "async": true,
-                "parameters": [
-                    { "name": "scriptId", "$ref": "ScriptId", "description": "Id of the script to run." },
-                    { "name": "executionContextId", "$ref": "ExecutionContextId", "optional": true, "description": "Specifies in which execution context to perform script run. If the parameter is omitted the evaluation will be performed in the context of the inspected page." },
-                    { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." },
-                    { "name": "silent", "type": "boolean", "optional": true, "description": "In silent mode exceptions thrown during evaluation are not reported and do not pause execution. Overrides <code>setPauseOnException</code> state." },
-                    { "name": "includeCommandLineAPI", "type": "boolean", "optional": true, "description": "Determines whether Command Line API should be available during the evaluation." },
-                    { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object which should be sent by value." },
-                    { "name": "generatePreview", "type": "boolean", "optional": true, "description": "Whether preview should be generated for the result." },
-                    { "name": "awaitPromise", "type": "boolean", "optional": true, "description": "Whether execution should wait for promise to be resolved. If the result of evaluation is not a Promise, it's considered to be an error." }
-                ],
-                "returns": [
-                    { "name": "result", "$ref": "RemoteObject", "description": "Run result." },
-                    { "name": "exceptionDetails", "$ref": "ExceptionDetails", "optional": true, "description": "Exception details."}
-                ],
-                "description": "Runs script with given id in a given context."
-            }
-        ],
-        "events": [
-            {
-                "name": "executionContextCreated",
-                "parameters": [
-                    { "name": "context", "$ref": "ExecutionContextDescription", "description": "A newly created execution contex." }
-                ],
-                "description": "Issued when new execution context is created."
-            },
-            {
-                "name": "executionContextDestroyed",
-                "parameters": [
-                    { "name": "executionContextId", "$ref": "ExecutionContextId", "description": "Id of the destroyed context" }
-                ],
-                "description": "Issued when execution context is destroyed."
-            },
-            {
-                "name": "executionContextsCleared",
-                "description": "Issued when all executionContexts were cleared in browser"
-            },
-            {
-                "name": "exceptionThrown",
-                "description": "Issued when exception was thrown and unhandled.",
-                "parameters": [
-                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp of the exception." },
-                    { "name": "exceptionDetails", "$ref": "ExceptionDetails" }
-                ]
-            },
-            {
-                "name": "exceptionRevoked",
-                "description": "Issued when unhandled exception was revoked.",
-                "parameters": [
-                    { "name": "reason", "type": "string", "description": "Reason describing why exception was revoked." },
-                    { "name": "exceptionId", "type": "integer", "description": "The id of revoked exception, as reported in <code>exceptionUnhandled</code>." }
-                ]
-            },
-            {
-                "name": "consoleAPICalled",
-                "description": "Issued when console API was called.",
-                "parameters": [
-                    { "name": "type", "type": "string", "enum": ["log", "debug", "info", "error", "warning", "dir", "dirxml", "table", "trace", "clear", "startGroup", "startGroupCollapsed", "endGroup", "assert", "profile", "profileEnd"], "description": "Type of the call." },
-                    { "name": "args", "type": "array", "items": { "$ref": "RemoteObject" }, "description": "Call arguments." },
-                    { "name": "executionContextId", "$ref": "ExecutionContextId", "description": "Identifier of the context where the call was made." },
-                    { "name": "timestamp", "$ref": "Timestamp", "description": "Call timestamp." },
-                    { "name": "stackTrace", "$ref": "StackTrace", "optional": true, "description": "Stack trace captured when the call was made." }
-                ]
-            },
-            {
-                "name": "inspectRequested",
-                "description": "Issued when object should be inspected (for example, as a result of inspect() command line API call).",
-                "parameters": [
-                    { "name": "object", "$ref": "RemoteObject" },
-                    { "name": "hints", "type": "object" }
-                ]
-            }
-        ]
-    },
-    {
-        "domain": "Debugger",
-        "description": "Debugger domain exposes JavaScript debugging capabilities. It allows setting and removing breakpoints, stepping through execution, exploring stack traces, etc.",
-        "dependencies": ["Runtime"],
-        "types": [
-            {
-                "id": "BreakpointId",
-                "type": "string",
-                "description": "Breakpoint identifier."
-            },
-            {
-                "id": "CallFrameId",
-                "type": "string",
-                "description": "Call frame identifier."
-            },
-            {
-                "id": "Location",
-                "type": "object",
-                "properties": [
-                    { "name": "scriptId", "$ref": "Runtime.ScriptId", "description": "Script identifier as reported in the <code>Debugger.scriptParsed</code>." },
-                    { "name": "lineNumber", "type": "integer", "description": "Line number in the script (0-based)." },
-                    { "name": "columnNumber", "type": "integer", "optional": true, "description": "Column number in the script (0-based)." }
-                ],
-                "description": "Location in the source code."
-            },
-            {
-                "id": "ScriptPosition",
-                "experimental": true,
-                "type": "object",
-                "properties": [
-                    { "name": "lineNumber", "type": "integer" },
-                    { "name": "columnNumber", "type": "integer" }
-                ],
-                "description": "Location in the source code."
-            },
-            {
-                "id": "CallFrame",
-                "type": "object",
-                "properties": [
-                    { "name": "callFrameId", "$ref": "CallFrameId", "description": "Call frame identifier. This identifier is only valid while the virtual machine is paused." },
-                    { "name": "functionName", "type": "string", "description": "Name of the JavaScript function called on this call frame." },
-                    { "name": "functionLocation", "$ref": "Location", "optional": true, "experimental": true, "description": "Location in the source code." },
-                    { "name": "location", "$ref": "Location", "description": "Location in the source code." },
-                    { "name": "scopeChain", "type": "array", "items": { "$ref": "Scope" }, "description": "Scope chain for this call frame." },
-                    { "name": "this", "$ref": "Runtime.RemoteObject", "description": "<code>this</code> object for this call frame." },
-                    { "name": "returnValue", "$ref": "Runtime.RemoteObject", "optional": true, "description": "The value being returned, if the function is at return point." }
-                ],
-                "description": "JavaScript call frame. Array of call frames form the call stack."
-            },
-            {
-                "id": "Scope",
-                "type": "object",
-                "properties": [
-                    { "name": "type", "type": "string", "enum": ["global", "local", "with", "closure", "catch", "block", "script"], "description": "Scope type." },
-                    { "name": "object", "$ref": "Runtime.RemoteObject", "description": "Object representing the scope. For <code>global</code> and <code>with</code> scopes it represents the actual object; for the rest of the scopes, it is artificial transient object enumerating scope variables as its properties." },
-                    { "name": "name", "type": "string", "optional": true },
-                    { "name": "startLocation", "$ref": "Location", "optional": true, "description": "Location in the source code where scope starts" },
-                    { "name": "endLocation", "$ref": "Location", "optional": true, "description": "Location in the source code where scope ends" }
-                ],
-                "description": "Scope description."
-            },
-            {
-                "id": "SearchMatch",
-                "type": "object",
-                "description": "Search match for resource.",
-                "exported": true,
-                "properties": [
-                    { "name": "lineNumber", "type": "number", "description": "Line number in resource content." },
-                    { "name": "lineContent", "type": "string", "description": "Line with match content." }
-                ],
-                "experimental": true
-            }
-        ],
-        "commands": [
-            {
-                "name": "enable",
-                "description": "Enables debugger for the given page. Clients should not assume that the debugging has been enabled until the result for this command is received."
-            },
-            {
-                "name": "disable",
-                "description": "Disables debugger for given page."
-            },
-            {
-                "name": "setBreakpointsActive",
-                "parameters": [
-                    { "name": "active", "type": "boolean", "description": "New value for breakpoints active state." }
-                ],
-                "description": "Activates / deactivates all breakpoints on the page."
-            },
-            {
-                "name": "setSkipAllPauses",
-                "parameters": [
-                    { "name": "skip", "type": "boolean", "description": "New value for skip pauses state." }
-                ],
-                "description": "Makes page not interrupt on any pauses (breakpoint, exception, dom exception etc)."
-            },
-            {
-                "name": "setBreakpointByUrl",
-                "parameters": [
-                    { "name": "lineNumber", "type": "integer", "description": "Line number to set breakpoint at." },
-                    { "name": "url", "type": "string", "optional": true, "description": "URL of the resources to set breakpoint on." },
-                    { "name": "urlRegex", "type": "string", "optional": true, "description": "Regex pattern for the URLs of the resources to set breakpoints on. Either <code>url</code> or <code>urlRegex</code> must be specified." },
-                    { "name": "columnNumber", "type": "integer", "optional": true, "description": "Offset in the line to set breakpoint at." },
-                    { "name": "condition", "type": "string", "optional": true, "description": "Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true." }
-                ],
-                "returns": [
-                    { "name": "breakpointId", "$ref": "BreakpointId", "description": "Id of the created breakpoint for further reference." },
-                    { "name": "locations", "type": "array", "items": { "$ref": "Location" }, "description": "List of the locations this breakpoint resolved into upon addition." }
-                ],
-                "description": "Sets JavaScript breakpoint at given location specified either by URL or URL regex. Once this command is issued, all existing parsed scripts will have breakpoints resolved and returned in <code>locations</code> property. Further matching script parsing will result in subsequent <code>breakpointResolved</code> events issued. This logical breakpoint will survive page reloads."
-            },
-            {
-                "name": "setBreakpoint",
-                "parameters": [
-                    { "name": "location", "$ref": "Location", "description": "Location to set breakpoint in." },
-                    { "name": "condition", "type": "string", "optional": true, "description": "Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true." }
-                ],
-                "returns": [
-                    { "name": "breakpointId", "$ref": "BreakpointId", "description": "Id of the created breakpoint for further reference." },
-                    { "name": "actualLocation", "$ref": "Location", "description": "Location this breakpoint resolved into." }
-                ],
-                "description": "Sets JavaScript breakpoint at a given location."
-            },
-            {
-                "name": "removeBreakpoint",
-                "parameters": [
-                    { "name": "breakpointId", "$ref": "BreakpointId" }
-                ],
-                "description": "Removes JavaScript breakpoint."
-            },
-            {
-                "name": "continueToLocation",
-                "parameters": [
-                    { "name": "location", "$ref": "Location", "description": "Location to continue to." }
-                ],
-                "description": "Continues execution until specific location is reached."
-            },
-            {
-                "name": "stepOver",
-                "description": "Steps over the statement."
-            },
-            {
-                "name": "stepInto",
-                "description": "Steps into the function call."
-            },
-            {
-                "name": "stepOut",
-                "description": "Steps out of the function call."
-            },
-            {
-                "name": "pause",
-                "description": "Stops on the next JavaScript statement."
-            },
-            {
-                "name": "resume",
-                "description": "Resumes JavaScript execution."
-            },
-            {
-                "name": "searchInContent",
-                "parameters": [
-                    { "name": "scriptId", "$ref": "Runtime.ScriptId", "description": "Id of the script to search in." },
-                    { "name": "query", "type": "string", "description": "String to search for."  },
-                    { "name": "caseSensitive", "type": "boolean", "optional": true, "description": "If true, search is case sensitive." },
-                    { "name": "isRegex", "type": "boolean", "optional": true, "description": "If true, treats string parameter as regex." }
-                ],
-                "returns": [
-                    { "name": "result", "type": "array", "items": { "$ref": "SearchMatch" }, "description": "List of search matches." }
-                ],
-                "experimental": true,
-                "description": "Searches for given string in script content."
-            },
-            {
-                "name": "setScriptSource",
-                "parameters": [
-                    { "name": "scriptId", "$ref": "Runtime.ScriptId", "description": "Id of the script to edit." },
-                    { "name": "scriptSource", "type": "string", "description": "New content of the script." },
-                    { "name": "dryRun", "type": "boolean", "optional": true, "description": " If true the change will not actually be applied. Dry run may be used to get result description without actually modifying the code." }
-                ],
-                "returns": [
-                    { "name": "callFrames", "type": "array", "optional": true, "items": { "$ref": "CallFrame" }, "description": "New stack trace in case editing has happened while VM was stopped." },
-                    { "name": "stackChanged", "type": "boolean", "optional": true, "description": "Whether current call stack  was modified after applying the changes." },
-                    { "name": "asyncStackTrace", "$ref": "Runtime.StackTrace", "optional": true, "description": "Async stack trace, if any." },
-                    { "name": "exceptionDetails", "optional": true, "$ref": "Runtime.ExceptionDetails", "description": "Exception details if any." }
-                ],
-                "description": "Edits JavaScript source live."
-            },
-            {
-                "name": "restartFrame",
-                "parameters": [
-                    { "name": "callFrameId", "$ref": "CallFrameId", "description": "Call frame identifier to evaluate on." }
-                ],
-                "returns": [
-                    { "name": "callFrames", "type": "array", "items": { "$ref": "CallFrame" }, "description": "New stack trace." },
-                    { "name": "asyncStackTrace", "$ref": "Runtime.StackTrace", "optional": true, "description": "Async stack trace, if any." }
-                ],
-                "description": "Restarts particular call frame from the beginning."
-            },
-            {
-                "name": "getScriptSource",
-                "parameters": [
-                    { "name": "scriptId", "$ref": "Runtime.ScriptId", "description": "Id of the script to get source for." }
-                ],
-                "returns": [
-                    { "name": "scriptSource", "type": "string", "description": "Script source." }
-                ],
-                "description": "Returns source for the script with given id."
-            },
-            {
-                "name": "setPauseOnExceptions",
-                "parameters": [
-                    { "name": "state", "type": "string", "enum": ["none", "uncaught", "all"], "description": "Pause on exceptions mode." }
-                ],
-                "description": "Defines pause on exceptions state. Can be set to stop on all exceptions, uncaught exceptions or no exceptions. Initial pause on exceptions state is <code>none</code>."
-            },
-            {
-                "name": "evaluateOnCallFrame",
-                "parameters": [
-                    { "name": "callFrameId", "$ref": "CallFrameId", "description": "Call frame identifier to evaluate on." },
-                    { "name": "expression", "type": "string", "description": "Expression to evaluate." },
-                    { "name": "objectGroup", "type": "string", "optional": true, "description": "String object group name to put result into (allows rapid releasing resulting object handles using <code>releaseObjectGroup</code>)." },
-                    { "name": "includeCommandLineAPI", "type": "boolean", "optional": true, "description": "Specifies whether command line API should be available to the evaluated expression, defaults to false." },
-                    { "name": "silent", "type": "boolean", "optional": true, "description": "In silent mode exceptions thrown during evaluation are not reported and do not pause execution. Overrides <code>setPauseOnException</code> state." },
-                    { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object that should be sent by value." },
-                    { "name": "generatePreview", "type": "boolean", "optional": true, "experimental": true, "description": "Whether preview should be generated for the result." }
-                ],
-                "returns": [
-                    { "name": "result", "$ref": "Runtime.RemoteObject", "description": "Object wrapper for the evaluation result." },
-                    { "name": "exceptionDetails", "$ref": "Runtime.ExceptionDetails", "optional": true, "description": "Exception details."}
-                ],
-                "description": "Evaluates expression on a given call frame."
-            },
-            {
-                "name": "setVariableValue",
-                "parameters": [
-                    { "name": "scopeNumber", "type": "integer", "description": "0-based number of scope as was listed in scope chain. Only 'local', 'closure' and 'catch' scope types are allowed. Other scopes could be manipulated manually." },
-                    { "name": "variableName", "type": "string", "description": "Variable name." },
-                    { "name": "newValue", "$ref": "Runtime.CallArgument", "description": "New variable value." },
-                    { "name": "callFrameId", "$ref": "CallFrameId", "description": "Id of callframe that holds variable." }
-                ],
-                "description": "Changes value of variable in a callframe. Object-based scopes are not supported and must be mutated manually."
-            },
-            {
-                "name": "setAsyncCallStackDepth",
-                "parameters": [
-                    { "name": "maxDepth", "type": "integer", "description": "Maximum depth of async call stacks. Setting to <code>0</code> will effectively disable collecting async call stacks (default)." }
-                ],
-                "description": "Enables or disables async call stacks tracking."
-            },
-            {
-                "name": "setBlackboxPatterns",
-                "parameters": [
-                    { "name": "patterns", "type": "array", "items": { "type": "string" }, "description": "Array of regexps that will be used to check script url for blackbox state." }
-                ],
-                "experimental": true,
-                "description": "Replace previous blackbox patterns with passed ones. Forces backend to skip stepping/pausing in scripts with url matching one of the patterns. VM will try to leave blackboxed script by performing 'step in' several times, finally resorting to 'step out' if unsuccessful."
-            },
-            {
-                "name": "setBlackboxedRanges",
-                "parameters": [
-                    { "name": "scriptId", "$ref": "Runtime.ScriptId", "description": "Id of the script." },
-                    { "name": "positions", "type": "array", "items": { "$ref": "ScriptPosition" } }
-                ],
-                "experimental": true,
-                "description": "Makes backend skip steps in the script in blackboxed ranges. VM will try leave blacklisted scripts by performing 'step in' several times, finally resorting to 'step out' if unsuccessful. Positions array contains positions where blackbox state is changed. First interval isn't blackboxed. Array should be sorted."
-            }
-        ],
-        "events": [
-            {
-                "name": "scriptParsed",
-                "parameters": [
-                    { "name": "scriptId", "$ref": "Runtime.ScriptId", "description": "Identifier of the script parsed." },
-                    { "name": "url", "type": "string", "description": "URL or name of the script parsed (if any)." },
-                    { "name": "startLine", "type": "integer", "description": "Line offset of the script within the resource with given URL (for script tags)." },
-                    { "name": "startColumn", "type": "integer", "description": "Column offset of the script within the resource with given URL." },
-                    { "name": "endLine", "type": "integer", "description": "Last line of the script." },
-                    { "name": "endColumn", "type": "integer", "description": "Length of the last line of the script." },
-                    { "name": "executionContextId", "$ref": "Runtime.ExecutionContextId", "description": "Specifies script creation context." },
-                    { "name": "hash", "type": "string", "description": "Content hash of the script."},
-                    { "name": "executionContextAuxData", "type": "object", "optional": true, "description": "Embedder-specific auxiliary data." },
-                    { "name": "isLiveEdit", "type": "boolean", "optional": true, "description": "True, if this script is generated as a result of the live edit operation.", "experimental": true },
-                    { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with script (if any)." },
-                    { "name": "hasSourceURL", "type": "boolean", "optional": true, "description": "True, if this script has sourceURL.", "experimental": true }
-                ],
-                "description": "Fired when virtual machine parses script. This event is also fired for all known and uncollected scripts upon enabling debugger."
-            },
-            {
-                "name": "scriptFailedToParse",
-                "parameters": [
-                    { "name": "scriptId", "$ref": "Runtime.ScriptId", "description": "Identifier of the script parsed." },
-                    { "name": "url", "type": "string", "description": "URL or name of the script parsed (if any)." },
-                    { "name": "startLine", "type": "integer", "description": "Line offset of the script within the resource with given URL (for script tags)." },
-                    { "name": "startColumn", "type": "integer", "description": "Column offset of the script within the resource with given URL." },
-                    { "name": "endLine", "type": "integer", "description": "Last line of the script." },
-                    { "name": "endColumn", "type": "integer", "description": "Length of the last line of the script." },
-                    { "name": "executionContextId", "$ref": "Runtime.ExecutionContextId", "description": "Specifies script creation context." },
-                    { "name": "hash", "type": "string", "description": "Content hash of the script."},
-                    { "name": "executionContextAuxData", "type": "object", "optional": true, "description": "Embedder-specific auxiliary data." },
-                    { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with script (if any)." },
-                    { "name": "hasSourceURL", "type": "boolean", "optional": true, "description": "True, if this script has sourceURL.", "experimental": true }
-                ],
-                "description": "Fired when virtual machine fails to parse the script."
-            },
-            {
-                "name": "breakpointResolved",
-                "parameters": [
-                    { "name": "breakpointId", "$ref": "BreakpointId", "description": "Breakpoint unique identifier." },
-                    { "name": "location", "$ref": "Location", "description": "Actual breakpoint location." }
-                ],
-                "description": "Fired when breakpoint is resolved to an actual script and location."
-            },
-            {
-                "name": "paused",
-                "parameters": [
-                    { "name": "callFrames", "type": "array", "items": { "$ref": "CallFrame" }, "description": "Call stack the virtual machine stopped on." },
-                    { "name": "reason", "type": "string", "enum": [ "XHR", "DOM", "EventListener", "exception", "assert", "debugCommand", "promiseRejection", "other" ], "description": "Pause reason.", "exported": true },
-                    { "name": "data", "type": "object", "optional": true, "description": "Object containing break-specific auxiliary properties." },
-                    { "name": "hitBreakpoints", "type": "array", "optional": true, "items": { "type": "string" }, "description": "Hit breakpoints IDs" },
-                    { "name": "asyncStackTrace", "$ref": "Runtime.StackTrace", "optional": true, "description": "Async stack trace, if any." }
-                ],
-                "description": "Fired when the virtual machine stopped on breakpoint or exception or any other stop criteria."
-            },
-            {
-                "name": "resumed",
-                "description": "Fired when the virtual machine resumed execution."
-            }
-        ]
-    },
-    {
-        "domain": "Console",
-        "description": "This domain is deprecated - use Runtime or Log instead.",
-        "dependencies": ["Runtime"],
-        "deprecated": true,
-        "types": [
-            {
-                "id": "ConsoleMessage",
-                "type": "object",
-                "description": "Console message.",
-                "properties": [
-                    { "name": "source", "type": "string", "enum": ["xml", "javascript", "network", "console-api", "storage", "appcache", "rendering", "security", "other", "deprecation", "worker"], "description": "Message source." },
-                    { "name": "level", "type": "string", "enum": ["log", "warning", "error", "debug", "info"], "description": "Message severity." },
-                    { "name": "text", "type": "string", "description": "Message text." },
-                    { "name": "url", "type": "string", "optional": true, "description": "URL of the message origin." },
-                    { "name": "line", "type": "integer", "optional": true, "description": "Line number in the resource that generated this message (1-based)." },
-                    { "name": "column", "type": "integer", "optional": true, "description": "Column number in the resource that generated this message (1-based)." }
-                ]
-            }
-        ],
-        "commands": [
-            {
-                "name": "enable",
-                "description": "Enables console domain, sends the messages collected so far to the client by means of the <code>messageAdded</code> notification."
-            },
-            {
-                "name": "disable",
-                "description": "Disables console domain, prevents further console messages from being reported to the client."
-            },
-            {
-                "name": "clearMessages",
-                "description": "Does nothing."
-            }
-        ],
-        "events": [
-            {
-                "name": "messageAdded",
-                "parameters": [
-                    { "name": "message", "$ref": "ConsoleMessage", "description": "Console message that has been added." }
-                ],
-                "description": "Issued when new console message is added."
-            }
-        ]
-    },
-    {
-        "domain": "Profiler",
-        "dependencies": ["Runtime", "Debugger"],
-        "types": [
-            {
-                "id": "ProfileNode",
-                "type": "object",
-                "description": "Profile node. Holds callsite information, execution statistics and child nodes.",
-                "properties": [
-                    { "name": "id", "type": "integer", "description": "Unique id of the node." },
-                    { "name": "callFrame", "$ref": "Runtime.CallFrame", "description": "Function location." },
-                    { "name": "hitCount", "type": "integer", "optional": true, "experimental": true, "description": "Number of samples where this node was on top of the call stack." },
-                    { "name": "children", "type": "array", "items": { "type": "integer" }, "optional": true, "description": "Child node ids." },
-                    { "name": "deoptReason", "type": "string", "optional": true, "description": "The reason of being not optimized. The function may be deoptimized or marked as don't optimize."},
-                    { "name": "positionTicks", "type": "array", "items": { "$ref": "PositionTickInfo" }, "optional": true, "experimental": true, "description": "An array of source position ticks." }
-                ]
-            },
-            {
-                "id": "Profile",
-                "type": "object",
-                "description": "Profile.",
-                "properties": [
-                    { "name": "nodes", "type": "array", "items": { "$ref": "ProfileNode" }, "description": "The list of profile nodes. First item is the root node." },
-                    { "name": "startTime", "type": "number", "description": "Profiling start timestamp in microseconds." },
-                    { "name": "endTime", "type": "number", "description": "Profiling end timestamp in microseconds." },
-                    { "name": "samples", "optional": true, "type": "array", "items": { "type": "integer" }, "description": "Ids of samples top nodes." },
-                    { "name": "timeDeltas", "optional": true, "type": "array", "items": { "type": "integer" }, "description": "Time intervals between adjacent samples in microseconds. The first delta is relative to the profile startTime." }
-                ]
-            },
-            {
-                "id": "PositionTickInfo",
-                "type": "object",
-                "experimental": true,
-                "description": "Specifies a number of samples attributed to a certain source position.",
-                "properties": [
-                    { "name": "line", "type": "integer", "description": "Source line number (1-based)." },
-                    { "name": "ticks", "type": "integer", "description": "Number of samples attributed to the source line." }
-                ]
-            }
-        ],
-        "commands": [
-            {
-                "name": "enable"
-            },
-            {
-                "name": "disable"
-            },
-            {
-                "name": "setSamplingInterval",
-                "parameters": [
-                    { "name": "interval", "type": "integer", "description": "New sampling interval in microseconds." }
-                ],
-                "description": "Changes CPU profiler sampling interval. Must be called before CPU profiles recording started."
-            },
-            {
-                "name": "start"
-            },
-            {
-                "name": "stop",
-                "returns": [
-                    { "name": "profile", "$ref": "Profile", "description": "Recorded profile." }
-                ]
-            }
-        ],
-        "events": [
-            {
-                "name": "consoleProfileStarted",
-                "parameters": [
-                    { "name": "id", "type": "string" },
-                    { "name": "location", "$ref": "Debugger.Location", "description": "Location of console.profile()." },
-                    { "name": "title", "type": "string", "optional": true, "description": "Profile title passed as an argument to console.profile()." }
-                ],
-                "description": "Sent when new profile recodring is started using console.profile() call."
-            },
-            {
-                "name": "consoleProfileFinished",
-                "parameters": [
-                    { "name": "id", "type": "string" },
-                    { "name": "location", "$ref": "Debugger.Location", "description": "Location of console.profileEnd()." },
-                    { "name": "profile", "$ref": "Profile" },
-                    { "name": "title", "type": "string", "optional": true, "description": "Profile title passed as an argument to console.profile()." }
-                ]
-            }
-        ]
-    },
-    {
-        "domain": "HeapProfiler",
-        "dependencies": ["Runtime"],
-        "experimental": true,
-        "types": [
-            {
-                "id": "HeapSnapshotObjectId",
-                "type": "string",
-                "description": "Heap snapshot object id."
-            },
-            {
-                "id": "SamplingHeapProfileNode",
-                "type": "object",
-                "description": "Sampling Heap Profile node. Holds callsite information, allocation statistics and child nodes.",
-                "properties": [
-                    { "name": "callFrame", "$ref": "Runtime.CallFrame", "description": "Function location." },
-                    { "name": "selfSize", "type": "number", "description": "Allocations size in bytes for the node excluding children." },
-                    { "name": "children", "type": "array", "items": { "$ref": "SamplingHeapProfileNode" }, "description": "Child nodes." }
-                ]
-            },
-            {
-                "id": "SamplingHeapProfile",
-                "type": "object",
-                "description": "Profile.",
-                "properties": [
-                    { "name": "head", "$ref": "SamplingHeapProfileNode" }
-                ]
-            }
-        ],
-        "commands": [
-            {
-                "name": "enable"
-            },
-            {
-                "name": "disable"
-            },
-            {
-                "name": "startTrackingHeapObjects",
-                "parameters": [
-                    { "name": "trackAllocations", "type": "boolean", "optional": true }
-                ]
-            },
-            {
-                "name": "stopTrackingHeapObjects",
-                "parameters": [
-                    { "name": "reportProgress", "type": "boolean", "optional": true, "description": "If true 'reportHeapSnapshotProgress' events will be generated while snapshot is being taken when the tracking is stopped." }
-                ]
-            },
-            {
-                "name": "takeHeapSnapshot",
-                "parameters": [
-                    { "name": "reportProgress", "type": "boolean", "optional": true, "description": "If true 'reportHeapSnapshotProgress' events will be generated while snapshot is being taken." }
-                ]
-            },
-            {
-                "name": "collectGarbage"
-            },
-            {
-                "name": "getObjectByHeapObjectId",
-                "parameters": [
-                    { "name": "objectId", "$ref": "HeapSnapshotObjectId" },
-                    { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." }
-                ],
-                "returns": [
-                    { "name": "result", "$ref": "Runtime.RemoteObject", "description": "Evaluation result." }
-                ]
-            },
-            {
-                "name": "addInspectedHeapObject",
-                "parameters": [
-                    { "name": "heapObjectId", "$ref": "HeapSnapshotObjectId", "description": "Heap snapshot object id to be accessible by means of $x command line API." }
-                ],
-                "description": "Enables console to refer to the node with given id via $x (see Command Line API for more details $x functions)."
-            },
-            {
-                "name": "getHeapObjectId",
-                "parameters": [
-                    { "name": "objectId", "$ref": "Runtime.RemoteObjectId", "description": "Identifier of the object to get heap object id for." }
-                ],
-                "returns": [
-                    { "name": "heapSnapshotObjectId", "$ref": "HeapSnapshotObjectId", "description": "Id of the heap snapshot object corresponding to the passed remote object id." }
-                ]
-            },
-            {
-                "name": "startSampling",
-                "parameters": [
-                    { "name": "samplingInterval", "type": "number", "optional": true, "description": "Average sample interval in bytes. Poisson distribution is used for the intervals. The default value is 32768 bytes." }
-                ]
-            },
-            {
-                "name": "stopSampling",
-                "returns": [
-                    { "name": "profile", "$ref": "SamplingHeapProfile", "description": "Recorded sampling heap profile." }
-                ]
-            }
-        ],
-        "events": [
-            {
-                "name": "addHeapSnapshotChunk",
-                "parameters": [
-                    { "name": "chunk", "type": "string" }
-                ]
-            },
-            {
-                "name": "resetProfiles"
-            },
-            {
-                "name": "reportHeapSnapshotProgress",
-                "parameters": [
-                    { "name": "done", "type": "integer" },
-                    { "name": "total", "type": "integer" },
-                    { "name": "finished", "type": "boolean", "optional": true }
-                ]
-            },
-            {
-                "name": "lastSeenObjectId",
-                "description": "If heap objects tracking has been started then backend regulary sends a current value for last seen object id and corresponding timestamp. If the were changes in the heap since last event then one or more heapStatsUpdate events will be sent before a new lastSeenObjectId event.",
-                "parameters": [
-                    { "name": "lastSeenObjectId", "type": "integer" },
-                    { "name": "timestamp", "type": "number" }
-                ]
-            },
-            {
-                "name": "heapStatsUpdate",
-                "description": "If heap objects tracking has been started then backend may send update for one or more fragments",
-                "parameters": [
-                    { "name": "statsUpdate", "type": "array", "items": { "type": "integer" }, "description": "An array of triplets. Each triplet describes a fragment. The first integer is the fragment index, the second integer is a total count of objects for the fragment, the third integer is a total size of the objects for the fragment."}
-                ]
-            }
-        ]
-    }]
+        {
+            "domain": "Schema",
+            "description": "Provides information about the protocol schema.",
+            "types": [
+                {
+                    "id": "Domain",
+                    "type": "object",
+                    "description": "Description of the protocol domain.",
+                    "exported": true,
+                    "properties": [
+                        { "name": "name", "type": "string", "description": "Domain name." },
+                        { "name": "version", "type": "string", "description": "Domain version." }
+                    ]
+                }
+            ],
+            "commands": [
+                {
+                    "name": "getDomains",
+                    "description": "Returns supported domains.",
+                    "handlers": ["browser", "renderer"],
+                    "returns": [
+                        { "name": "domains", "type": "array", "items": { "$ref": "Domain" }, "description": "List of supported domains." }
+                    ]
+                }
+            ]
+        },
+        {
+            "domain": "Runtime",
+            "description": "Runtime domain exposes JavaScript runtime by means of remote evaluation and mirror objects. Evaluation results are returned as mirror object that expose object type, string representation and unique identifier that can be used for further object reference. Original objects are maintained in memory unless they are either explicitly released or are released along with the other objects in their object group.",
+            "types": [
+                {
+                    "id": "ScriptId",
+                    "type": "string",
+                    "description": "Unique script identifier."
+                },
+                {
+                    "id": "RemoteObjectId",
+                    "type": "string",
+                    "description": "Unique object identifier."
+                },
+                {
+                    "id": "UnserializableValue",
+                    "type": "string",
+                    "enum": ["Infinity", "NaN", "-Infinity", "-0"],
+                    "description": "Primitive value which cannot be JSON-stringified."
+                },
+                {
+                    "id": "RemoteObject",
+                    "type": "object",
+                    "description": "Mirror object referencing original JavaScript object.",
+                    "exported": true,
+                    "properties": [
+                        { "name": "type", "type": "string", "enum": ["object", "function", "undefined", "string", "number", "boolean", "symbol"], "description": "Object type." },
+                        { "name": "subtype", "type": "string", "optional": true, "enum": ["array", "null", "node", "regexp", "date", "map", "set", "iterator", "generator", "error", "proxy", "promise", "typedarray"], "description": "Object subtype hint. Specified for <code>object</code> type values only." },
+                        { "name": "className", "type": "string", "optional": true, "description": "Object class (constructor) name. Specified for <code>object</code> type values only." },
+                        { "name": "value", "type": "any", "optional": true, "description": "Remote object value in case of primitive values or JSON values (if it was requested)." },
+                        { "name": "unserializableValue", "$ref": "UnserializableValue", "optional": true, "description": "Primitive value which can not be JSON-stringified does not have <code>value</code>, but gets this property." },
+                        { "name": "description", "type": "string", "optional": true, "description": "String representation of the object." },
+                        { "name": "objectId", "$ref": "RemoteObjectId", "optional": true, "description": "Unique object identifier (for non-primitive values)." },
+                        { "name": "preview", "$ref": "ObjectPreview", "optional": true, "description": "Preview containing abbreviated property values. Specified for <code>object</code> type values only.", "experimental": true },
+                        { "name": "customPreview", "$ref": "CustomPreview", "optional": true, "experimental": true}
+                    ]
+                },
+                {
+                    "id": "CustomPreview",
+                    "type": "object",
+                    "experimental": true,
+                    "properties": [
+                        { "name": "header", "type": "string"},
+                        { "name": "hasBody", "type": "boolean"},
+                        { "name": "formatterObjectId", "$ref": "RemoteObjectId"},
+                        { "name": "bindRemoteObjectFunctionId", "$ref": "RemoteObjectId" },
+                        { "name": "configObjectId", "$ref": "RemoteObjectId", "optional": true }
+                    ]
+                },
+                {
+                    "id": "ObjectPreview",
+                    "type": "object",
+                    "experimental": true,
+                    "description": "Object containing abbreviated remote object value.",
+                    "properties": [
+                        { "name": "type", "type": "string", "enum": ["object", "function", "undefined", "string", "number", "boolean", "symbol"], "description": "Object type." },
+                        { "name": "subtype", "type": "string", "optional": true, "enum": ["array", "null", "node", "regexp", "date", "map", "set", "iterator", "generator", "error"], "description": "Object subtype hint. Specified for <code>object</code> type values only." },
+                        { "name": "description", "type": "string", "optional": true, "description": "String representation of the object." },
+                        { "name": "overflow", "type": "boolean", "description": "True iff some of the properties or entries of the original object did not fit." },
+                        { "name": "properties", "type": "array", "items": { "$ref": "PropertyPreview" }, "description": "List of the properties." },
+                        { "name": "entries", "type": "array", "items": { "$ref": "EntryPreview" }, "optional": true, "description": "List of the entries. Specified for <code>map</code> and <code>set</code> subtype values only." }
+                    ]
+                },
+                {
+                    "id": "PropertyPreview",
+                    "type": "object",
+                    "experimental": true,
+                    "properties": [
+                        { "name": "name", "type": "string", "description": "Property name." },
+                        { "name": "type", "type": "string", "enum": ["object", "function", "undefined", "string", "number", "boolean", "symbol", "accessor"], "description": "Object type. Accessor means that the property itself is an accessor property." },
+                        { "name": "value", "type": "string", "optional": true, "description": "User-friendly property value string." },
+                        { "name": "valuePreview", "$ref": "ObjectPreview", "optional": true, "description": "Nested value preview." },
+                        { "name": "subtype", "type": "string", "optional": true, "enum": ["array", "null", "node", "regexp", "date", "map", "set", "iterator", "generator", "error"], "description": "Object subtype hint. Specified for <code>object</code> type values only." }
+                    ]
+                },
+                {
+                    "id": "EntryPreview",
+                    "type": "object",
+                    "experimental": true,
+                    "properties": [
+                        { "name": "key", "$ref": "ObjectPreview", "optional": true, "description": "Preview of the key. Specified for map-like collection entries." },
+                        { "name": "value", "$ref": "ObjectPreview", "description": "Preview of the value." }
+                    ]
+                },
+                {
+                    "id": "PropertyDescriptor",
+                    "type": "object",
+                    "description": "Object property descriptor.",
+                    "properties": [
+                        { "name": "name", "type": "string", "description": "Property name or symbol description." },
+                        { "name": "value", "$ref": "RemoteObject", "optional": true, "description": "The value associated with the property." },
+                        { "name": "writable", "type": "boolean", "optional": true, "description": "True if the value associated with the property may be changed (data descriptors only)." },
+                        { "name": "get", "$ref": "RemoteObject", "optional": true, "description": "A function which serves as a getter for the property, or <code>undefined</code> if there is no getter (accessor descriptors only)." },
+                        { "name": "set", "$ref": "RemoteObject", "optional": true, "description": "A function which serves as a setter for the property, or <code>undefined</code> if there is no setter (accessor descriptors only)." },
+                        { "name": "configurable", "type": "boolean", "description": "True if the type of this property descriptor may be changed and if the property may be deleted from the corresponding object." },
+                        { "name": "enumerable", "type": "boolean", "description": "True if this property shows up during enumeration of the properties on the corresponding object." },
+                        { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." },
+                        { "name": "isOwn", "optional": true, "type": "boolean", "description": "True if the property is owned for the object." },
+                        { "name": "symbol", "$ref": "RemoteObject", "optional": true, "description": "Property symbol object, if the property is of the <code>symbol</code> type." }
+                    ]
+                },
+                {
+                    "id": "InternalPropertyDescriptor",
+                    "type": "object",
+                    "description": "Object internal property descriptor. This property isn't normally visible in JavaScript code.",
+                    "properties": [
+                        { "name": "name", "type": "string", "description": "Conventional property name." },
+                        { "name": "value", "$ref": "RemoteObject", "optional": true, "description": "The value associated with the property." }
+                    ]
+                },
+                {
+                    "id": "CallArgument",
+                    "type": "object",
+                    "description": "Represents function call argument. Either remote object id <code>objectId</code>, primitive <code>value</code>, unserializable primitive value or neither of (for undefined) them should be specified.",
+                    "properties": [
+                        { "name": "value", "type": "any", "optional": true, "description": "Primitive value." },
+                        { "name": "unserializableValue", "$ref": "UnserializableValue", "optional": true, "description": "Primitive value which can not be JSON-stringified." },
+                        { "name": "objectId", "$ref": "RemoteObjectId", "optional": true, "description": "Remote object handle." }
+                    ]
+                },
+                {
+                    "id": "ExecutionContextId",
+                    "type": "integer",
+                    "description": "Id of an execution context."
+                },
+                {
+                    "id": "ExecutionContextDescription",
+                    "type": "object",
+                    "description": "Description of an isolated world.",
+                    "properties": [
+                        { "name": "id", "$ref": "ExecutionContextId", "description": "Unique id of the execution context. It can be used to specify in which execution context script evaluation should be performed." },
+                        { "name": "origin", "type": "string", "description": "Execution context origin." },
+                        { "name": "name", "type": "string", "description": "Human readable name describing given context." },
+                        { "name": "auxData", "type": "object", "optional": true, "description": "Embedder-specific auxiliary data." }
+                    ]
+                },
+                {
+                    "id": "ExceptionDetails",
+                    "type": "object",
+                    "description": "Detailed information about exception (or error) that was thrown during script compilation or execution.",
+                    "properties": [
+                        { "name": "exceptionId", "type": "integer", "description": "Exception id." },
+                        { "name": "text", "type": "string", "description": "Exception text, which should be used together with exception object when available." },
+                        { "name": "lineNumber", "type": "integer", "description": "Line number of the exception location (0-based)." },
+                        { "name": "columnNumber", "type": "integer", "description": "Column number of the exception location (0-based)." },
+                        { "name": "scriptId", "$ref": "ScriptId", "optional": true, "description": "Script ID of the exception location." },
+                        { "name": "url", "type": "string", "optional": true, "description": "URL of the exception location, to be used when the script was not reported." },
+                        { "name": "stackTrace", "$ref": "StackTrace", "optional": true, "description": "JavaScript stack trace if available." },
+                        { "name": "exception", "$ref": "RemoteObject", "optional": true, "description": "Exception object if available." },
+                        { "name": "executionContextId", "$ref": "ExecutionContextId", "optional": true, "description": "Identifier of the context where exception happened." }
+                    ]
+                },
+                {
+                    "id": "Timestamp",
+                    "type": "number",
+                    "description": "Number of milliseconds since epoch."
+                },
+                {
+                    "id": "CallFrame",
+                    "type": "object",
+                    "description": "Stack entry for runtime errors and assertions.",
+                    "properties": [
+                        { "name": "functionName", "type": "string", "description": "JavaScript function name." },
+                        { "name": "scriptId", "$ref": "ScriptId", "description": "JavaScript script id." },
+                        { "name": "url", "type": "string", "description": "JavaScript script name or url." },
+                        { "name": "lineNumber", "type": "integer", "description": "JavaScript script line number (0-based)." },
+                        { "name": "columnNumber", "type": "integer", "description": "JavaScript script column number (0-based)." }
+                    ]
+                },
+                {
+                    "id": "StackTrace",
+                    "type": "object",
+                    "description": "Call frames for assertions or error messages.",
+                    "exported": true,
+                    "properties": [
+                        { "name": "description", "type": "string", "optional": true, "description": "String label of this stack trace. For async traces this may be a name of the function that initiated the async call." },
+                        { "name": "callFrames", "type": "array", "items": { "$ref": "CallFrame" }, "description": "JavaScript function name." },
+                        { "name": "parent", "$ref": "StackTrace", "optional": true, "description": "Asynchronous JavaScript stack trace that preceded this stack, if available." }
+                    ]
+                }
+            ],
+            "commands": [
+                {
+                    "name": "evaluate",
+                    "async": true,
+                    "parameters": [
+                        { "name": "expression", "type": "string", "description": "Expression to evaluate." },
+                        { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." },
+                        { "name": "includeCommandLineAPI", "type": "boolean", "optional": true, "description": "Determines whether Command Line API should be available during the evaluation." },
+                        { "name": "silent", "type": "boolean", "optional": true, "description": "In silent mode exceptions thrown during evaluation are not reported and do not pause execution. Overrides <code>setPauseOnException</code> state." },
+                        { "name": "contextId", "$ref": "ExecutionContextId", "optional": true, "description": "Specifies in which execution context to perform evaluation. If the parameter is omitted the evaluation will be performed in the context of the inspected page." },
+                        { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object that should be sent by value." },
+                        { "name": "generatePreview", "type": "boolean", "optional": true, "experimental": true, "description": "Whether preview should be generated for the result." },
+                        { "name": "userGesture", "type": "boolean", "optional": true, "experimental": true, "description": "Whether execution should be treated as initiated by user in the UI." },
+                        { "name": "awaitPromise", "type": "boolean", "optional":true, "description": "Whether execution should wait for promise to be resolved. If the result of evaluation is not a Promise, it's considered to be an error." }
+                    ],
+                    "returns": [
+                        { "name": "result", "$ref": "RemoteObject", "description": "Evaluation result." },
+                        { "name": "exceptionDetails", "$ref": "ExceptionDetails", "optional": true, "description": "Exception details."}
+                    ],
+                    "description": "Evaluates expression on global object."
+                },
+                {
+                    "name": "awaitPromise",
+                    "async": true,
+                    "parameters": [
+                        { "name": "promiseObjectId", "$ref": "RemoteObjectId", "description": "Identifier of the promise." },
+                        { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object that should be sent by value." },
+                        { "name": "generatePreview", "type": "boolean", "optional": true, "description": "Whether preview should be generated for the result." }
+                    ],
+                    "returns": [
+                        { "name": "result", "$ref": "RemoteObject", "description": "Promise result. Will contain rejected value if promise was rejected." },
+                        { "name": "exceptionDetails", "$ref": "ExceptionDetails", "optional": true, "description": "Exception details if stack strace is available."}
+                    ],
+                    "description": "Add handler to promise with given promise object id."
+                },
+                {
+                    "name": "callFunctionOn",
+                    "async": true,
+                    "parameters": [
+                        { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to call function on." },
+                        { "name": "functionDeclaration", "type": "string", "description": "Declaration of the function to call." },
+                        { "name": "arguments", "type": "array", "items": { "$ref": "CallArgument", "description": "Call argument." }, "optional": true, "description": "Call arguments. All call arguments must belong to the same JavaScript world as the target object." },
+                        { "name": "silent", "type": "boolean", "optional": true, "description": "In silent mode exceptions thrown during evaluation are not reported and do not pause execution. Overrides <code>setPauseOnException</code> state." },
+                        { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object which should be sent by value." },
+                        { "name": "generatePreview", "type": "boolean", "optional": true, "experimental": true, "description": "Whether preview should be generated for the result." },
+                        { "name": "userGesture", "type": "boolean", "optional": true, "experimental": true, "description": "Whether execution should be treated as initiated by user in the UI." },
+                        { "name": "awaitPromise", "type": "boolean", "optional":true, "description": "Whether execution should wait for promise to be resolved. If the result of evaluation is not a Promise, it's considered to be an error." }
+                    ],
+                    "returns": [
+                        { "name": "result", "$ref": "RemoteObject", "description": "Call result." },
+                        { "name": "exceptionDetails", "$ref": "ExceptionDetails", "optional": true, "description": "Exception details."}
+                    ],
+                    "description": "Calls function with given declaration on the given object. Object group of the result is inherited from the target object."
+                },
+                {
+                    "name": "getProperties",
+                    "parameters": [
+                        { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to return properties for." },
+                        { "name": "ownProperties", "optional": true, "type": "boolean", "description": "If true, returns properties belonging only to the element itself, not to its prototype chain." },
+                        { "name": "accessorPropertiesOnly", "optional": true, "type": "boolean", "description": "If true, returns accessor properties (with getter/setter) only; internal properties are not returned either.", "experimental": true },
+                        { "name": "generatePreview", "type": "boolean", "optional": true, "experimental": true, "description": "Whether preview should be generated for the results." }
+                    ],
+                    "returns": [
+                        { "name": "result", "type": "array", "items": { "$ref": "PropertyDescriptor" }, "description": "Object properties." },
+                        { "name": "internalProperties", "optional": true, "type": "array", "items": { "$ref": "InternalPropertyDescriptor" }, "description": "Internal object properties (only of the element itself)." },
+                        { "name": "exceptionDetails", "$ref": "ExceptionDetails", "optional": true, "description": "Exception details."}
+                    ],
+                    "description": "Returns properties of a given object. Object group of the result is inherited from the target object."
+                },
+                {
+                    "name": "releaseObject",
+                    "parameters": [
+                        { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to release." }
+                    ],
+                    "description": "Releases remote object with given id."
+                },
+                {
+                    "name": "releaseObjectGroup",
+                    "parameters": [
+                        { "name": "objectGroup", "type": "string", "description": "Symbolic object group name." }
+                    ],
+                    "description": "Releases all remote objects that belong to a given group."
+                },
+                {
+                    "name": "runIfWaitingForDebugger",
+                    "description": "Tells inspected instance to run if it was waiting for debugger to attach."
+                },
+                {
+                    "name": "enable",
+                    "description": "Enables reporting of execution contexts creation by means of <code>executionContextCreated</code> event. When the reporting gets enabled the event will be sent immediately for each existing execution context."
+                },
+                {
+                    "name": "disable",
+                    "description": "Disables reporting of execution contexts creation."
+                },
+                {
+                    "name": "discardConsoleEntries",
+                    "description": "Discards collected exceptions and console API calls."
+                },
+                {
+                    "name": "setCustomObjectFormatterEnabled",
+                    "parameters": [
+                        {
+                            "name": "enabled",
+                            "type": "boolean"
+                        }
+                    ],
+                    "experimental": true
+                },
+                {
+                    "name": "compileScript",
+                    "parameters": [
+                        { "name": "expression", "type": "string", "description": "Expression to compile." },
+                        { "name": "sourceURL", "type": "string", "description": "Source url to be set for the script." },
+                        { "name": "persistScript", "type": "boolean", "description": "Specifies whether the compiled script should be persisted." },
+                        { "name": "executionContextId", "$ref": "ExecutionContextId", "optional": true, "description": "Specifies in which execution context to perform script run. If the parameter is omitted the evaluation will be performed in the context of the inspected page." }
+                    ],
+                    "returns": [
+                        { "name": "scriptId", "$ref": "ScriptId", "optional": true, "description": "Id of the script." },
+                        { "name": "exceptionDetails", "$ref": "ExceptionDetails", "optional": true, "description": "Exception details."}
+                    ],
+                    "description": "Compiles expression."
+                },
+                {
+                    "name": "runScript",
+                    "async": true,
+                    "parameters": [
+                        { "name": "scriptId", "$ref": "ScriptId", "description": "Id of the script to run." },
+                        { "name": "executionContextId", "$ref": "ExecutionContextId", "optional": true, "description": "Specifies in which execution context to perform script run. If the parameter is omitted the evaluation will be performed in the context of the inspected page." },
+                        { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." },
+                        { "name": "silent", "type": "boolean", "optional": true, "description": "In silent mode exceptions thrown during evaluation are not reported and do not pause execution. Overrides <code>setPauseOnException</code> state." },
+                        { "name": "includeCommandLineAPI", "type": "boolean", "optional": true, "description": "Determines whether Command Line API should be available during the evaluation." },
+                        { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object which should be sent by value." },
+                        { "name": "generatePreview", "type": "boolean", "optional": true, "description": "Whether preview should be generated for the result." },
+                        { "name": "awaitPromise", "type": "boolean", "optional": true, "description": "Whether execution should wait for promise to be resolved. If the result of evaluation is not a Promise, it's considered to be an error." }
+                    ],
+                    "returns": [
+                        { "name": "result", "$ref": "RemoteObject", "description": "Run result." },
+                        { "name": "exceptionDetails", "$ref": "ExceptionDetails", "optional": true, "description": "Exception details."}
+                    ],
+                    "description": "Runs script with given id in a given context."
+                }
+            ],
+            "events": [
+                {
+                    "name": "executionContextCreated",
+                    "parameters": [
+                        { "name": "context", "$ref": "ExecutionContextDescription", "description": "A newly created execution contex." }
+                    ],
+                    "description": "Issued when new execution context is created."
+                },
+                {
+                    "name": "executionContextDestroyed",
+                    "parameters": [
+                        { "name": "executionContextId", "$ref": "ExecutionContextId", "description": "Id of the destroyed context" }
+                    ],
+                    "description": "Issued when execution context is destroyed."
+                },
+                {
+                    "name": "executionContextsCleared",
+                    "description": "Issued when all executionContexts were cleared in browser"
+                },
+                {
+                    "name": "exceptionThrown",
+                    "description": "Issued when exception was thrown and unhandled.",
+                    "parameters": [
+                        { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp of the exception." },
+                        { "name": "exceptionDetails", "$ref": "ExceptionDetails" }
+                    ]
+                },
+                {
+                    "name": "exceptionRevoked",
+                    "description": "Issued when unhandled exception was revoked.",
+                    "parameters": [
+                        { "name": "reason", "type": "string", "description": "Reason describing why exception was revoked." },
+                        { "name": "exceptionId", "type": "integer", "description": "The id of revoked exception, as reported in <code>exceptionUnhandled</code>." }
+                    ]
+                },
+                {
+                    "name": "consoleAPICalled",
+                    "description": "Issued when console API was called.",
+                    "parameters": [
+                        { "name": "type", "type": "string", "enum": ["log", "debug", "info", "error", "warning", "dir", "dirxml", "table", "trace", "clear", "startGroup", "startGroupCollapsed", "endGroup", "assert", "profile", "profileEnd"], "description": "Type of the call." },
+                        { "name": "args", "type": "array", "items": { "$ref": "RemoteObject" }, "description": "Call arguments." },
+                        { "name": "executionContextId", "$ref": "ExecutionContextId", "description": "Identifier of the context where the call was made." },
+                        { "name": "timestamp", "$ref": "Timestamp", "description": "Call timestamp." },
+                        { "name": "stackTrace", "$ref": "StackTrace", "optional": true, "description": "Stack trace captured when the call was made." }
+                    ]
+                },
+                {
+                    "name": "inspectRequested",
+                    "description": "Issued when object should be inspected (for example, as a result of inspect() command line API call).",
+                    "parameters": [
+                        { "name": "object", "$ref": "RemoteObject" },
+                        { "name": "hints", "type": "object" }
+                    ]
+                }
+            ]
+        },
+        {
+            "domain": "Debugger",
+            "description": "Debugger domain exposes JavaScript debugging capabilities. It allows setting and removing breakpoints, stepping through execution, exploring stack traces, etc.",
+            "dependencies": ["Runtime"],
+            "types": [
+                {
+                    "id": "BreakpointId",
+                    "type": "string",
+                    "description": "Breakpoint identifier."
+                },
+                {
+                    "id": "CallFrameId",
+                    "type": "string",
+                    "description": "Call frame identifier."
+                },
+                {
+                    "id": "Location",
+                    "type": "object",
+                    "properties": [
+                        { "name": "scriptId", "$ref": "Runtime.ScriptId", "description": "Script identifier as reported in the <code>Debugger.scriptParsed</code>." },
+                        { "name": "lineNumber", "type": "integer", "description": "Line number in the script (0-based)." },
+                        { "name": "columnNumber", "type": "integer", "optional": true, "description": "Column number in the script (0-based)." }
+                    ],
+                    "description": "Location in the source code."
+                },
+                {
+                    "id": "ScriptPosition",
+                    "experimental": true,
+                    "type": "object",
+                    "properties": [
+                        { "name": "lineNumber", "type": "integer" },
+                        { "name": "columnNumber", "type": "integer" }
+                    ],
+                    "description": "Location in the source code."
+                },
+                {
+                    "id": "CallFrame",
+                    "type": "object",
+                    "properties": [
+                        { "name": "callFrameId", "$ref": "CallFrameId", "description": "Call frame identifier. This identifier is only valid while the virtual machine is paused." },
+                        { "name": "functionName", "type": "string", "description": "Name of the JavaScript function called on this call frame." },
+                        { "name": "functionLocation", "$ref": "Location", "optional": true, "experimental": true, "description": "Location in the source code." },
+                        { "name": "location", "$ref": "Location", "description": "Location in the source code." },
+                        { "name": "scopeChain", "type": "array", "items": { "$ref": "Scope" }, "description": "Scope chain for this call frame." },
+                        { "name": "this", "$ref": "Runtime.RemoteObject", "description": "<code>this</code> object for this call frame." },
+                        { "name": "returnValue", "$ref": "Runtime.RemoteObject", "optional": true, "description": "The value being returned, if the function is at return point." }
+                    ],
+                    "description": "JavaScript call frame. Array of call frames form the call stack."
+                },
+                {
+                    "id": "Scope",
+                    "type": "object",
+                    "properties": [
+                        { "name": "type", "type": "string", "enum": ["global", "local", "with", "closure", "catch", "block", "script"], "description": "Scope type." },
+                        { "name": "object", "$ref": "Runtime.RemoteObject", "description": "Object representing the scope. For <code>global</code> and <code>with</code> scopes it represents the actual object; for the rest of the scopes, it is artificial transient object enumerating scope variables as its properties." },
+                        { "name": "name", "type": "string", "optional": true },
+                        { "name": "startLocation", "$ref": "Location", "optional": true, "description": "Location in the source code where scope starts" },
+                        { "name": "endLocation", "$ref": "Location", "optional": true, "description": "Location in the source code where scope ends" }
+                    ],
+                    "description": "Scope description."
+                },
+                {
+                    "id": "SearchMatch",
+                    "type": "object",
+                    "description": "Search match for resource.",
+                    "exported": true,
+                    "properties": [
+                        { "name": "lineNumber", "type": "number", "description": "Line number in resource content." },
+                        { "name": "lineContent", "type": "string", "description": "Line with match content." }
+                    ],
+                    "experimental": true
+                }
+            ],
+            "commands": [
+                {
+                    "name": "enable",
+                    "description": "Enables debugger for the given page. Clients should not assume that the debugging has been enabled until the result for this command is received."
+                },
+                {
+                    "name": "disable",
+                    "description": "Disables debugger for given page."
+                },
+                {
+                    "name": "setBreakpointsActive",
+                    "parameters": [
+                        { "name": "active", "type": "boolean", "description": "New value for breakpoints active state." }
+                    ],
+                    "description": "Activates / deactivates all breakpoints on the page."
+                },
+                {
+                    "name": "setSkipAllPauses",
+                    "parameters": [
+                        { "name": "skip", "type": "boolean", "description": "New value for skip pauses state." }
+                    ],
+                    "description": "Makes page not interrupt on any pauses (breakpoint, exception, dom exception etc)."
+                },
+                {
+                    "name": "setBreakpointByUrl",
+                    "parameters": [
+                        { "name": "lineNumber", "type": "integer", "description": "Line number to set breakpoint at." },
+                        { "name": "url", "type": "string", "optional": true, "description": "URL of the resources to set breakpoint on." },
+                        { "name": "urlRegex", "type": "string", "optional": true, "description": "Regex pattern for the URLs of the resources to set breakpoints on. Either <code>url</code> or <code>urlRegex</code> must be specified." },
+                        { "name": "columnNumber", "type": "integer", "optional": true, "description": "Offset in the line to set breakpoint at." },
+                        { "name": "condition", "type": "string", "optional": true, "description": "Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true." }
+                    ],
+                    "returns": [
+                        { "name": "breakpointId", "$ref": "BreakpointId", "description": "Id of the created breakpoint for further reference." },
+                        { "name": "locations", "type": "array", "items": { "$ref": "Location" }, "description": "List of the locations this breakpoint resolved into upon addition." }
+                    ],
+                    "description": "Sets JavaScript breakpoint at given location specified either by URL or URL regex. Once this command is issued, all existing parsed scripts will have breakpoints resolved and returned in <code>locations</code> property. Further matching script parsing will result in subsequent <code>breakpointResolved</code> events issued. This logical breakpoint will survive page reloads."
+                },
+                {
+                    "name": "setBreakpoint",
+                    "parameters": [
+                        { "name": "location", "$ref": "Location", "description": "Location to set breakpoint in." },
+                        { "name": "condition", "type": "string", "optional": true, "description": "Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true." }
+                    ],
+                    "returns": [
+                        { "name": "breakpointId", "$ref": "BreakpointId", "description": "Id of the created breakpoint for further reference." },
+                        { "name": "actualLocation", "$ref": "Location", "description": "Location this breakpoint resolved into." }
+                    ],
+                    "description": "Sets JavaScript breakpoint at a given location."
+                },
+                {
+                    "name": "removeBreakpoint",
+                    "parameters": [
+                        { "name": "breakpointId", "$ref": "BreakpointId" }
+                    ],
+                    "description": "Removes JavaScript breakpoint."
+                },
+                {
+                    "name": "continueToLocation",
+                    "parameters": [
+                        { "name": "location", "$ref": "Location", "description": "Location to continue to." }
+                    ],
+                    "description": "Continues execution until specific location is reached."
+                },
+                {
+                    "name": "stepOver",
+                    "description": "Steps over the statement."
+                },
+                {
+                    "name": "stepInto",
+                    "description": "Steps into the function call."
+                },
+                {
+                    "name": "stepOut",
+                    "description": "Steps out of the function call."
+                },
+                {
+                    "name": "pause",
+                    "description": "Stops on the next JavaScript statement."
+                },
+                {
+                    "name": "resume",
+                    "description": "Resumes JavaScript execution."
+                },
+                {
+                    "name": "searchInContent",
+                    "parameters": [
+                        { "name": "scriptId", "$ref": "Runtime.ScriptId", "description": "Id of the script to search in." },
+                        { "name": "query", "type": "string", "description": "String to search for."  },
+                        { "name": "caseSensitive", "type": "boolean", "optional": true, "description": "If true, search is case sensitive." },
+                        { "name": "isRegex", "type": "boolean", "optional": true, "description": "If true, treats string parameter as regex." }
+                    ],
+                    "returns": [
+                        { "name": "result", "type": "array", "items": { "$ref": "SearchMatch" }, "description": "List of search matches." }
+                    ],
+                    "experimental": true,
+                    "description": "Searches for given string in script content."
+                },
+                {
+                    "name": "setScriptSource",
+                    "parameters": [
+                        { "name": "scriptId", "$ref": "Runtime.ScriptId", "description": "Id of the script to edit." },
+                        { "name": "scriptSource", "type": "string", "description": "New content of the script." },
+                        { "name": "dryRun", "type": "boolean", "optional": true, "description": " If true the change will not actually be applied. Dry run may be used to get result description without actually modifying the code." }
+                    ],
+                    "returns": [
+                        { "name": "callFrames", "type": "array", "optional": true, "items": { "$ref": "CallFrame" }, "description": "New stack trace in case editing has happened while VM was stopped." },
+                        { "name": "stackChanged", "type": "boolean", "optional": true, "description": "Whether current call stack  was modified after applying the changes." },
+                        { "name": "asyncStackTrace", "$ref": "Runtime.StackTrace", "optional": true, "description": "Async stack trace, if any." },
+                        { "name": "exceptionDetails", "optional": true, "$ref": "Runtime.ExceptionDetails", "description": "Exception details if any." }
+                    ],
+                    "description": "Edits JavaScript source live."
+                },
+                {
+                    "name": "restartFrame",
+                    "parameters": [
+                        { "name": "callFrameId", "$ref": "CallFrameId", "description": "Call frame identifier to evaluate on." }
+                    ],
+                    "returns": [
+                        { "name": "callFrames", "type": "array", "items": { "$ref": "CallFrame" }, "description": "New stack trace." },
+                        { "name": "asyncStackTrace", "$ref": "Runtime.StackTrace", "optional": true, "description": "Async stack trace, if any." }
+                    ],
+                    "description": "Restarts particular call frame from the beginning."
+                },
+                {
+                    "name": "getScriptSource",
+                    "parameters": [
+                        { "name": "scriptId", "$ref": "Runtime.ScriptId", "description": "Id of the script to get source for." }
+                    ],
+                    "returns": [
+                        { "name": "scriptSource", "type": "string", "description": "Script source." }
+                    ],
+                    "description": "Returns source for the script with given id."
+                },
+                {
+                    "name": "setPauseOnExceptions",
+                    "parameters": [
+                        { "name": "state", "type": "string", "enum": ["none", "uncaught", "all"], "description": "Pause on exceptions mode." }
+                    ],
+                    "description": "Defines pause on exceptions state. Can be set to stop on all exceptions, uncaught exceptions or no exceptions. Initial pause on exceptions state is <code>none</code>."
+                },
+                {
+                    "name": "evaluateOnCallFrame",
+                    "parameters": [
+                        { "name": "callFrameId", "$ref": "CallFrameId", "description": "Call frame identifier to evaluate on." },
+                        { "name": "expression", "type": "string", "description": "Expression to evaluate." },
+                        { "name": "objectGroup", "type": "string", "optional": true, "description": "String object group name to put result into (allows rapid releasing resulting object handles using <code>releaseObjectGroup</code>)." },
+                        { "name": "includeCommandLineAPI", "type": "boolean", "optional": true, "description": "Specifies whether command line API should be available to the evaluated expression, defaults to false." },
+                        { "name": "silent", "type": "boolean", "optional": true, "description": "In silent mode exceptions thrown during evaluation are not reported and do not pause execution. Overrides <code>setPauseOnException</code> state." },
+                        { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object that should be sent by value." },
+                        { "name": "generatePreview", "type": "boolean", "optional": true, "experimental": true, "description": "Whether preview should be generated for the result." }
+                    ],
+                    "returns": [
+                        { "name": "result", "$ref": "Runtime.RemoteObject", "description": "Object wrapper for the evaluation result." },
+                        { "name": "exceptionDetails", "$ref": "Runtime.ExceptionDetails", "optional": true, "description": "Exception details."}
+                    ],
+                    "description": "Evaluates expression on a given call frame."
+                },
+                {
+                    "name": "setVariableValue",
+                    "parameters": [
+                        { "name": "scopeNumber", "type": "integer", "description": "0-based number of scope as was listed in scope chain. Only 'local', 'closure' and 'catch' scope types are allowed. Other scopes could be manipulated manually." },
+                        { "name": "variableName", "type": "string", "description": "Variable name." },
+                        { "name": "newValue", "$ref": "Runtime.CallArgument", "description": "New variable value." },
+                        { "name": "callFrameId", "$ref": "CallFrameId", "description": "Id of callframe that holds variable." }
+                    ],
+                    "description": "Changes value of variable in a callframe. Object-based scopes are not supported and must be mutated manually."
+                },
+                {
+                    "name": "setAsyncCallStackDepth",
+                    "parameters": [
+                        { "name": "maxDepth", "type": "integer", "description": "Maximum depth of async call stacks. Setting to <code>0</code> will effectively disable collecting async call stacks (default)." }
+                    ],
+                    "description": "Enables or disables async call stacks tracking."
+                },
+                {
+                    "name": "setBlackboxPatterns",
+                    "parameters": [
+                        { "name": "patterns", "type": "array", "items": { "type": "string" }, "description": "Array of regexps that will be used to check script url for blackbox state." }
+                    ],
+                    "experimental": true,
+                    "description": "Replace previous blackbox patterns with passed ones. Forces backend to skip stepping/pausing in scripts with url matching one of the patterns. VM will try to leave blackboxed script by performing 'step in' several times, finally resorting to 'step out' if unsuccessful."
+                },
+                {
+                    "name": "setBlackboxedRanges",
+                    "parameters": [
+                        { "name": "scriptId", "$ref": "Runtime.ScriptId", "description": "Id of the script." },
+                        { "name": "positions", "type": "array", "items": { "$ref": "ScriptPosition" } }
+                    ],
+                    "experimental": true,
+                    "description": "Makes backend skip steps in the script in blackboxed ranges. VM will try leave blacklisted scripts by performing 'step in' several times, finally resorting to 'step out' if unsuccessful. Positions array contains positions where blackbox state is changed. First interval isn't blackboxed. Array should be sorted."
+                }
+            ],
+            "events": [
+                {
+                    "name": "scriptParsed",
+                    "parameters": [
+                        { "name": "scriptId", "$ref": "Runtime.ScriptId", "description": "Identifier of the script parsed." },
+                        { "name": "url", "type": "string", "description": "URL or name of the script parsed (if any)." },
+                        { "name": "startLine", "type": "integer", "description": "Line offset of the script within the resource with given URL (for script tags)." },
+                        { "name": "startColumn", "type": "integer", "description": "Column offset of the script within the resource with given URL." },
+                        { "name": "endLine", "type": "integer", "description": "Last line of the script." },
+                        { "name": "endColumn", "type": "integer", "description": "Length of the last line of the script." },
+                        { "name": "executionContextId", "$ref": "Runtime.ExecutionContextId", "description": "Specifies script creation context." },
+                        { "name": "hash", "type": "string", "description": "Content hash of the script."},
+                        { "name": "executionContextAuxData", "type": "object", "optional": true, "description": "Embedder-specific auxiliary data." },
+                        { "name": "isLiveEdit", "type": "boolean", "optional": true, "description": "True, if this script is generated as a result of the live edit operation.", "experimental": true },
+                        { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with script (if any)." },
+                        { "name": "hasSourceURL", "type": "boolean", "optional": true, "description": "True, if this script has sourceURL.", "experimental": true }
+                    ],
+                    "description": "Fired when virtual machine parses script. This event is also fired for all known and uncollected scripts upon enabling debugger."
+                },
+                {
+                    "name": "scriptFailedToParse",
+                    "parameters": [
+                        { "name": "scriptId", "$ref": "Runtime.ScriptId", "description": "Identifier of the script parsed." },
+                        { "name": "url", "type": "string", "description": "URL or name of the script parsed (if any)." },
+                        { "name": "startLine", "type": "integer", "description": "Line offset of the script within the resource with given URL (for script tags)." },
+                        { "name": "startColumn", "type": "integer", "description": "Column offset of the script within the resource with given URL." },
+                        { "name": "endLine", "type": "integer", "description": "Last line of the script." },
+                        { "name": "endColumn", "type": "integer", "description": "Length of the last line of the script." },
+                        { "name": "executionContextId", "$ref": "Runtime.ExecutionContextId", "description": "Specifies script creation context." },
+                        { "name": "hash", "type": "string", "description": "Content hash of the script."},
+                        { "name": "executionContextAuxData", "type": "object", "optional": true, "description": "Embedder-specific auxiliary data." },
+                        { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with script (if any)." },
+                        { "name": "hasSourceURL", "type": "boolean", "optional": true, "description": "True, if this script has sourceURL.", "experimental": true }
+                    ],
+                    "description": "Fired when virtual machine fails to parse the script."
+                },
+                {
+                    "name": "breakpointResolved",
+                    "parameters": [
+                        { "name": "breakpointId", "$ref": "BreakpointId", "description": "Breakpoint unique identifier." },
+                        { "name": "location", "$ref": "Location", "description": "Actual breakpoint location." }
+                    ],
+                    "description": "Fired when breakpoint is resolved to an actual script and location."
+                },
+                {
+                    "name": "paused",
+                    "parameters": [
+                        { "name": "callFrames", "type": "array", "items": { "$ref": "CallFrame" }, "description": "Call stack the virtual machine stopped on." },
+                        { "name": "reason", "type": "string", "enum": [ "XHR", "DOM", "EventListener", "exception", "assert", "debugCommand", "promiseRejection", "other" ], "description": "Pause reason.", "exported": true },
+                        { "name": "data", "type": "object", "optional": true, "description": "Object containing break-specific auxiliary properties." },
+                        { "name": "hitBreakpoints", "type": "array", "optional": true, "items": { "type": "string" }, "description": "Hit breakpoints IDs" },
+                        { "name": "asyncStackTrace", "$ref": "Runtime.StackTrace", "optional": true, "description": "Async stack trace, if any." }
+                    ],
+                    "description": "Fired when the virtual machine stopped on breakpoint or exception or any other stop criteria."
+                },
+                {
+                    "name": "resumed",
+                    "description": "Fired when the virtual machine resumed execution."
+                }
+            ]
+        },
+        {
+            "domain": "Console",
+            "description": "This domain is deprecated - use Runtime or Log instead.",
+            "dependencies": ["Runtime"],
+            "deprecated": true,
+            "types": [
+                {
+                    "id": "ConsoleMessage",
+                    "type": "object",
+                    "description": "Console message.",
+                    "properties": [
+                        { "name": "source", "type": "string", "enum": ["xml", "javascript", "network", "console-api", "storage", "appcache", "rendering", "security", "other", "deprecation", "worker"], "description": "Message source." },
+                        { "name": "level", "type": "string", "enum": ["log", "warning", "error", "debug", "info"], "description": "Message severity." },
+                        { "name": "text", "type": "string", "description": "Message text." },
+                        { "name": "url", "type": "string", "optional": true, "description": "URL of the message origin." },
+                        { "name": "line", "type": "integer", "optional": true, "description": "Line number in the resource that generated this message (1-based)." },
+                        { "name": "column", "type": "integer", "optional": true, "description": "Column number in the resource that generated this message (1-based)." }
+                    ]
+                }
+            ],
+            "commands": [
+                {
+                    "name": "enable",
+                    "description": "Enables console domain, sends the messages collected so far to the client by means of the <code>messageAdded</code> notification."
+                },
+                {
+                    "name": "disable",
+                    "description": "Disables console domain, prevents further console messages from being reported to the client."
+                },
+                {
+                    "name": "clearMessages",
+                    "description": "Does nothing."
+                }
+            ],
+            "events": [
+                {
+                    "name": "messageAdded",
+                    "parameters": [
+                        { "name": "message", "$ref": "ConsoleMessage", "description": "Console message that has been added." }
+                    ],
+                    "description": "Issued when new console message is added."
+                }
+            ]
+        },
+        {
+            "domain": "Profiler",
+            "dependencies": ["Runtime", "Debugger"],
+            "types": [
+                {
+                    "id": "ProfileNode",
+                    "type": "object",
+                    "description": "Profile node. Holds callsite information, execution statistics and child nodes.",
+                    "properties": [
+                        { "name": "id", "type": "integer", "description": "Unique id of the node." },
+                        { "name": "callFrame", "$ref": "Runtime.CallFrame", "description": "Function location." },
+                        { "name": "hitCount", "type": "integer", "optional": true, "experimental": true, "description": "Number of samples where this node was on top of the call stack." },
+                        { "name": "children", "type": "array", "items": { "type": "integer" }, "optional": true, "description": "Child node ids." },
+                        { "name": "deoptReason", "type": "string", "optional": true, "description": "The reason of being not optimized. The function may be deoptimized or marked as don't optimize."},
+                        { "name": "positionTicks", "type": "array", "items": { "$ref": "PositionTickInfo" }, "optional": true, "experimental": true, "description": "An array of source position ticks." }
+                    ]
+                },
+                {
+                    "id": "Profile",
+                    "type": "object",
+                    "description": "Profile.",
+                    "properties": [
+                        { "name": "nodes", "type": "array", "items": { "$ref": "ProfileNode" }, "description": "The list of profile nodes. First item is the root node." },
+                        { "name": "startTime", "type": "number", "description": "Profiling start timestamp in microseconds." },
+                        { "name": "endTime", "type": "number", "description": "Profiling end timestamp in microseconds." },
+                        { "name": "samples", "optional": true, "type": "array", "items": { "type": "integer" }, "description": "Ids of samples top nodes." },
+                        { "name": "timeDeltas", "optional": true, "type": "array", "items": { "type": "integer" }, "description": "Time intervals between adjacent samples in microseconds. The first delta is relative to the profile startTime." }
+                    ]
+                },
+                {
+                    "id": "PositionTickInfo",
+                    "type": "object",
+                    "experimental": true,
+                    "description": "Specifies a number of samples attributed to a certain source position.",
+                    "properties": [
+                        { "name": "line", "type": "integer", "description": "Source line number (1-based)." },
+                        { "name": "ticks", "type": "integer", "description": "Number of samples attributed to the source line." }
+                    ]
+                }
+            ],
+            "commands": [
+                {
+                    "name": "enable"
+                },
+                {
+                    "name": "disable"
+                },
+                {
+                    "name": "setSamplingInterval",
+                    "parameters": [
+                        { "name": "interval", "type": "integer", "description": "New sampling interval in microseconds." }
+                    ],
+                    "description": "Changes CPU profiler sampling interval. Must be called before CPU profiles recording started."
+                },
+                {
+                    "name": "start"
+                },
+                {
+                    "name": "stop",
+                    "returns": [
+                        { "name": "profile", "$ref": "Profile", "description": "Recorded profile." }
+                    ]
+                }
+            ],
+            "events": [
+                {
+                    "name": "consoleProfileStarted",
+                    "parameters": [
+                        { "name": "id", "type": "string" },
+                        { "name": "location", "$ref": "Debugger.Location", "description": "Location of console.profile()." },
+                        { "name": "title", "type": "string", "optional": true, "description": "Profile title passed as an argument to console.profile()." }
+                    ],
+                    "description": "Sent when new profile recodring is started using console.profile() call."
+                },
+                {
+                    "name": "consoleProfileFinished",
+                    "parameters": [
+                        { "name": "id", "type": "string" },
+                        { "name": "location", "$ref": "Debugger.Location", "description": "Location of console.profileEnd()." },
+                        { "name": "profile", "$ref": "Profile" },
+                        { "name": "title", "type": "string", "optional": true, "description": "Profile title passed as an argument to console.profile()." }
+                    ]
+                }
+            ]
+        },
+        {
+            "domain": "HeapProfiler",
+            "dependencies": ["Runtime"],
+            "experimental": true,
+            "types": [
+                {
+                    "id": "HeapSnapshotObjectId",
+                    "type": "string",
+                    "description": "Heap snapshot object id."
+                },
+                {
+                    "id": "SamplingHeapProfileNode",
+                    "type": "object",
+                    "description": "Sampling Heap Profile node. Holds callsite information, allocation statistics and child nodes.",
+                    "properties": [
+                        { "name": "callFrame", "$ref": "Runtime.CallFrame", "description": "Function location." },
+                        { "name": "selfSize", "type": "number", "description": "Allocations size in bytes for the node excluding children." },
+                        { "name": "children", "type": "array", "items": { "$ref": "SamplingHeapProfileNode" }, "description": "Child nodes." }
+                    ]
+                },
+                {
+                    "id": "SamplingHeapProfile",
+                    "type": "object",
+                    "description": "Profile.",
+                    "properties": [
+                        { "name": "head", "$ref": "SamplingHeapProfileNode" }
+                    ]
+                }
+            ],
+            "commands": [
+                {
+                    "name": "enable"
+                },
+                {
+                    "name": "disable"
+                },
+                {
+                    "name": "startTrackingHeapObjects",
+                    "parameters": [
+                        { "name": "trackAllocations", "type": "boolean", "optional": true }
+                    ]
+                },
+                {
+                    "name": "stopTrackingHeapObjects",
+                    "parameters": [
+                        { "name": "reportProgress", "type": "boolean", "optional": true, "description": "If true 'reportHeapSnapshotProgress' events will be generated while snapshot is being taken when the tracking is stopped." }
+                    ]
+                },
+                {
+                    "name": "takeHeapSnapshot",
+                    "parameters": [
+                        { "name": "reportProgress", "type": "boolean", "optional": true, "description": "If true 'reportHeapSnapshotProgress' events will be generated while snapshot is being taken." }
+                    ]
+                },
+                {
+                    "name": "collectGarbage"
+                },
+                {
+                    "name": "getObjectByHeapObjectId",
+                    "parameters": [
+                        { "name": "objectId", "$ref": "HeapSnapshotObjectId" },
+                        { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." }
+                    ],
+                    "returns": [
+                        { "name": "result", "$ref": "Runtime.RemoteObject", "description": "Evaluation result." }
+                    ]
+                },
+                {
+                    "name": "addInspectedHeapObject",
+                    "parameters": [
+                        { "name": "heapObjectId", "$ref": "HeapSnapshotObjectId", "description": "Heap snapshot object id to be accessible by means of $x command line API." }
+                    ],
+                    "description": "Enables console to refer to the node with given id via $x (see Command Line API for more details $x functions)."
+                },
+                {
+                    "name": "getHeapObjectId",
+                    "parameters": [
+                        { "name": "objectId", "$ref": "Runtime.RemoteObjectId", "description": "Identifier of the object to get heap object id for." }
+                    ],
+                    "returns": [
+                        { "name": "heapSnapshotObjectId", "$ref": "HeapSnapshotObjectId", "description": "Id of the heap snapshot object corresponding to the passed remote object id." }
+                    ]
+                },
+                {
+                    "name": "startSampling",
+                    "parameters": [
+                        { "name": "samplingInterval", "type": "number", "optional": true, "description": "Average sample interval in bytes. Poisson distribution is used for the intervals. The default value is 32768 bytes." }
+                    ]
+                },
+                {
+                    "name": "stopSampling",
+                    "returns": [
+                        { "name": "profile", "$ref": "SamplingHeapProfile", "description": "Recorded sampling heap profile." }
+                    ]
+                }
+            ],
+            "events": [
+                {
+                    "name": "addHeapSnapshotChunk",
+                    "parameters": [
+                        { "name": "chunk", "type": "string" }
+                    ]
+                },
+                {
+                    "name": "resetProfiles"
+                },
+                {
+                    "name": "reportHeapSnapshotProgress",
+                    "parameters": [
+                        { "name": "done", "type": "integer" },
+                        { "name": "total", "type": "integer" },
+                        { "name": "finished", "type": "boolean", "optional": true }
+                    ]
+                },
+                {
+                    "name": "lastSeenObjectId",
+                    "description": "If heap objects tracking has been started then backend regulary sends a current value for last seen object id and corresponding timestamp. If the were changes in the heap since last event then one or more heapStatsUpdate events will be sent before a new lastSeenObjectId event.",
+                    "parameters": [
+                        { "name": "lastSeenObjectId", "type": "integer" },
+                        { "name": "timestamp", "type": "number" }
+                    ]
+                },
+                {
+                    "name": "heapStatsUpdate",
+                    "description": "If heap objects tracking has been started then backend may send update for one or more fragments",
+                    "parameters": [
+                        { "name": "statsUpdate", "type": "array", "items": { "type": "integer" }, "description": "An array of triplets. Each triplet describes a fragment. The first integer is the fragment index, the second integer is a total count of objects for the fragment, the third integer is a total size of the objects for the fragment."}
+                    ]
+                }
+            ]
+        },
+        {
+            "domain": "GenericTypes",
+            "description": "Exposes generic types to be used by any domain.",
+            "types": [
+                {
+                    "id": "SearchMatch",
+                    "type": "object",
+                    "description": "Search match in a resource.",
+                    "properties": [
+                        {
+                            "name": "lineNumber",
+                            "type": "number",
+                            "description": "Line number in resource content."
+                        },
+                        {
+                            "name": "lineContent",
+                            "type": "string",
+                            "description": "Line with match content."
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "domain": "Page",
+            "description": "Actions and events related to the inspected page belong to the page domain.",
+            "types": [
+                {
+                    "id": "ResourceType",
+                    "type": "string",
+                    "enum": [
+                        "Document",
+                        "Stylesheet",
+                        "Image",
+                        "Font",
+                        "Script",
+                        "XHR",
+                        "WebSocket",
+                        "Other"
+                    ],
+                    "description": "Resource type as it was perceived by the rendering engine."
+                },
+                {
+                    "id": "CoordinateSystem",
+                    "type": "string",
+                    "enum": [
+                        "Viewport",
+                        "Page"
+                    ],
+                    "description": "Coordinate system used by supplied coordinates."
+                },
+                {
+                    "id": "Frame",
+                    "type": "object",
+                    "description": "Information about the Frame on the page.",
+                    "properties": [
+                        {
+                            "name": "id",
+                            "type": "string",
+                            "description": "Frame unique identifier."
+                        },
+                        {
+                            "name": "parentId",
+                            "type": "string",
+                            "optional": true,
+                            "description": "Parent frame identifier."
+                        },
+                        {
+                            "name": "loaderId",
+                            "type": "string",
+                            "description": "Identifier of the loader associated with this frame."
+                        },
+                        {
+                            "name": "name",
+                            "type": "string",
+                            "optional": true,
+                            "description": "Frame's name as specified in the tag."
+                        },
+                        {
+                            "name": "url",
+                            "type": "string",
+                            "description": "Frame document's URL."
+                        },
+                        {
+                            "name": "securityOrigin",
+                            "type": "string",
+                            "description": "Frame document's security origin."
+                        },
+                        {
+                            "name": "mimeType",
+                            "type": "string",
+                            "description": "Frame document's mimeType as determined by the browser."
+                        }
+                    ]
+                },
+                {
+                    "id": "FrameResource",
+                    "type": "object",
+                    "properties": [
+                        {
+                            "name": "url",
+                            "type": "string",
+                            "description": "Resource URL."
+                        },
+                        {
+                            "name": "type",
+                            "$ref": "ResourceType",
+                            "description": "Type of this resource."
+                        },
+                        {
+                            "name": "mimeType",
+                            "type": "string",
+                            "description": "Resource mimeType as determined by the browser."
+                        },
+                        {
+                            "name": "failed",
+                            "type": "boolean",
+                            "optional": true,
+                            "description": "True if the resource failed to load."
+                        },
+                        {
+                            "name": "canceled",
+                            "type": "boolean",
+                            "optional": true,
+                            "description": "True if the resource was canceled during loading."
+                        },
+                        {
+                            "name": "sourceMapURL",
+                            "type": "string",
+                            "optional": true,
+                            "description": "URL of source map associated with this resource (if any)."
+                        }
+                    ]
+                },
+                {
+                    "id": "FrameResourceTree",
+                    "type": "object",
+                    "description": "Information about the Frame hierarchy along with their cached resources.",
+                    "properties": [
+                        {
+                            "name": "frame",
+                            "$ref": "Frame",
+                            "description": "Frame information for this tree item."
+                        },
+                        {
+                            "name": "childFrames",
+                            "type": "array",
+                            "optional": true,
+                            "items": {
+                                "$ref": "FrameResourceTree"
+                            },
+                            "description": "Child frames."
+                        },
+                        {
+                            "name": "resources",
+                            "type": "array",
+                            "items": {
+                                "$ref": "FrameResource"
+                            },
+                            "description": "Information about frame resources."
+                        }
+                    ]
+                },
+                {
+                    "id": "SearchResult",
+                    "type": "object",
+                    "description": "Search result for resource.",
+                    "properties": [
+                        {
+                            "name": "url",
+                            "type": "string",
+                            "description": "Resource URL."
+                        },
+                        {
+                            "name": "frameId",
+                            "type": "string",
+                            "description": "Resource frame id."
+                        },
+                        {
+                            "name": "matchesCount",
+                            "type": "number",
+                            "description": "Number of matches in the resource content."
+                        },
+                        {
+                            "name": "requestId",
+                            "type": "string",
+                            "optional": true,
+                            "description": "Network request id."
+                        }
+                    ]
+                },
+                {
+                    "id": "ScriptIdentifier",
+                    "type": "string",
+                    "description": "Unique script identifier."
+                }
+            ],
+            "commands": [
+                {
+                    "name": "enable",
+                    "description": "Enables page domain notifications."
+                },
+                {
+                    "name": "disable",
+                    "description": "Disables page domain notifications."
+                },
+                {
+                    "name": "addScriptToEvaluateOnLoad",
+                    "parameters": [
+                        {
+                            "name": "scriptSource",
+                            "type": "string"
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "identifier",
+                            "$ref": "ScriptIdentifier",
+                            "description": "Identifier of the added script."
+                        }
+                    ]
+                },
+                {
+                    "name": "removeScriptToEvaluateOnLoad",
+                    "parameters": [
+                        {
+                            "name": "identifier",
+                            "$ref": "ScriptIdentifier"
+                        }
+                    ]
+                },
+                {
+                    "name": "reload",
+                    "parameters": [
+                        {
+                            "name": "ignoreCache",
+                            "type": "boolean",
+                            "optional": true,
+                            "description": "If true, browser cache is ignored (as if the user pressed Shift+refresh)."
+                        },
+                        {
+                            "name": "scriptToEvaluateOnLoad",
+                            "type": "string",
+                            "optional": true,
+                            "description": "If set, the script will be injected into all frames of the inspected page after reload."
+                        }
+                    ],
+                    "description": "Reloads given page optionally ignoring the cache."
+                },
+                {
+                    "name": "getResourceTree",
+                    "description": "Returns present frame / resource tree structure.",
+                    "returns": [
+                        {
+                            "name": "frameTree",
+                            "$ref": "FrameResourceTree",
+                            "description": "Present frame / resource tree structure."
+                        }
+                    ]
+                },
+                {
+                    "name": "getResourceContent",
+                    "description": "Returns content of the given resource.",
+                    "parameters": [
+                        {
+                            "name": "frameId",
+                            "type": "string",
+                            "description": "Frame id to get resource for."
+                        },
+                        {
+                            "name": "url",
+                            "type": "string",
+                            "description": "URL of the resource to get content for."
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "content",
+                            "type": "string",
+                            "description": "Resource content."
+                        },
+                        {
+                            "name": "base64Encoded",
+                            "type": "boolean",
+                            "description": "True, if content was served as base64."
+                        }
+                    ]
+                },
+                {
+                    "name": "searchInResource",
+                    "description": "Searches for given string in resource content.",
+                    "parameters": [
+                        {
+                            "name": "frameId",
+                            "type": "string",
+                            "description": "Frame id for resource to search in."
+                        },
+                        {
+                            "name": "url",
+                            "type": "string",
+                            "description": "URL of the resource to search in."
+                        },
+                        {
+                            "name": "query",
+                            "type": "string",
+                            "description": "String to search for."
+                        },
+                        {
+                            "name": "caseSensitive",
+                            "type": "boolean",
+                            "optional": true,
+                            "description": "If true, search is case sensitive."
+                        },
+                        {
+                            "name": "isRegex",
+                            "type": "boolean",
+                            "optional": true,
+                            "description": "If true, treats string parameter as regex."
+                        },
+                        {
+                            "name": "requestId",
+                            "type": "string",
+                            "optional": true,
+                            "description": "Request id for resource to search in."
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "result",
+                            "type": "array",
+                            "items": {
+                                "$ref": "GenericTypes.SearchMatch"
+                            },
+                            "description": "List of search matches."
+                        }
+                    ]
+                },
+                {
+                    "name": "searchInResources",
+                    "description": "Searches for given string in frame / resource tree structure.",
+                    "parameters": [
+                        {
+                            "name": "text",
+                            "type": "string",
+                            "description": "String to search for."
+                        },
+                        {
+                            "name": "caseSensitive",
+                            "type": "boolean",
+                            "optional": true,
+                            "description": "If true, search is case sensitive."
+                        },
+                        {
+                            "name": "isRegex",
+                            "type": "boolean",
+                            "optional": true,
+                            "description": "If true, treats string parameter as regex."
+                        }
+                    ],
+                    "returns": [
+                        {
+                            "name": "result",
+                            "type": "array",
+                            "items": {
+                                "$ref": "SearchResult"
+                            },
+                            "description": "List of search results."
+                        }
+                    ]
+                },
+                {
+                    "name": "setDocumentContent",
+                    "description": "Sets given markup as the document's HTML.",
+                    "parameters": [
+                        {
+                            "name": "frameId",
+                            "type": "string",
+                            "description": "Frame id to set HTML for."
+                        },
+                        {
+                            "name": "html",
+                            "type": "string",
+                            "description": "HTML content to set."
+                        }
+                    ]
+                }
+            ],
+            "events": [
+                {
+                    "name": "loadEventFired",
+                    "parameters": [
+                        {
+                            "name": "timestamp",
+                            "type": "number"
+                        }
+                    ]
+                },
+                {
+                    "name": "frameDetached",
+                    "description": "Fired when frame has been detached from its parent.",
+                    "parameters": [
+                        {
+                            "name": "frameId",
+                            "type": "string",
+                            "description": "Id of the frame that has been detached."
+                        }
+                    ]
+                },
+                {
+                    "name": "frameStartedLoading",
+                    "description": "Fired when frame has started loading.",
+                    "parameters": [
+                        {
+                            "name": "frameId",
+                            "type": "string",
+                            "description": "Id of the frame that has started loading."
+                        }
+                    ]
+                },
+                {
+                    "name": "frameStoppedLoading",
+                    "description": "Fired when frame has stopped loading.",
+                    "parameters": [
+                        {
+                            "name": "frameId",
+                            "type": "string",
+                            "description": "Id of the frame that has stopped loading."
+                        }
+                    ]
+                }
+            ]
+        }]
 }

--- a/runtime/src/main/jni/v8_inspector/src/inspector/protocol/GenericTypes.cpp
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/protocol/GenericTypes.cpp
@@ -1,0 +1,103 @@
+// This file is generated
+
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "src/inspector/protocol/GenericTypes.h"
+
+#include "src/inspector/protocol/Protocol.h"
+
+namespace v8_inspector {
+namespace protocol {
+namespace GenericTypes {
+
+// ------------- Enum values from types.
+
+const char Metainfo::domainName[] = "GenericTypes";
+const char Metainfo::commandPrefix[] = "GenericTypes.";
+const char Metainfo::version[] = "1.1";
+
+std::unique_ptr<SearchMatch> SearchMatch::parse(protocol::Value* value, ErrorSupport* errors) {
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<SearchMatch> result(new SearchMatch());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* lineNumberValue = object->get("lineNumber");
+    errors->setName("lineNumber");
+    result->m_lineNumber = ValueConversions<double>::parse(lineNumberValue, errors);
+    protocol::Value* lineContentValue = object->get("lineContent");
+    errors->setName("lineContent");
+    result->m_lineContent = ValueConversions<String>::parse(lineContentValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        return nullptr;
+    }
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> SearchMatch::serialize() const {
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("lineNumber", ValueConversions<double>::serialize(m_lineNumber));
+    result->setValue("lineContent", ValueConversions<String>::serialize(m_lineContent));
+    return result;
+}
+
+std::unique_ptr<SearchMatch> SearchMatch::clone() const {
+    ErrorSupport errors;
+    return parse(serialize().get(), &errors);
+}
+
+// ------------- Enum values from params.
+
+
+// ------------- Frontend notifications.
+
+void Frontend::flush() {
+    m_frontendChannel->flushProtocolNotifications();
+}
+
+// --------------------- Dispatcher.
+
+class DispatcherImpl : public protocol::DispatcherBase {
+    public:
+        DispatcherImpl(FrontendChannel* frontendChannel, Backend* backend)
+            : DispatcherBase(frontendChannel)
+            , m_backend(backend) {
+        }
+        ~DispatcherImpl() override { }
+        void dispatch(int callId, const String& method, std::unique_ptr<protocol::DictionaryValue> messageObject) override;
+
+    protected:
+        using CallHandler = void (DispatcherImpl::*)(int callId, std::unique_ptr<DictionaryValue> messageObject, ErrorSupport* errors);
+        using DispatchMap = protocol::HashMap<String, CallHandler>;
+        DispatchMap m_dispatchMap;
+
+
+        Backend* m_backend;
+};
+
+void DispatcherImpl::dispatch(int callId, const String& method, std::unique_ptr<protocol::DictionaryValue> messageObject) {
+    protocol::HashMap<String, CallHandler>::iterator it = m_dispatchMap.find(method);
+    if (it == m_dispatchMap.end()) {
+        reportProtocolError(callId, MethodNotFound, "'" + method + "' wasn't found", nullptr);
+        return;
+    }
+
+    protocol::ErrorSupport errors;
+    (this->*(it->second))(callId, std::move(messageObject), &errors);
+}
+
+
+// static
+void Dispatcher::wire(UberDispatcher* dispatcher, Backend* backend) {
+    dispatcher->registerBackend("GenericTypes", wrapUnique(new DispatcherImpl(dispatcher->channel(), backend)));
+}
+
+} // GenericTypes
+} // namespace v8_inspector
+} // namespace protocol

--- a/runtime/src/main/jni/v8_inspector/src/inspector/protocol/GenericTypes.cpp
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/protocol/GenericTypes.cpp
@@ -16,7 +16,7 @@ namespace GenericTypes {
 
 const char Metainfo::domainName[] = "GenericTypes";
 const char Metainfo::commandPrefix[] = "GenericTypes.";
-const char Metainfo::version[] = "1.1";
+const char Metainfo::version[] = "1.2";
 
 std::unique_ptr<SearchMatch> SearchMatch::parse(protocol::Value* value, ErrorSupport* errors) {
     if (!value || value->type() != protocol::Value::TypeObject) {

--- a/runtime/src/main/jni/v8_inspector/src/inspector/protocol/GenericTypes.h
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/protocol/GenericTypes.h
@@ -1,0 +1,149 @@
+// This file is generated
+
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef v8_inspector_protocol_GenericTypes_h
+#define v8_inspector_protocol_GenericTypes_h
+
+#include "src/inspector/protocol/Protocol.h"
+// For each imported domain we generate a ValueConversions struct instead of a full domain definition
+// and include Domain::API version from there.
+
+namespace v8_inspector {
+namespace protocol {
+namespace GenericTypes {
+
+// ------------- Forward and enum declarations.
+// Search match in a resource.
+class SearchMatch;
+
+// ------------- Type and builder declarations.
+
+// Search match in a resource.
+class  SearchMatch {
+        PROTOCOL_DISALLOW_COPY(SearchMatch);
+    public:
+        static std::unique_ptr<SearchMatch> parse(protocol::Value* value, ErrorSupport* errors);
+
+        ~SearchMatch() { }
+
+        double getLineNumber() {
+            return m_lineNumber;
+        }
+        void setLineNumber(double value) {
+            m_lineNumber = value;
+        }
+
+        String getLineContent() {
+            return m_lineContent;
+        }
+        void setLineContent(const String& value) {
+            m_lineContent = value;
+        }
+
+        std::unique_ptr<protocol::DictionaryValue> serialize() const;
+        std::unique_ptr<SearchMatch> clone() const;
+
+        template<int STATE>
+        class SearchMatchBuilder {
+            public:
+                enum {
+                    NoFieldsSet = 0,
+                    LineNumberSet = 1 << 1,
+                    LineContentSet = 1 << 2,
+                    AllFieldsSet = (LineNumberSet | LineContentSet | 0)
+                };
+
+
+                SearchMatchBuilder<STATE | LineNumberSet>& setLineNumber(double value) {
+                    static_assert(!(STATE & LineNumberSet), "property lineNumber should not be set yet");
+                    m_result->setLineNumber(value);
+                    return castState<LineNumberSet>();
+                }
+
+                SearchMatchBuilder<STATE | LineContentSet>& setLineContent(const String& value) {
+                    static_assert(!(STATE & LineContentSet), "property lineContent should not be set yet");
+                    m_result->setLineContent(value);
+                    return castState<LineContentSet>();
+                }
+
+                std::unique_ptr<SearchMatch> build() {
+                    static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+                    return std::move(m_result);
+                }
+
+            private:
+                friend class SearchMatch;
+                SearchMatchBuilder() : m_result(new SearchMatch()) { }
+
+                template<int STEP> SearchMatchBuilder<STATE | STEP>& castState() {
+                    return *reinterpret_cast<SearchMatchBuilder<STATE | STEP>*>(this);
+                }
+
+                std::unique_ptr<protocol::GenericTypes::SearchMatch> m_result;
+        };
+
+        static SearchMatchBuilder<0> create() {
+            return SearchMatchBuilder<0>();
+        }
+
+    private:
+        SearchMatch() {
+            m_lineNumber = 0;
+        }
+
+        double m_lineNumber;
+        String m_lineContent;
+};
+
+
+// ------------- Backend interface.
+
+class  Backend {
+    public:
+        virtual ~Backend() { }
+
+
+        virtual void disable(ErrorString*) { }
+};
+
+// ------------- Frontend interface.
+
+class  Frontend {
+    public:
+        Frontend(FrontendChannel* frontendChannel) : m_frontendChannel(frontendChannel) { }
+
+        void flush();
+    private:
+        FrontendChannel* m_frontendChannel;
+};
+
+// ------------- Dispatcher.
+
+class  Dispatcher {
+    public:
+        static void wire(UberDispatcher*, Backend*);
+
+    private:
+        Dispatcher() { }
+};
+
+// ------------- Metainfo.
+
+class  Metainfo {
+    public:
+        using BackendClass = Backend;
+        using FrontendClass = Frontend;
+        using DispatcherClass = Dispatcher;
+        static const char domainName[];
+        static const char commandPrefix[];
+        static const char version[];
+};
+
+} // namespace GenericTypes
+} // namespace v8_inspector
+} // namespace protocol
+
+#endif // !defined(v8_inspector_protocol_GenericTypes_h)

--- a/runtime/src/main/jni/v8_inspector/src/inspector/protocol/Page.cpp
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/protocol/Page.cpp
@@ -7,7 +7,6 @@
 #include "src/inspector/protocol/Page.h"
 
 #include "src/inspector/protocol/Protocol.h"
-#include "GenericTypes.h"
 
 namespace v8_inspector {
 namespace protocol {
@@ -247,108 +246,16 @@ std::unique_ptr<SearchResult> SearchResult::clone() const {
     return parse(serialize().get(), &errors);
 }
 
-std::unique_ptr<Cookie> Cookie::parse(protocol::Value* value, ErrorSupport* errors) {
-    if (!value || value->type() != protocol::Value::TypeObject) {
-        errors->addError("object expected");
-        return nullptr;
-    }
-
-    std::unique_ptr<Cookie> result(new Cookie());
-    protocol::DictionaryValue* object = DictionaryValue::cast(value);
-    errors->push();
-    protocol::Value* nameValue = object->get("name");
-    errors->setName("name");
-    result->m_name = ValueConversions<String>::parse(nameValue, errors);
-    protocol::Value* valueValue = object->get("value");
-    errors->setName("value");
-    result->m_value = ValueConversions<String>::parse(valueValue, errors);
-    protocol::Value* domainValue = object->get("domain");
-    errors->setName("domain");
-    result->m_domain = ValueConversions<String>::parse(domainValue, errors);
-    protocol::Value* pathValue = object->get("path");
-    errors->setName("path");
-    result->m_path = ValueConversions<String>::parse(pathValue, errors);
-    protocol::Value* expiresValue = object->get("expires");
-    errors->setName("expires");
-    result->m_expires = ValueConversions<double>::parse(expiresValue, errors);
-    protocol::Value* sizeValue = object->get("size");
-    errors->setName("size");
-    result->m_size = ValueConversions<int>::parse(sizeValue, errors);
-    protocol::Value* httpOnlyValue = object->get("httpOnly");
-    errors->setName("httpOnly");
-    result->m_httpOnly = ValueConversions<bool>::parse(httpOnlyValue, errors);
-    protocol::Value* secureValue = object->get("secure");
-    errors->setName("secure");
-    result->m_secure = ValueConversions<bool>::parse(secureValue, errors);
-    protocol::Value* sessionValue = object->get("session");
-    errors->setName("session");
-    result->m_session = ValueConversions<bool>::parse(sessionValue, errors);
-    errors->pop();
-    if (errors->hasErrors()) {
-        return nullptr;
-    }
-    return result;
-}
-
-std::unique_ptr<protocol::DictionaryValue> Cookie::serialize() const {
-    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
-    result->setValue("name", ValueConversions<String>::serialize(m_name));
-    result->setValue("value", ValueConversions<String>::serialize(m_value));
-    result->setValue("domain", ValueConversions<String>::serialize(m_domain));
-    result->setValue("path", ValueConversions<String>::serialize(m_path));
-    result->setValue("expires", ValueConversions<double>::serialize(m_expires));
-    result->setValue("size", ValueConversions<int>::serialize(m_size));
-    result->setValue("httpOnly", ValueConversions<bool>::serialize(m_httpOnly));
-    result->setValue("secure", ValueConversions<bool>::serialize(m_secure));
-    result->setValue("session", ValueConversions<bool>::serialize(m_session));
-    return result;
-}
-
-std::unique_ptr<Cookie> Cookie::clone() const {
-    ErrorSupport errors;
-    return parse(serialize().get(), &errors);
-}
-
 // ------------- Enum values from params.
 
 
-namespace GetScriptExecutionStatus {
-namespace ResultEnum {
-const char* Allowed = "allowed";
-const char* Disabled = "disabled";
-const char* Forbidden = "forbidden";
-} // namespace ResultEnum
-} // namespace GetScriptExecutionStatus
-
 // ------------- Frontend notifications.
-
-void Frontend::domContentEventFired(double timestamp) {
-    std::unique_ptr<protocol::DictionaryValue> jsonMessage = DictionaryValue::create();
-    jsonMessage->setString("method", "Page.domContentEventFired");
-    std::unique_ptr<protocol::DictionaryValue> paramsObject = DictionaryValue::create();
-    paramsObject->setValue("timestamp", ValueConversions<double>::serialize(timestamp));
-    jsonMessage->setObject("params", std::move(paramsObject));
-    if (m_frontendChannel) {
-        m_frontendChannel->sendProtocolNotification(jsonMessage->toJSONString());
-    }
-}
 
 void Frontend::loadEventFired(double timestamp) {
     std::unique_ptr<protocol::DictionaryValue> jsonMessage = DictionaryValue::create();
     jsonMessage->setString("method", "Page.loadEventFired");
     std::unique_ptr<protocol::DictionaryValue> paramsObject = DictionaryValue::create();
     paramsObject->setValue("timestamp", ValueConversions<double>::serialize(timestamp));
-    jsonMessage->setObject("params", std::move(paramsObject));
-    if (m_frontendChannel) {
-        m_frontendChannel->sendProtocolNotification(jsonMessage->toJSONString());
-    }
-}
-
-void Frontend::frameNavigated(std::unique_ptr<protocol::Page::Frame> frame) {
-    std::unique_ptr<protocol::DictionaryValue> jsonMessage = DictionaryValue::create();
-    jsonMessage->setString("method", "Page.frameNavigated");
-    std::unique_ptr<protocol::DictionaryValue> paramsObject = DictionaryValue::create();
-    paramsObject->setValue("frame", ValueConversions<protocol::Page::Frame>::serialize(frame.get()));
     jsonMessage->setObject("params", std::move(paramsObject));
     if (m_frontendChannel) {
         m_frontendChannel->sendProtocolNotification(jsonMessage->toJSONString());
@@ -388,61 +295,6 @@ void Frontend::frameStoppedLoading(const String& frameId) {
     }
 }
 
-void Frontend::frameScheduledNavigation(const String& frameId, double delay) {
-    std::unique_ptr<protocol::DictionaryValue> jsonMessage = DictionaryValue::create();
-    jsonMessage->setString("method", "Page.frameScheduledNavigation");
-    std::unique_ptr<protocol::DictionaryValue> paramsObject = DictionaryValue::create();
-    paramsObject->setValue("frameId", ValueConversions<String>::serialize(frameId));
-    paramsObject->setValue("delay", ValueConversions<double>::serialize(delay));
-    jsonMessage->setObject("params", std::move(paramsObject));
-    if (m_frontendChannel) {
-        m_frontendChannel->sendProtocolNotification(jsonMessage->toJSONString());
-    }
-}
-
-void Frontend::frameClearedScheduledNavigation(const String& frameId) {
-    std::unique_ptr<protocol::DictionaryValue> jsonMessage = DictionaryValue::create();
-    jsonMessage->setString("method", "Page.frameClearedScheduledNavigation");
-    std::unique_ptr<protocol::DictionaryValue> paramsObject = DictionaryValue::create();
-    paramsObject->setValue("frameId", ValueConversions<String>::serialize(frameId));
-    jsonMessage->setObject("params", std::move(paramsObject));
-    if (m_frontendChannel) {
-        m_frontendChannel->sendProtocolNotification(jsonMessage->toJSONString());
-    }
-}
-
-void Frontend::javascriptDialogOpening(const String& message) {
-    std::unique_ptr<protocol::DictionaryValue> jsonMessage = DictionaryValue::create();
-    jsonMessage->setString("method", "Page.javascriptDialogOpening");
-    std::unique_ptr<protocol::DictionaryValue> paramsObject = DictionaryValue::create();
-    paramsObject->setValue("message", ValueConversions<String>::serialize(message));
-    jsonMessage->setObject("params", std::move(paramsObject));
-    if (m_frontendChannel) {
-        m_frontendChannel->sendProtocolNotification(jsonMessage->toJSONString());
-    }
-}
-
-void Frontend::javascriptDialogClosed() {
-    std::unique_ptr<protocol::DictionaryValue> jsonMessage = DictionaryValue::create();
-    jsonMessage->setString("method", "Page.javascriptDialogClosed");
-    std::unique_ptr<protocol::DictionaryValue> paramsObject = DictionaryValue::create();
-    jsonMessage->setObject("params", std::move(paramsObject));
-    if (m_frontendChannel) {
-        m_frontendChannel->sendProtocolNotification(jsonMessage->toJSONString());
-    }
-}
-
-void Frontend::scriptsEnabled(bool isEnabled) {
-    std::unique_ptr<protocol::DictionaryValue> jsonMessage = DictionaryValue::create();
-    jsonMessage->setString("method", "Page.scriptsEnabled");
-    std::unique_ptr<protocol::DictionaryValue> paramsObject = DictionaryValue::create();
-    paramsObject->setValue("isEnabled", ValueConversions<bool>::serialize(isEnabled));
-    jsonMessage->setObject("params", std::move(paramsObject));
-    if (m_frontendChannel) {
-        m_frontendChannel->sendProtocolNotification(jsonMessage->toJSONString());
-    }
-}
-
 void Frontend::flush() {
     m_frontendChannel->flushProtocolNotifications();
 }
@@ -459,25 +311,11 @@ class DispatcherImpl : public protocol::DispatcherBase {
             m_dispatchMap["Page.addScriptToEvaluateOnLoad"] = &DispatcherImpl::addScriptToEvaluateOnLoad;
             m_dispatchMap["Page.removeScriptToEvaluateOnLoad"] = &DispatcherImpl::removeScriptToEvaluateOnLoad;
             m_dispatchMap["Page.reload"] = &DispatcherImpl::reload;
-            m_dispatchMap["Page.navigate"] = &DispatcherImpl::navigate;
-            m_dispatchMap["Page.getCookies"] = &DispatcherImpl::getCookies;
-            m_dispatchMap["Page.deleteCookie"] = &DispatcherImpl::deleteCookie;
             m_dispatchMap["Page.getResourceTree"] = &DispatcherImpl::getResourceTree;
             m_dispatchMap["Page.getResourceContent"] = &DispatcherImpl::getResourceContent;
             m_dispatchMap["Page.searchInResource"] = &DispatcherImpl::searchInResource;
             m_dispatchMap["Page.searchInResources"] = &DispatcherImpl::searchInResources;
             m_dispatchMap["Page.setDocumentContent"] = &DispatcherImpl::setDocumentContent;
-            m_dispatchMap["Page.setShowPaintRects"] = &DispatcherImpl::setShowPaintRects;
-            m_dispatchMap["Page.getScriptExecutionStatus"] = &DispatcherImpl::getScriptExecutionStatus;
-            m_dispatchMap["Page.setScriptExecutionDisabled"] = &DispatcherImpl::setScriptExecutionDisabled;
-            m_dispatchMap["Page.setTouchEmulationEnabled"] = &DispatcherImpl::setTouchEmulationEnabled;
-            m_dispatchMap["Page.setEmulatedMedia"] = &DispatcherImpl::setEmulatedMedia;
-            m_dispatchMap["Page.getCompositingBordersVisible"] = &DispatcherImpl::getCompositingBordersVisible;
-            m_dispatchMap["Page.setCompositingBordersVisible"] = &DispatcherImpl::setCompositingBordersVisible;
-            m_dispatchMap["Page.snapshotNode"] = &DispatcherImpl::snapshotNode;
-            m_dispatchMap["Page.snapshotRect"] = &DispatcherImpl::snapshotRect;
-            m_dispatchMap["Page.handleJavaScriptDialog"] = &DispatcherImpl::handleJavaScriptDialog;
-            m_dispatchMap["Page.archive"] = &DispatcherImpl::archive;
         }
         ~DispatcherImpl() override { }
         void dispatch(int callId, const String& method, std::unique_ptr<protocol::DictionaryValue> messageObject) override;
@@ -492,25 +330,11 @@ class DispatcherImpl : public protocol::DispatcherBase {
         void addScriptToEvaluateOnLoad(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
         void removeScriptToEvaluateOnLoad(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
         void reload(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
-        void navigate(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
-        void getCookies(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
-        void deleteCookie(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
         void getResourceTree(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
         void getResourceContent(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
         void searchInResource(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
         void searchInResources(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
         void setDocumentContent(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
-        void setShowPaintRects(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
-        void getScriptExecutionStatus(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
-        void setScriptExecutionDisabled(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
-        void setTouchEmulationEnabled(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
-        void setEmulatedMedia(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
-        void getCompositingBordersVisible(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
-        void setCompositingBordersVisible(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
-        void snapshotNode(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
-        void snapshotRect(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
-        void handleJavaScriptDialog(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
-        void archive(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
 
         Backend* m_backend;
 };
@@ -620,67 +444,6 @@ void DispatcherImpl::reload(int callId, std::unique_ptr<DictionaryValue> request
     std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
     ErrorString error;
     m_backend->reload(&error, in_ignoreCache, in_scriptToEvaluateOnLoad);
-    if (weak->get()) {
-        weak->get()->sendResponse(callId, error);
-    }
-}
-
-void DispatcherImpl::navigate(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
-    // Prepare input parameters.
-    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
-    errors->push();
-    protocol::Value* urlValue = object ? object->get("url") : nullptr;
-    errors->setName("url");
-    String in_url = ValueConversions<String>::parse(urlValue, errors);
-    errors->pop();
-    if (errors->hasErrors()) {
-        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
-        return;
-    }
-
-    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
-    ErrorString error;
-    m_backend->navigate(&error, in_url);
-    if (weak->get()) {
-        weak->get()->sendResponse(callId, error);
-    }
-}
-
-void DispatcherImpl::getCookies(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
-    // Declare output parameters.
-    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
-    std::unique_ptr<protocol::Array<protocol::Page::Cookie>> out_cookies;
-
-    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
-    ErrorString error;
-    m_backend->getCookies(&error, &out_cookies);
-    if (!error.length()) {
-        result->setValue("cookies", ValueConversions<protocol::Array<protocol::Page::Cookie>>::serialize(out_cookies.get()));
-    }
-    if (weak->get()) {
-        weak->get()->sendResponse(callId, error, std::move(result));
-    }
-}
-
-void DispatcherImpl::deleteCookie(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
-    // Prepare input parameters.
-    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
-    errors->push();
-    protocol::Value* cookieNameValue = object ? object->get("cookieName") : nullptr;
-    errors->setName("cookieName");
-    String in_cookieName = ValueConversions<String>::parse(cookieNameValue, errors);
-    protocol::Value* urlValue = object ? object->get("url") : nullptr;
-    errors->setName("url");
-    String in_url = ValueConversions<String>::parse(urlValue, errors);
-    errors->pop();
-    if (errors->hasErrors()) {
-        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
-        return;
-    }
-
-    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
-    ErrorString error;
-    m_backend->deleteCookie(&error, in_cookieName, in_url);
     if (weak->get()) {
         weak->get()->sendResponse(callId, error);
     }
@@ -845,252 +608,6 @@ void DispatcherImpl::setDocumentContent(int callId, std::unique_ptr<DictionaryVa
     m_backend->setDocumentContent(&error, in_frameId, in_html);
     if (weak->get()) {
         weak->get()->sendResponse(callId, error);
-    }
-}
-
-void DispatcherImpl::setShowPaintRects(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
-    // Prepare input parameters.
-    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
-    errors->push();
-    protocol::Value* resultValue = object ? object->get("result") : nullptr;
-    errors->setName("result");
-    bool in_result = ValueConversions<bool>::parse(resultValue, errors);
-    errors->pop();
-    if (errors->hasErrors()) {
-        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
-        return;
-    }
-
-    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
-    ErrorString error;
-    m_backend->setShowPaintRects(&error, in_result);
-    if (weak->get()) {
-        weak->get()->sendResponse(callId, error);
-    }
-}
-
-void DispatcherImpl::getScriptExecutionStatus(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
-    // Declare output parameters.
-    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
-    String out_result;
-
-    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
-    ErrorString error;
-    m_backend->getScriptExecutionStatus(&error, &out_result);
-    if (!error.length()) {
-        result->setValue("result", ValueConversions<String>::serialize(out_result));
-    }
-    if (weak->get()) {
-        weak->get()->sendResponse(callId, error, std::move(result));
-    }
-}
-
-void DispatcherImpl::setScriptExecutionDisabled(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
-    // Prepare input parameters.
-    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
-    errors->push();
-    protocol::Value* valueValue = object ? object->get("value") : nullptr;
-    errors->setName("value");
-    bool in_value = ValueConversions<bool>::parse(valueValue, errors);
-    errors->pop();
-    if (errors->hasErrors()) {
-        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
-        return;
-    }
-
-    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
-    ErrorString error;
-    m_backend->setScriptExecutionDisabled(&error, in_value);
-    if (weak->get()) {
-        weak->get()->sendResponse(callId, error);
-    }
-}
-
-void DispatcherImpl::setTouchEmulationEnabled(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
-    // Prepare input parameters.
-    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
-    errors->push();
-    protocol::Value* enabledValue = object ? object->get("enabled") : nullptr;
-    errors->setName("enabled");
-    bool in_enabled = ValueConversions<bool>::parse(enabledValue, errors);
-    errors->pop();
-    if (errors->hasErrors()) {
-        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
-        return;
-    }
-
-    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
-    ErrorString error;
-    m_backend->setTouchEmulationEnabled(&error, in_enabled);
-    if (weak->get()) {
-        weak->get()->sendResponse(callId, error);
-    }
-}
-
-void DispatcherImpl::setEmulatedMedia(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
-    // Prepare input parameters.
-    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
-    errors->push();
-    protocol::Value* mediaValue = object ? object->get("media") : nullptr;
-    errors->setName("media");
-    String in_media = ValueConversions<String>::parse(mediaValue, errors);
-    errors->pop();
-    if (errors->hasErrors()) {
-        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
-        return;
-    }
-
-    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
-    ErrorString error;
-    m_backend->setEmulatedMedia(&error, in_media);
-    if (weak->get()) {
-        weak->get()->sendResponse(callId, error);
-    }
-}
-
-void DispatcherImpl::getCompositingBordersVisible(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
-    // Declare output parameters.
-    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
-    bool out_result;
-
-    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
-    ErrorString error;
-    m_backend->getCompositingBordersVisible(&error, &out_result);
-    if (!error.length()) {
-        result->setValue("result", ValueConversions<bool>::serialize(out_result));
-    }
-    if (weak->get()) {
-        weak->get()->sendResponse(callId, error, std::move(result));
-    }
-}
-
-void DispatcherImpl::setCompositingBordersVisible(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
-    // Prepare input parameters.
-    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
-    errors->push();
-    protocol::Value* visibleValue = object ? object->get("visible") : nullptr;
-    errors->setName("visible");
-    bool in_visible = ValueConversions<bool>::parse(visibleValue, errors);
-    errors->pop();
-    if (errors->hasErrors()) {
-        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
-        return;
-    }
-
-    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
-    ErrorString error;
-    m_backend->setCompositingBordersVisible(&error, in_visible);
-    if (weak->get()) {
-        weak->get()->sendResponse(callId, error);
-    }
-}
-
-void DispatcherImpl::snapshotNode(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
-    // Prepare input parameters.
-    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
-    errors->push();
-    protocol::Value* nodeIdValue = object ? object->get("nodeId") : nullptr;
-    errors->setName("nodeId");
-    int in_nodeId = ValueConversions<int>::parse(nodeIdValue, errors);
-    errors->pop();
-    if (errors->hasErrors()) {
-        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
-        return;
-    }
-    // Declare output parameters.
-    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
-    String out_dataURL;
-
-    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
-    ErrorString error;
-    m_backend->snapshotNode(&error, in_nodeId, &out_dataURL);
-    if (!error.length()) {
-        result->setValue("dataURL", ValueConversions<String>::serialize(out_dataURL));
-    }
-    if (weak->get()) {
-        weak->get()->sendResponse(callId, error, std::move(result));
-    }
-}
-
-void DispatcherImpl::snapshotRect(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
-    // Prepare input parameters.
-    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
-    errors->push();
-    protocol::Value* xValue = object ? object->get("x") : nullptr;
-    errors->setName("x");
-    int in_x = ValueConversions<int>::parse(xValue, errors);
-    protocol::Value* yValue = object ? object->get("y") : nullptr;
-    errors->setName("y");
-    int in_y = ValueConversions<int>::parse(yValue, errors);
-    protocol::Value* widthValue = object ? object->get("width") : nullptr;
-    errors->setName("width");
-    int in_width = ValueConversions<int>::parse(widthValue, errors);
-    protocol::Value* heightValue = object ? object->get("height") : nullptr;
-    errors->setName("height");
-    int in_height = ValueConversions<int>::parse(heightValue, errors);
-    protocol::Value* coordinateSystemValue = object ? object->get("coordinateSystem") : nullptr;
-    errors->setName("coordinateSystem");
-    String in_coordinateSystem = ValueConversions<String>::parse(coordinateSystemValue, errors);
-    errors->pop();
-    if (errors->hasErrors()) {
-        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
-        return;
-    }
-    // Declare output parameters.
-    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
-    String out_dataURL;
-
-    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
-    ErrorString error;
-    m_backend->snapshotRect(&error, in_x, in_y, in_width, in_height, in_coordinateSystem, &out_dataURL);
-    if (!error.length()) {
-        result->setValue("dataURL", ValueConversions<String>::serialize(out_dataURL));
-    }
-    if (weak->get()) {
-        weak->get()->sendResponse(callId, error, std::move(result));
-    }
-}
-
-void DispatcherImpl::handleJavaScriptDialog(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
-    // Prepare input parameters.
-    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
-    errors->push();
-    protocol::Value* acceptValue = object ? object->get("accept") : nullptr;
-    errors->setName("accept");
-    bool in_accept = ValueConversions<bool>::parse(acceptValue, errors);
-    protocol::Value* promptTextValue = object ? object->get("promptText") : nullptr;
-    Maybe<String> in_promptText;
-    if (promptTextValue) {
-        errors->setName("promptText");
-        in_promptText = ValueConversions<String>::parse(promptTextValue, errors);
-    }
-    errors->pop();
-    if (errors->hasErrors()) {
-        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
-        return;
-    }
-
-    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
-    ErrorString error;
-    m_backend->handleJavaScriptDialog(&error, in_accept, in_promptText);
-    if (weak->get()) {
-        weak->get()->sendResponse(callId, error);
-    }
-}
-
-void DispatcherImpl::archive(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
-    // Declare output parameters.
-    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
-    String out_data;
-
-    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
-    ErrorString error;
-    m_backend->archive(&error, &out_data);
-    if (!error.length()) {
-        result->setValue("data", ValueConversions<String>::serialize(out_data));
-    }
-    if (weak->get()) {
-        weak->get()->sendResponse(callId, error, std::move(result));
     }
 }
 

--- a/runtime/src/main/jni/v8_inspector/src/inspector/protocol/Page.cpp
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/protocol/Page.cpp
@@ -1,0 +1,1104 @@
+// This file is generated
+
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "src/inspector/protocol/Page.h"
+
+#include "src/inspector/protocol/Protocol.h"
+#include "GenericTypes.h"
+
+namespace v8_inspector {
+namespace protocol {
+namespace Page {
+
+// ------------- Enum values from types.
+
+const char Metainfo::domainName[] = "Page";
+const char Metainfo::commandPrefix[] = "Page.";
+const char Metainfo::version[] = "1.2";
+
+namespace ResourceTypeEnum {
+const char* Document = "Document";
+const char* Stylesheet = "Stylesheet";
+const char* Image = "Image";
+const char* Font = "Font";
+const char* Script = "Script";
+const char* XHR = "XHR";
+const char* WebSocket = "WebSocket";
+const char* Other = "Other";
+} // namespace ResourceTypeEnum
+
+namespace CoordinateSystemEnum {
+const char* Viewport = "Viewport";
+const char* Page = "Page";
+} // namespace CoordinateSystemEnum
+
+std::unique_ptr<Frame> Frame::parse(protocol::Value* value, ErrorSupport* errors) {
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<Frame> result(new Frame());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* idValue = object->get("id");
+    errors->setName("id");
+    result->m_id = ValueConversions<String>::parse(idValue, errors);
+    protocol::Value* parentIdValue = object->get("parentId");
+    if (parentIdValue) {
+        errors->setName("parentId");
+        result->m_parentId = ValueConversions<String>::parse(parentIdValue, errors);
+    }
+    protocol::Value* loaderIdValue = object->get("loaderId");
+    errors->setName("loaderId");
+    result->m_loaderId = ValueConversions<String>::parse(loaderIdValue, errors);
+    protocol::Value* nameValue = object->get("name");
+    if (nameValue) {
+        errors->setName("name");
+        result->m_name = ValueConversions<String>::parse(nameValue, errors);
+    }
+    protocol::Value* urlValue = object->get("url");
+    errors->setName("url");
+    result->m_url = ValueConversions<String>::parse(urlValue, errors);
+    protocol::Value* securityOriginValue = object->get("securityOrigin");
+    errors->setName("securityOrigin");
+    result->m_securityOrigin = ValueConversions<String>::parse(securityOriginValue, errors);
+    protocol::Value* mimeTypeValue = object->get("mimeType");
+    errors->setName("mimeType");
+    result->m_mimeType = ValueConversions<String>::parse(mimeTypeValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        return nullptr;
+    }
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> Frame::serialize() const {
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("id", ValueConversions<String>::serialize(m_id));
+    if (m_parentId.isJust()) {
+        result->setValue("parentId", ValueConversions<String>::serialize(m_parentId.fromJust()));
+    }
+    result->setValue("loaderId", ValueConversions<String>::serialize(m_loaderId));
+    if (m_name.isJust()) {
+        result->setValue("name", ValueConversions<String>::serialize(m_name.fromJust()));
+    }
+    result->setValue("url", ValueConversions<String>::serialize(m_url));
+    result->setValue("securityOrigin", ValueConversions<String>::serialize(m_securityOrigin));
+    result->setValue("mimeType", ValueConversions<String>::serialize(m_mimeType));
+    return result;
+}
+
+std::unique_ptr<Frame> Frame::clone() const {
+    ErrorSupport errors;
+    return parse(serialize().get(), &errors);
+}
+
+std::unique_ptr<FrameResource> FrameResource::parse(protocol::Value* value, ErrorSupport* errors) {
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<FrameResource> result(new FrameResource());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* urlValue = object->get("url");
+    errors->setName("url");
+    result->m_url = ValueConversions<String>::parse(urlValue, errors);
+    protocol::Value* typeValue = object->get("type");
+    errors->setName("type");
+    result->m_type = ValueConversions<String>::parse(typeValue, errors);
+    protocol::Value* mimeTypeValue = object->get("mimeType");
+    errors->setName("mimeType");
+    result->m_mimeType = ValueConversions<String>::parse(mimeTypeValue, errors);
+    protocol::Value* failedValue = object->get("failed");
+    if (failedValue) {
+        errors->setName("failed");
+        result->m_failed = ValueConversions<bool>::parse(failedValue, errors);
+    }
+    protocol::Value* canceledValue = object->get("canceled");
+    if (canceledValue) {
+        errors->setName("canceled");
+        result->m_canceled = ValueConversions<bool>::parse(canceledValue, errors);
+    }
+    protocol::Value* sourceMapURLValue = object->get("sourceMapURL");
+    if (sourceMapURLValue) {
+        errors->setName("sourceMapURL");
+        result->m_sourceMapURL = ValueConversions<String>::parse(sourceMapURLValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors()) {
+        return nullptr;
+    }
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> FrameResource::serialize() const {
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("url", ValueConversions<String>::serialize(m_url));
+    result->setValue("type", ValueConversions<String>::serialize(m_type));
+    result->setValue("mimeType", ValueConversions<String>::serialize(m_mimeType));
+    if (m_failed.isJust()) {
+        result->setValue("failed", ValueConversions<bool>::serialize(m_failed.fromJust()));
+    }
+    if (m_canceled.isJust()) {
+        result->setValue("canceled", ValueConversions<bool>::serialize(m_canceled.fromJust()));
+    }
+    if (m_sourceMapURL.isJust()) {
+        result->setValue("sourceMapURL", ValueConversions<String>::serialize(m_sourceMapURL.fromJust()));
+    }
+    return result;
+}
+
+std::unique_ptr<FrameResource> FrameResource::clone() const {
+    ErrorSupport errors;
+    return parse(serialize().get(), &errors);
+}
+
+std::unique_ptr<FrameResourceTree> FrameResourceTree::parse(protocol::Value* value, ErrorSupport* errors) {
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<FrameResourceTree> result(new FrameResourceTree());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* frameValue = object->get("frame");
+    errors->setName("frame");
+    result->m_frame = ValueConversions<protocol::Page::Frame>::parse(frameValue, errors);
+    protocol::Value* childFramesValue = object->get("childFrames");
+    if (childFramesValue) {
+        errors->setName("childFrames");
+        result->m_childFrames = ValueConversions<protocol::Array<protocol::Page::FrameResourceTree>>::parse(childFramesValue, errors);
+    }
+    protocol::Value* resourcesValue = object->get("resources");
+    errors->setName("resources");
+    result->m_resources = ValueConversions<protocol::Array<protocol::Page::FrameResource>>::parse(resourcesValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        return nullptr;
+    }
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> FrameResourceTree::serialize() const {
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("frame", ValueConversions<protocol::Page::Frame>::serialize(m_frame.get()));
+    if (m_childFrames.isJust()) {
+        result->setValue("childFrames", ValueConversions<protocol::Array<protocol::Page::FrameResourceTree>>::serialize(m_childFrames.fromJust()));
+    }
+    result->setValue("resources", ValueConversions<protocol::Array<protocol::Page::FrameResource>>::serialize(m_resources.get()));
+    return result;
+}
+
+std::unique_ptr<FrameResourceTree> FrameResourceTree::clone() const {
+    ErrorSupport errors;
+    return parse(serialize().get(), &errors);
+}
+
+std::unique_ptr<SearchResult> SearchResult::parse(protocol::Value* value, ErrorSupport* errors) {
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<SearchResult> result(new SearchResult());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* urlValue = object->get("url");
+    errors->setName("url");
+    result->m_url = ValueConversions<String>::parse(urlValue, errors);
+    protocol::Value* frameIdValue = object->get("frameId");
+    errors->setName("frameId");
+    result->m_frameId = ValueConversions<String>::parse(frameIdValue, errors);
+    protocol::Value* matchesCountValue = object->get("matchesCount");
+    errors->setName("matchesCount");
+    result->m_matchesCount = ValueConversions<double>::parse(matchesCountValue, errors);
+    protocol::Value* requestIdValue = object->get("requestId");
+    if (requestIdValue) {
+        errors->setName("requestId");
+        result->m_requestId = ValueConversions<String>::parse(requestIdValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors()) {
+        return nullptr;
+    }
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> SearchResult::serialize() const {
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("url", ValueConversions<String>::serialize(m_url));
+    result->setValue("frameId", ValueConversions<String>::serialize(m_frameId));
+    result->setValue("matchesCount", ValueConversions<double>::serialize(m_matchesCount));
+    if (m_requestId.isJust()) {
+        result->setValue("requestId", ValueConversions<String>::serialize(m_requestId.fromJust()));
+    }
+    return result;
+}
+
+std::unique_ptr<SearchResult> SearchResult::clone() const {
+    ErrorSupport errors;
+    return parse(serialize().get(), &errors);
+}
+
+std::unique_ptr<Cookie> Cookie::parse(protocol::Value* value, ErrorSupport* errors) {
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<Cookie> result(new Cookie());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* nameValue = object->get("name");
+    errors->setName("name");
+    result->m_name = ValueConversions<String>::parse(nameValue, errors);
+    protocol::Value* valueValue = object->get("value");
+    errors->setName("value");
+    result->m_value = ValueConversions<String>::parse(valueValue, errors);
+    protocol::Value* domainValue = object->get("domain");
+    errors->setName("domain");
+    result->m_domain = ValueConversions<String>::parse(domainValue, errors);
+    protocol::Value* pathValue = object->get("path");
+    errors->setName("path");
+    result->m_path = ValueConversions<String>::parse(pathValue, errors);
+    protocol::Value* expiresValue = object->get("expires");
+    errors->setName("expires");
+    result->m_expires = ValueConversions<double>::parse(expiresValue, errors);
+    protocol::Value* sizeValue = object->get("size");
+    errors->setName("size");
+    result->m_size = ValueConversions<int>::parse(sizeValue, errors);
+    protocol::Value* httpOnlyValue = object->get("httpOnly");
+    errors->setName("httpOnly");
+    result->m_httpOnly = ValueConversions<bool>::parse(httpOnlyValue, errors);
+    protocol::Value* secureValue = object->get("secure");
+    errors->setName("secure");
+    result->m_secure = ValueConversions<bool>::parse(secureValue, errors);
+    protocol::Value* sessionValue = object->get("session");
+    errors->setName("session");
+    result->m_session = ValueConversions<bool>::parse(sessionValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        return nullptr;
+    }
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> Cookie::serialize() const {
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("name", ValueConversions<String>::serialize(m_name));
+    result->setValue("value", ValueConversions<String>::serialize(m_value));
+    result->setValue("domain", ValueConversions<String>::serialize(m_domain));
+    result->setValue("path", ValueConversions<String>::serialize(m_path));
+    result->setValue("expires", ValueConversions<double>::serialize(m_expires));
+    result->setValue("size", ValueConversions<int>::serialize(m_size));
+    result->setValue("httpOnly", ValueConversions<bool>::serialize(m_httpOnly));
+    result->setValue("secure", ValueConversions<bool>::serialize(m_secure));
+    result->setValue("session", ValueConversions<bool>::serialize(m_session));
+    return result;
+}
+
+std::unique_ptr<Cookie> Cookie::clone() const {
+    ErrorSupport errors;
+    return parse(serialize().get(), &errors);
+}
+
+// ------------- Enum values from params.
+
+
+namespace GetScriptExecutionStatus {
+namespace ResultEnum {
+const char* Allowed = "allowed";
+const char* Disabled = "disabled";
+const char* Forbidden = "forbidden";
+} // namespace ResultEnum
+} // namespace GetScriptExecutionStatus
+
+// ------------- Frontend notifications.
+
+void Frontend::domContentEventFired(double timestamp) {
+    std::unique_ptr<protocol::DictionaryValue> jsonMessage = DictionaryValue::create();
+    jsonMessage->setString("method", "Page.domContentEventFired");
+    std::unique_ptr<protocol::DictionaryValue> paramsObject = DictionaryValue::create();
+    paramsObject->setValue("timestamp", ValueConversions<double>::serialize(timestamp));
+    jsonMessage->setObject("params", std::move(paramsObject));
+    if (m_frontendChannel) {
+        m_frontendChannel->sendProtocolNotification(jsonMessage->toJSONString());
+    }
+}
+
+void Frontend::loadEventFired(double timestamp) {
+    std::unique_ptr<protocol::DictionaryValue> jsonMessage = DictionaryValue::create();
+    jsonMessage->setString("method", "Page.loadEventFired");
+    std::unique_ptr<protocol::DictionaryValue> paramsObject = DictionaryValue::create();
+    paramsObject->setValue("timestamp", ValueConversions<double>::serialize(timestamp));
+    jsonMessage->setObject("params", std::move(paramsObject));
+    if (m_frontendChannel) {
+        m_frontendChannel->sendProtocolNotification(jsonMessage->toJSONString());
+    }
+}
+
+void Frontend::frameNavigated(std::unique_ptr<protocol::Page::Frame> frame) {
+    std::unique_ptr<protocol::DictionaryValue> jsonMessage = DictionaryValue::create();
+    jsonMessage->setString("method", "Page.frameNavigated");
+    std::unique_ptr<protocol::DictionaryValue> paramsObject = DictionaryValue::create();
+    paramsObject->setValue("frame", ValueConversions<protocol::Page::Frame>::serialize(frame.get()));
+    jsonMessage->setObject("params", std::move(paramsObject));
+    if (m_frontendChannel) {
+        m_frontendChannel->sendProtocolNotification(jsonMessage->toJSONString());
+    }
+}
+
+void Frontend::frameDetached(const String& frameId) {
+    std::unique_ptr<protocol::DictionaryValue> jsonMessage = DictionaryValue::create();
+    jsonMessage->setString("method", "Page.frameDetached");
+    std::unique_ptr<protocol::DictionaryValue> paramsObject = DictionaryValue::create();
+    paramsObject->setValue("frameId", ValueConversions<String>::serialize(frameId));
+    jsonMessage->setObject("params", std::move(paramsObject));
+    if (m_frontendChannel) {
+        m_frontendChannel->sendProtocolNotification(jsonMessage->toJSONString());
+    }
+}
+
+void Frontend::frameStartedLoading(const String& frameId) {
+    std::unique_ptr<protocol::DictionaryValue> jsonMessage = DictionaryValue::create();
+    jsonMessage->setString("method", "Page.frameStartedLoading");
+    std::unique_ptr<protocol::DictionaryValue> paramsObject = DictionaryValue::create();
+    paramsObject->setValue("frameId", ValueConversions<String>::serialize(frameId));
+    jsonMessage->setObject("params", std::move(paramsObject));
+    if (m_frontendChannel) {
+        m_frontendChannel->sendProtocolNotification(jsonMessage->toJSONString());
+    }
+}
+
+void Frontend::frameStoppedLoading(const String& frameId) {
+    std::unique_ptr<protocol::DictionaryValue> jsonMessage = DictionaryValue::create();
+    jsonMessage->setString("method", "Page.frameStoppedLoading");
+    std::unique_ptr<protocol::DictionaryValue> paramsObject = DictionaryValue::create();
+    paramsObject->setValue("frameId", ValueConversions<String>::serialize(frameId));
+    jsonMessage->setObject("params", std::move(paramsObject));
+    if (m_frontendChannel) {
+        m_frontendChannel->sendProtocolNotification(jsonMessage->toJSONString());
+    }
+}
+
+void Frontend::frameScheduledNavigation(const String& frameId, double delay) {
+    std::unique_ptr<protocol::DictionaryValue> jsonMessage = DictionaryValue::create();
+    jsonMessage->setString("method", "Page.frameScheduledNavigation");
+    std::unique_ptr<protocol::DictionaryValue> paramsObject = DictionaryValue::create();
+    paramsObject->setValue("frameId", ValueConversions<String>::serialize(frameId));
+    paramsObject->setValue("delay", ValueConversions<double>::serialize(delay));
+    jsonMessage->setObject("params", std::move(paramsObject));
+    if (m_frontendChannel) {
+        m_frontendChannel->sendProtocolNotification(jsonMessage->toJSONString());
+    }
+}
+
+void Frontend::frameClearedScheduledNavigation(const String& frameId) {
+    std::unique_ptr<protocol::DictionaryValue> jsonMessage = DictionaryValue::create();
+    jsonMessage->setString("method", "Page.frameClearedScheduledNavigation");
+    std::unique_ptr<protocol::DictionaryValue> paramsObject = DictionaryValue::create();
+    paramsObject->setValue("frameId", ValueConversions<String>::serialize(frameId));
+    jsonMessage->setObject("params", std::move(paramsObject));
+    if (m_frontendChannel) {
+        m_frontendChannel->sendProtocolNotification(jsonMessage->toJSONString());
+    }
+}
+
+void Frontend::javascriptDialogOpening(const String& message) {
+    std::unique_ptr<protocol::DictionaryValue> jsonMessage = DictionaryValue::create();
+    jsonMessage->setString("method", "Page.javascriptDialogOpening");
+    std::unique_ptr<protocol::DictionaryValue> paramsObject = DictionaryValue::create();
+    paramsObject->setValue("message", ValueConversions<String>::serialize(message));
+    jsonMessage->setObject("params", std::move(paramsObject));
+    if (m_frontendChannel) {
+        m_frontendChannel->sendProtocolNotification(jsonMessage->toJSONString());
+    }
+}
+
+void Frontend::javascriptDialogClosed() {
+    std::unique_ptr<protocol::DictionaryValue> jsonMessage = DictionaryValue::create();
+    jsonMessage->setString("method", "Page.javascriptDialogClosed");
+    std::unique_ptr<protocol::DictionaryValue> paramsObject = DictionaryValue::create();
+    jsonMessage->setObject("params", std::move(paramsObject));
+    if (m_frontendChannel) {
+        m_frontendChannel->sendProtocolNotification(jsonMessage->toJSONString());
+    }
+}
+
+void Frontend::scriptsEnabled(bool isEnabled) {
+    std::unique_ptr<protocol::DictionaryValue> jsonMessage = DictionaryValue::create();
+    jsonMessage->setString("method", "Page.scriptsEnabled");
+    std::unique_ptr<protocol::DictionaryValue> paramsObject = DictionaryValue::create();
+    paramsObject->setValue("isEnabled", ValueConversions<bool>::serialize(isEnabled));
+    jsonMessage->setObject("params", std::move(paramsObject));
+    if (m_frontendChannel) {
+        m_frontendChannel->sendProtocolNotification(jsonMessage->toJSONString());
+    }
+}
+
+void Frontend::flush() {
+    m_frontendChannel->flushProtocolNotifications();
+}
+
+// --------------------- Dispatcher.
+
+class DispatcherImpl : public protocol::DispatcherBase {
+    public:
+        DispatcherImpl(FrontendChannel* frontendChannel, Backend* backend)
+            : DispatcherBase(frontendChannel)
+            , m_backend(backend) {
+            m_dispatchMap["Page.enable"] = &DispatcherImpl::enable;
+            m_dispatchMap["Page.disable"] = &DispatcherImpl::disable;
+            m_dispatchMap["Page.addScriptToEvaluateOnLoad"] = &DispatcherImpl::addScriptToEvaluateOnLoad;
+            m_dispatchMap["Page.removeScriptToEvaluateOnLoad"] = &DispatcherImpl::removeScriptToEvaluateOnLoad;
+            m_dispatchMap["Page.reload"] = &DispatcherImpl::reload;
+            m_dispatchMap["Page.navigate"] = &DispatcherImpl::navigate;
+            m_dispatchMap["Page.getCookies"] = &DispatcherImpl::getCookies;
+            m_dispatchMap["Page.deleteCookie"] = &DispatcherImpl::deleteCookie;
+            m_dispatchMap["Page.getResourceTree"] = &DispatcherImpl::getResourceTree;
+            m_dispatchMap["Page.getResourceContent"] = &DispatcherImpl::getResourceContent;
+            m_dispatchMap["Page.searchInResource"] = &DispatcherImpl::searchInResource;
+            m_dispatchMap["Page.searchInResources"] = &DispatcherImpl::searchInResources;
+            m_dispatchMap["Page.setDocumentContent"] = &DispatcherImpl::setDocumentContent;
+            m_dispatchMap["Page.setShowPaintRects"] = &DispatcherImpl::setShowPaintRects;
+            m_dispatchMap["Page.getScriptExecutionStatus"] = &DispatcherImpl::getScriptExecutionStatus;
+            m_dispatchMap["Page.setScriptExecutionDisabled"] = &DispatcherImpl::setScriptExecutionDisabled;
+            m_dispatchMap["Page.setTouchEmulationEnabled"] = &DispatcherImpl::setTouchEmulationEnabled;
+            m_dispatchMap["Page.setEmulatedMedia"] = &DispatcherImpl::setEmulatedMedia;
+            m_dispatchMap["Page.getCompositingBordersVisible"] = &DispatcherImpl::getCompositingBordersVisible;
+            m_dispatchMap["Page.setCompositingBordersVisible"] = &DispatcherImpl::setCompositingBordersVisible;
+            m_dispatchMap["Page.snapshotNode"] = &DispatcherImpl::snapshotNode;
+            m_dispatchMap["Page.snapshotRect"] = &DispatcherImpl::snapshotRect;
+            m_dispatchMap["Page.handleJavaScriptDialog"] = &DispatcherImpl::handleJavaScriptDialog;
+            m_dispatchMap["Page.archive"] = &DispatcherImpl::archive;
+        }
+        ~DispatcherImpl() override { }
+        void dispatch(int callId, const String& method, std::unique_ptr<protocol::DictionaryValue> messageObject) override;
+
+    protected:
+        using CallHandler = void (DispatcherImpl::*)(int callId, std::unique_ptr<DictionaryValue> messageObject, ErrorSupport* errors);
+        using DispatchMap = protocol::HashMap<String, CallHandler>;
+        DispatchMap m_dispatchMap;
+
+        void enable(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+        void disable(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+        void addScriptToEvaluateOnLoad(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+        void removeScriptToEvaluateOnLoad(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+        void reload(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+        void navigate(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+        void getCookies(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+        void deleteCookie(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+        void getResourceTree(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+        void getResourceContent(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+        void searchInResource(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+        void searchInResources(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+        void setDocumentContent(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+        void setShowPaintRects(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+        void getScriptExecutionStatus(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+        void setScriptExecutionDisabled(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+        void setTouchEmulationEnabled(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+        void setEmulatedMedia(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+        void getCompositingBordersVisible(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+        void setCompositingBordersVisible(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+        void snapshotNode(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+        void snapshotRect(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+        void handleJavaScriptDialog(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+        void archive(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+
+        Backend* m_backend;
+};
+
+void DispatcherImpl::dispatch(int callId, const String& method, std::unique_ptr<protocol::DictionaryValue> messageObject) {
+    protocol::HashMap<String, CallHandler>::iterator it = m_dispatchMap.find(method);
+    if (it == m_dispatchMap.end()) {
+        reportProtocolError(callId, MethodNotFound, "'" + method + "' wasn't found", nullptr);
+        return;
+    }
+
+    protocol::ErrorSupport errors;
+    (this->*(it->second))(callId, std::move(messageObject), &errors);
+}
+
+
+void DispatcherImpl::enable(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    ErrorString error;
+    m_backend->enable(&error);
+    if (weak->get()) {
+        weak->get()->sendResponse(callId, error);
+    }
+}
+
+void DispatcherImpl::disable(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    ErrorString error;
+    m_backend->disable(&error);
+    if (weak->get()) {
+        weak->get()->sendResponse(callId, error);
+    }
+}
+
+void DispatcherImpl::addScriptToEvaluateOnLoad(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* scriptSourceValue = object ? object->get("scriptSource") : nullptr;
+    errors->setName("scriptSource");
+    String in_scriptSource = ValueConversions<String>::parse(scriptSourceValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
+        return;
+    }
+    // Declare output parameters.
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    String out_identifier;
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    ErrorString error;
+    m_backend->addScriptToEvaluateOnLoad(&error, in_scriptSource, &out_identifier);
+    if (!error.length()) {
+        result->setValue("identifier", ValueConversions<String>::serialize(out_identifier));
+    }
+    if (weak->get()) {
+        weak->get()->sendResponse(callId, error, std::move(result));
+    }
+}
+
+void DispatcherImpl::removeScriptToEvaluateOnLoad(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* identifierValue = object ? object->get("identifier") : nullptr;
+    errors->setName("identifier");
+    String in_identifier = ValueConversions<String>::parse(identifierValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
+        return;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    ErrorString error;
+    m_backend->removeScriptToEvaluateOnLoad(&error, in_identifier);
+    if (weak->get()) {
+        weak->get()->sendResponse(callId, error);
+    }
+}
+
+void DispatcherImpl::reload(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* ignoreCacheValue = object ? object->get("ignoreCache") : nullptr;
+    Maybe<bool> in_ignoreCache;
+    if (ignoreCacheValue) {
+        errors->setName("ignoreCache");
+        in_ignoreCache = ValueConversions<bool>::parse(ignoreCacheValue, errors);
+    }
+    protocol::Value* scriptToEvaluateOnLoadValue = object ? object->get("scriptToEvaluateOnLoad") : nullptr;
+    Maybe<String> in_scriptToEvaluateOnLoad;
+    if (scriptToEvaluateOnLoadValue) {
+        errors->setName("scriptToEvaluateOnLoad");
+        in_scriptToEvaluateOnLoad = ValueConversions<String>::parse(scriptToEvaluateOnLoadValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
+        return;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    ErrorString error;
+    m_backend->reload(&error, in_ignoreCache, in_scriptToEvaluateOnLoad);
+    if (weak->get()) {
+        weak->get()->sendResponse(callId, error);
+    }
+}
+
+void DispatcherImpl::navigate(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* urlValue = object ? object->get("url") : nullptr;
+    errors->setName("url");
+    String in_url = ValueConversions<String>::parse(urlValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
+        return;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    ErrorString error;
+    m_backend->navigate(&error, in_url);
+    if (weak->get()) {
+        weak->get()->sendResponse(callId, error);
+    }
+}
+
+void DispatcherImpl::getCookies(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
+    // Declare output parameters.
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    std::unique_ptr<protocol::Array<protocol::Page::Cookie>> out_cookies;
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    ErrorString error;
+    m_backend->getCookies(&error, &out_cookies);
+    if (!error.length()) {
+        result->setValue("cookies", ValueConversions<protocol::Array<protocol::Page::Cookie>>::serialize(out_cookies.get()));
+    }
+    if (weak->get()) {
+        weak->get()->sendResponse(callId, error, std::move(result));
+    }
+}
+
+void DispatcherImpl::deleteCookie(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* cookieNameValue = object ? object->get("cookieName") : nullptr;
+    errors->setName("cookieName");
+    String in_cookieName = ValueConversions<String>::parse(cookieNameValue, errors);
+    protocol::Value* urlValue = object ? object->get("url") : nullptr;
+    errors->setName("url");
+    String in_url = ValueConversions<String>::parse(urlValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
+        return;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    ErrorString error;
+    m_backend->deleteCookie(&error, in_cookieName, in_url);
+    if (weak->get()) {
+        weak->get()->sendResponse(callId, error);
+    }
+}
+
+void DispatcherImpl::getResourceTree(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
+    // Declare output parameters.
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    std::unique_ptr<protocol::Page::FrameResourceTree> out_frameTree;
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    ErrorString error;
+    m_backend->getResourceTree(&error, &out_frameTree);
+    if (!error.length()) {
+        result->setValue("frameTree", ValueConversions<protocol::Page::FrameResourceTree>::serialize(out_frameTree.get()));
+    }
+    if (weak->get()) {
+        weak->get()->sendResponse(callId, error, std::move(result));
+    }
+}
+
+void DispatcherImpl::getResourceContent(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* frameIdValue = object ? object->get("frameId") : nullptr;
+    errors->setName("frameId");
+    String in_frameId = ValueConversions<String>::parse(frameIdValue, errors);
+    protocol::Value* urlValue = object ? object->get("url") : nullptr;
+    errors->setName("url");
+    String in_url = ValueConversions<String>::parse(urlValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
+        return;
+    }
+    // Declare output parameters.
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    String out_content;
+    bool out_base64Encoded;
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    ErrorString error;
+    m_backend->getResourceContent(&error, in_frameId, in_url, &out_content, &out_base64Encoded);
+    if (!error.length()) {
+        result->setValue("content", ValueConversions<String>::serialize(out_content));
+        result->setValue("base64Encoded", ValueConversions<bool>::serialize(out_base64Encoded));
+    }
+    if (weak->get()) {
+        weak->get()->sendResponse(callId, error, std::move(result));
+    }
+}
+
+void DispatcherImpl::searchInResource(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* frameIdValue = object ? object->get("frameId") : nullptr;
+    errors->setName("frameId");
+    String in_frameId = ValueConversions<String>::parse(frameIdValue, errors);
+    protocol::Value* urlValue = object ? object->get("url") : nullptr;
+    errors->setName("url");
+    String in_url = ValueConversions<String>::parse(urlValue, errors);
+    protocol::Value* queryValue = object ? object->get("query") : nullptr;
+    errors->setName("query");
+    String in_query = ValueConversions<String>::parse(queryValue, errors);
+    protocol::Value* caseSensitiveValue = object ? object->get("caseSensitive") : nullptr;
+    Maybe<bool> in_caseSensitive;
+    if (caseSensitiveValue) {
+        errors->setName("caseSensitive");
+        in_caseSensitive = ValueConversions<bool>::parse(caseSensitiveValue, errors);
+    }
+    protocol::Value* isRegexValue = object ? object->get("isRegex") : nullptr;
+    Maybe<bool> in_isRegex;
+    if (isRegexValue) {
+        errors->setName("isRegex");
+        in_isRegex = ValueConversions<bool>::parse(isRegexValue, errors);
+    }
+    protocol::Value* requestIdValue = object ? object->get("requestId") : nullptr;
+    Maybe<String> in_requestId;
+    if (requestIdValue) {
+        errors->setName("requestId");
+        in_requestId = ValueConversions<String>::parse(requestIdValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
+        return;
+    }
+    // Declare output parameters.
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    std::unique_ptr<protocol::Array<protocol::GenericTypes::SearchMatch>> out_result;
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    ErrorString error;
+    m_backend->searchInResource(&error, in_frameId, in_url, in_query, in_caseSensitive, in_isRegex, in_requestId, &out_result);
+    if (!error.length()) {
+        result->setValue("result", ValueConversions<protocol::Array<protocol::GenericTypes::SearchMatch>>::serialize(out_result.get()));
+    }
+    if (weak->get()) {
+        weak->get()->sendResponse(callId, error, std::move(result));
+    }
+}
+
+void DispatcherImpl::searchInResources(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* textValue = object ? object->get("text") : nullptr;
+    errors->setName("text");
+    String in_text = ValueConversions<String>::parse(textValue, errors);
+    protocol::Value* caseSensitiveValue = object ? object->get("caseSensitive") : nullptr;
+    Maybe<bool> in_caseSensitive;
+    if (caseSensitiveValue) {
+        errors->setName("caseSensitive");
+        in_caseSensitive = ValueConversions<bool>::parse(caseSensitiveValue, errors);
+    }
+    protocol::Value* isRegexValue = object ? object->get("isRegex") : nullptr;
+    Maybe<bool> in_isRegex;
+    if (isRegexValue) {
+        errors->setName("isRegex");
+        in_isRegex = ValueConversions<bool>::parse(isRegexValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
+        return;
+    }
+    // Declare output parameters.
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    std::unique_ptr<protocol::Array<protocol::Page::SearchResult>> out_result;
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    ErrorString error;
+    m_backend->searchInResources(&error, in_text, in_caseSensitive, in_isRegex, &out_result);
+    if (!error.length()) {
+        result->setValue("result", ValueConversions<protocol::Array<protocol::Page::SearchResult>>::serialize(out_result.get()));
+    }
+    if (weak->get()) {
+        weak->get()->sendResponse(callId, error, std::move(result));
+    }
+}
+
+void DispatcherImpl::setDocumentContent(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* frameIdValue = object ? object->get("frameId") : nullptr;
+    errors->setName("frameId");
+    String in_frameId = ValueConversions<String>::parse(frameIdValue, errors);
+    protocol::Value* htmlValue = object ? object->get("html") : nullptr;
+    errors->setName("html");
+    String in_html = ValueConversions<String>::parse(htmlValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
+        return;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    ErrorString error;
+    m_backend->setDocumentContent(&error, in_frameId, in_html);
+    if (weak->get()) {
+        weak->get()->sendResponse(callId, error);
+    }
+}
+
+void DispatcherImpl::setShowPaintRects(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* resultValue = object ? object->get("result") : nullptr;
+    errors->setName("result");
+    bool in_result = ValueConversions<bool>::parse(resultValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
+        return;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    ErrorString error;
+    m_backend->setShowPaintRects(&error, in_result);
+    if (weak->get()) {
+        weak->get()->sendResponse(callId, error);
+    }
+}
+
+void DispatcherImpl::getScriptExecutionStatus(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
+    // Declare output parameters.
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    String out_result;
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    ErrorString error;
+    m_backend->getScriptExecutionStatus(&error, &out_result);
+    if (!error.length()) {
+        result->setValue("result", ValueConversions<String>::serialize(out_result));
+    }
+    if (weak->get()) {
+        weak->get()->sendResponse(callId, error, std::move(result));
+    }
+}
+
+void DispatcherImpl::setScriptExecutionDisabled(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* valueValue = object ? object->get("value") : nullptr;
+    errors->setName("value");
+    bool in_value = ValueConversions<bool>::parse(valueValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
+        return;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    ErrorString error;
+    m_backend->setScriptExecutionDisabled(&error, in_value);
+    if (weak->get()) {
+        weak->get()->sendResponse(callId, error);
+    }
+}
+
+void DispatcherImpl::setTouchEmulationEnabled(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* enabledValue = object ? object->get("enabled") : nullptr;
+    errors->setName("enabled");
+    bool in_enabled = ValueConversions<bool>::parse(enabledValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
+        return;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    ErrorString error;
+    m_backend->setTouchEmulationEnabled(&error, in_enabled);
+    if (weak->get()) {
+        weak->get()->sendResponse(callId, error);
+    }
+}
+
+void DispatcherImpl::setEmulatedMedia(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* mediaValue = object ? object->get("media") : nullptr;
+    errors->setName("media");
+    String in_media = ValueConversions<String>::parse(mediaValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
+        return;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    ErrorString error;
+    m_backend->setEmulatedMedia(&error, in_media);
+    if (weak->get()) {
+        weak->get()->sendResponse(callId, error);
+    }
+}
+
+void DispatcherImpl::getCompositingBordersVisible(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
+    // Declare output parameters.
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    bool out_result;
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    ErrorString error;
+    m_backend->getCompositingBordersVisible(&error, &out_result);
+    if (!error.length()) {
+        result->setValue("result", ValueConversions<bool>::serialize(out_result));
+    }
+    if (weak->get()) {
+        weak->get()->sendResponse(callId, error, std::move(result));
+    }
+}
+
+void DispatcherImpl::setCompositingBordersVisible(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* visibleValue = object ? object->get("visible") : nullptr;
+    errors->setName("visible");
+    bool in_visible = ValueConversions<bool>::parse(visibleValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
+        return;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    ErrorString error;
+    m_backend->setCompositingBordersVisible(&error, in_visible);
+    if (weak->get()) {
+        weak->get()->sendResponse(callId, error);
+    }
+}
+
+void DispatcherImpl::snapshotNode(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* nodeIdValue = object ? object->get("nodeId") : nullptr;
+    errors->setName("nodeId");
+    int in_nodeId = ValueConversions<int>::parse(nodeIdValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
+        return;
+    }
+    // Declare output parameters.
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    String out_dataURL;
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    ErrorString error;
+    m_backend->snapshotNode(&error, in_nodeId, &out_dataURL);
+    if (!error.length()) {
+        result->setValue("dataURL", ValueConversions<String>::serialize(out_dataURL));
+    }
+    if (weak->get()) {
+        weak->get()->sendResponse(callId, error, std::move(result));
+    }
+}
+
+void DispatcherImpl::snapshotRect(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* xValue = object ? object->get("x") : nullptr;
+    errors->setName("x");
+    int in_x = ValueConversions<int>::parse(xValue, errors);
+    protocol::Value* yValue = object ? object->get("y") : nullptr;
+    errors->setName("y");
+    int in_y = ValueConversions<int>::parse(yValue, errors);
+    protocol::Value* widthValue = object ? object->get("width") : nullptr;
+    errors->setName("width");
+    int in_width = ValueConversions<int>::parse(widthValue, errors);
+    protocol::Value* heightValue = object ? object->get("height") : nullptr;
+    errors->setName("height");
+    int in_height = ValueConversions<int>::parse(heightValue, errors);
+    protocol::Value* coordinateSystemValue = object ? object->get("coordinateSystem") : nullptr;
+    errors->setName("coordinateSystem");
+    String in_coordinateSystem = ValueConversions<String>::parse(coordinateSystemValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
+        return;
+    }
+    // Declare output parameters.
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    String out_dataURL;
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    ErrorString error;
+    m_backend->snapshotRect(&error, in_x, in_y, in_width, in_height, in_coordinateSystem, &out_dataURL);
+    if (!error.length()) {
+        result->setValue("dataURL", ValueConversions<String>::serialize(out_dataURL));
+    }
+    if (weak->get()) {
+        weak->get()->sendResponse(callId, error, std::move(result));
+    }
+}
+
+void DispatcherImpl::handleJavaScriptDialog(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* acceptValue = object ? object->get("accept") : nullptr;
+    errors->setName("accept");
+    bool in_accept = ValueConversions<bool>::parse(acceptValue, errors);
+    protocol::Value* promptTextValue = object ? object->get("promptText") : nullptr;
+    Maybe<String> in_promptText;
+    if (promptTextValue) {
+        errors->setName("promptText");
+        in_promptText = ValueConversions<String>::parse(promptTextValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, InvalidParams, kInvalidRequest, errors);
+        return;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    ErrorString error;
+    m_backend->handleJavaScriptDialog(&error, in_accept, in_promptText);
+    if (weak->get()) {
+        weak->get()->sendResponse(callId, error);
+    }
+}
+
+void DispatcherImpl::archive(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors) {
+    // Declare output parameters.
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    String out_data;
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    ErrorString error;
+    m_backend->archive(&error, &out_data);
+    if (!error.length()) {
+        result->setValue("data", ValueConversions<String>::serialize(out_data));
+    }
+    if (weak->get()) {
+        weak->get()->sendResponse(callId, error, std::move(result));
+    }
+}
+
+// static
+void Dispatcher::wire(UberDispatcher* dispatcher, Backend* backend) {
+    dispatcher->registerBackend("Page", wrapUnique(new DispatcherImpl(dispatcher->channel(), backend)));
+}
+
+} // Page
+} // namespace v8_inspector
+} // namespace protocol

--- a/runtime/src/main/jni/v8_inspector/src/inspector/protocol/Page.h
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/protocol/Page.h
@@ -1,0 +1,827 @@
+// This file is generated
+
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef v8_inspector_protocol_Page_h
+#define v8_inspector_protocol_Page_h
+
+#include "src/inspector/protocol/Protocol.h"
+#include "GenericTypes.h"
+// For each imported domain we generate a ValueConversions struct instead of a full domain definition
+// and include Domain::API version from there.
+
+namespace v8_inspector {
+namespace protocol {
+namespace Page {
+
+// ------------- Forward and enum declarations.
+// Resource type as it was perceived by the rendering engine.
+using ResourceType = String;
+// Coordinate system used by supplied coordinates.
+using CoordinateSystem = String;
+// Information about the Frame on the page.
+class Frame;
+//
+class FrameResource;
+// Information about the Frame hierarchy along with their cached resources.
+class FrameResourceTree;
+// Search result for resource.
+class SearchResult;
+// Cookie object
+class Cookie;
+// Unique script identifier.
+using ScriptIdentifier = String;
+
+namespace ResourceTypeEnum {
+extern const char* Document;
+extern const char* Stylesheet;
+extern const char* Image;
+extern const char* Font;
+extern const char* Script;
+extern const char* XHR;
+extern const char* WebSocket;
+extern const char* Other;
+} // namespace ResourceTypeEnum
+
+namespace CoordinateSystemEnum {
+extern const char* Viewport;
+extern const char* Page;
+} // namespace CoordinateSystemEnum
+
+namespace GetScriptExecutionStatus {
+namespace ResultEnum {
+extern const char* Allowed;
+extern const char* Disabled;
+extern const char* Forbidden;
+} // ResultEnum
+} // GetScriptExecutionStatus
+
+// ------------- Type and builder declarations.
+
+// Information about the Frame on the page.
+class  Frame {
+        PROTOCOL_DISALLOW_COPY(Frame);
+    public:
+        static std::unique_ptr<Frame> parse(protocol::Value* value, ErrorSupport* errors);
+
+        ~Frame() { }
+
+        String getId() {
+            return m_id;
+        }
+        void setId(const String& value) {
+            m_id = value;
+        }
+
+        bool hasParentId() {
+            return m_parentId.isJust();
+        }
+        String getParentId(const String& defaultValue) {
+            return m_parentId.isJust() ? m_parentId.fromJust() : defaultValue;
+        }
+        void setParentId(const String& value) {
+            m_parentId = value;
+        }
+
+        String getLoaderId() {
+            return m_loaderId;
+        }
+        void setLoaderId(const String& value) {
+            m_loaderId = value;
+        }
+
+        bool hasName() {
+            return m_name.isJust();
+        }
+        String getName(const String& defaultValue) {
+            return m_name.isJust() ? m_name.fromJust() : defaultValue;
+        }
+        void setName(const String& value) {
+            m_name = value;
+        }
+
+        String getUrl() {
+            return m_url;
+        }
+        void setUrl(const String& value) {
+            m_url = value;
+        }
+
+        String getSecurityOrigin() {
+            return m_securityOrigin;
+        }
+        void setSecurityOrigin(const String& value) {
+            m_securityOrigin = value;
+        }
+
+        String getMimeType() {
+            return m_mimeType;
+        }
+        void setMimeType(const String& value) {
+            m_mimeType = value;
+        }
+
+        std::unique_ptr<protocol::DictionaryValue> serialize() const;
+        std::unique_ptr<Frame> clone() const;
+
+        template<int STATE>
+        class FrameBuilder {
+            public:
+                enum {
+                    NoFieldsSet = 0,
+                    IdSet = 1 << 1,
+                    LoaderIdSet = 1 << 2,
+                    UrlSet = 1 << 3,
+                    SecurityOriginSet = 1 << 4,
+                    MimeTypeSet = 1 << 5,
+                    AllFieldsSet = (IdSet | LoaderIdSet | UrlSet | SecurityOriginSet | MimeTypeSet | 0)
+                };
+
+
+                FrameBuilder<STATE | IdSet>& setId(const String& value) {
+                    static_assert(!(STATE & IdSet), "property id should not be set yet");
+                    m_result->setId(value);
+                    return castState<IdSet>();
+                }
+
+                FrameBuilder<STATE>& setParentId(const String& value) {
+                    m_result->setParentId(value);
+                    return *this;
+                }
+
+                FrameBuilder<STATE | LoaderIdSet>& setLoaderId(const String& value) {
+                    static_assert(!(STATE & LoaderIdSet), "property loaderId should not be set yet");
+                    m_result->setLoaderId(value);
+                    return castState<LoaderIdSet>();
+                }
+
+                FrameBuilder<STATE>& setName(const String& value) {
+                    m_result->setName(value);
+                    return *this;
+                }
+
+                FrameBuilder<STATE | UrlSet>& setUrl(const String& value) {
+                    static_assert(!(STATE & UrlSet), "property url should not be set yet");
+                    m_result->setUrl(value);
+                    return castState<UrlSet>();
+                }
+
+                FrameBuilder<STATE | SecurityOriginSet>& setSecurityOrigin(const String& value) {
+                    static_assert(!(STATE & SecurityOriginSet), "property securityOrigin should not be set yet");
+                    m_result->setSecurityOrigin(value);
+                    return castState<SecurityOriginSet>();
+                }
+
+                FrameBuilder<STATE | MimeTypeSet>& setMimeType(const String& value) {
+                    static_assert(!(STATE & MimeTypeSet), "property mimeType should not be set yet");
+                    m_result->setMimeType(value);
+                    return castState<MimeTypeSet>();
+                }
+
+                std::unique_ptr<Frame> build() {
+                    static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+                    return std::move(m_result);
+                }
+
+            private:
+                friend class Frame;
+                FrameBuilder() : m_result(new Frame()) { }
+
+                template<int STEP> FrameBuilder<STATE | STEP>& castState() {
+                    return *reinterpret_cast<FrameBuilder<STATE | STEP>*>(this);
+                }
+
+                std::unique_ptr<protocol::Page::Frame> m_result;
+        };
+
+        static FrameBuilder<0> create() {
+            return FrameBuilder<0>();
+        }
+
+    private:
+        Frame() {
+        }
+
+        String m_id;
+        Maybe<String> m_parentId;
+        String m_loaderId;
+        Maybe<String> m_name;
+        String m_url;
+        String m_securityOrigin;
+        String m_mimeType;
+};
+
+
+//
+class  FrameResource {
+        PROTOCOL_DISALLOW_COPY(FrameResource);
+    public:
+        static std::unique_ptr<FrameResource> parse(protocol::Value* value, ErrorSupport* errors);
+
+        ~FrameResource() { }
+
+        String getUrl() {
+            return m_url;
+        }
+        void setUrl(const String& value) {
+            m_url = value;
+        }
+
+        String getType() {
+            return m_type;
+        }
+        void setType(const String& value) {
+            m_type = value;
+        }
+
+        String getMimeType() {
+            return m_mimeType;
+        }
+        void setMimeType(const String& value) {
+            m_mimeType = value;
+        }
+
+        bool hasFailed() {
+            return m_failed.isJust();
+        }
+        bool getFailed(bool defaultValue) {
+            return m_failed.isJust() ? m_failed.fromJust() : defaultValue;
+        }
+        void setFailed(bool value) {
+            m_failed = value;
+        }
+
+        bool hasCanceled() {
+            return m_canceled.isJust();
+        }
+        bool getCanceled(bool defaultValue) {
+            return m_canceled.isJust() ? m_canceled.fromJust() : defaultValue;
+        }
+        void setCanceled(bool value) {
+            m_canceled = value;
+        }
+
+        bool hasSourceMapURL() {
+            return m_sourceMapURL.isJust();
+        }
+        String getSourceMapURL(const String& defaultValue) {
+            return m_sourceMapURL.isJust() ? m_sourceMapURL.fromJust() : defaultValue;
+        }
+        void setSourceMapURL(const String& value) {
+            m_sourceMapURL = value;
+        }
+
+        std::unique_ptr<protocol::DictionaryValue> serialize() const;
+        std::unique_ptr<FrameResource> clone() const;
+
+        template<int STATE>
+        class FrameResourceBuilder {
+            public:
+                enum {
+                    NoFieldsSet = 0,
+                    UrlSet = 1 << 1,
+                    TypeSet = 1 << 2,
+                    MimeTypeSet = 1 << 3,
+                    AllFieldsSet = (UrlSet | TypeSet | MimeTypeSet | 0)
+                };
+
+
+                FrameResourceBuilder<STATE | UrlSet>& setUrl(const String& value) {
+                    static_assert(!(STATE & UrlSet), "property url should not be set yet");
+                    m_result->setUrl(value);
+                    return castState<UrlSet>();
+                }
+
+                FrameResourceBuilder<STATE | TypeSet>& setType(const String& value) {
+                    static_assert(!(STATE & TypeSet), "property type should not be set yet");
+                    m_result->setType(value);
+                    return castState<TypeSet>();
+                }
+
+                FrameResourceBuilder<STATE | MimeTypeSet>& setMimeType(const String& value) {
+                    static_assert(!(STATE & MimeTypeSet), "property mimeType should not be set yet");
+                    m_result->setMimeType(value);
+                    return castState<MimeTypeSet>();
+                }
+
+                FrameResourceBuilder<STATE>& setFailed(bool value) {
+                    m_result->setFailed(value);
+                    return *this;
+                }
+
+                FrameResourceBuilder<STATE>& setCanceled(bool value) {
+                    m_result->setCanceled(value);
+                    return *this;
+                }
+
+                FrameResourceBuilder<STATE>& setSourceMapURL(const String& value) {
+                    m_result->setSourceMapURL(value);
+                    return *this;
+                }
+
+                std::unique_ptr<FrameResource> build() {
+                    static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+                    return std::move(m_result);
+                }
+
+            private:
+                friend class FrameResource;
+                FrameResourceBuilder() : m_result(new FrameResource()) { }
+
+                template<int STEP> FrameResourceBuilder<STATE | STEP>& castState() {
+                    return *reinterpret_cast<FrameResourceBuilder<STATE | STEP>*>(this);
+                }
+
+                std::unique_ptr<protocol::Page::FrameResource> m_result;
+        };
+
+        static FrameResourceBuilder<0> create() {
+            return FrameResourceBuilder<0>();
+        }
+
+    private:
+        FrameResource() {
+        }
+
+        String m_url;
+        String m_type;
+        String m_mimeType;
+        Maybe<bool> m_failed;
+        Maybe<bool> m_canceled;
+        Maybe<String> m_sourceMapURL;
+};
+
+
+// Information about the Frame hierarchy along with their cached resources.
+class  FrameResourceTree {
+        PROTOCOL_DISALLOW_COPY(FrameResourceTree);
+    public:
+        static std::unique_ptr<FrameResourceTree> parse(protocol::Value* value, ErrorSupport* errors);
+
+        ~FrameResourceTree() { }
+
+        protocol::Page::Frame* getFrame() {
+            return m_frame.get();
+        }
+        void setFrame(std::unique_ptr<protocol::Page::Frame> value) {
+            m_frame = std::move(value);
+        }
+
+        bool hasChildFrames() {
+            return m_childFrames.isJust();
+        }
+        protocol::Array<protocol::Page::FrameResourceTree>* getChildFrames(protocol::Array<protocol::Page::FrameResourceTree>* defaultValue) {
+            return m_childFrames.isJust() ? m_childFrames.fromJust() : defaultValue;
+        }
+        void setChildFrames(std::unique_ptr<protocol::Array<protocol::Page::FrameResourceTree>> value) {
+            m_childFrames = std::move(value);
+        }
+
+        protocol::Array<protocol::Page::FrameResource>* getResources() {
+            return m_resources.get();
+        }
+        void setResources(std::unique_ptr<protocol::Array<protocol::Page::FrameResource>> value) {
+            m_resources = std::move(value);
+        }
+
+        std::unique_ptr<protocol::DictionaryValue> serialize() const;
+        std::unique_ptr<FrameResourceTree> clone() const;
+
+        template<int STATE>
+        class FrameResourceTreeBuilder {
+            public:
+                enum {
+                    NoFieldsSet = 0,
+                    FrameSet = 1 << 1,
+                    ResourcesSet = 1 << 2,
+                    AllFieldsSet = (FrameSet | ResourcesSet | 0)
+                };
+
+
+                FrameResourceTreeBuilder<STATE | FrameSet>& setFrame(std::unique_ptr<protocol::Page::Frame> value) {
+                    static_assert(!(STATE & FrameSet), "property frame should not be set yet");
+                    m_result->setFrame(std::move(value));
+                    return castState<FrameSet>();
+                }
+
+                FrameResourceTreeBuilder<STATE>& setChildFrames(std::unique_ptr<protocol::Array<protocol::Page::FrameResourceTree>> value) {
+                    m_result->setChildFrames(std::move(value));
+                    return *this;
+                }
+
+                FrameResourceTreeBuilder<STATE | ResourcesSet>& setResources(std::unique_ptr<protocol::Array<protocol::Page::FrameResource>> value) {
+                    static_assert(!(STATE & ResourcesSet), "property resources should not be set yet");
+                    m_result->setResources(std::move(value));
+                    return castState<ResourcesSet>();
+                }
+
+                std::unique_ptr<FrameResourceTree> build() {
+                    static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+                    return std::move(m_result);
+                }
+
+            private:
+                friend class FrameResourceTree;
+                FrameResourceTreeBuilder() : m_result(new FrameResourceTree()) { }
+
+                template<int STEP> FrameResourceTreeBuilder<STATE | STEP>& castState() {
+                    return *reinterpret_cast<FrameResourceTreeBuilder<STATE | STEP>*>(this);
+                }
+
+                std::unique_ptr<protocol::Page::FrameResourceTree> m_result;
+        };
+
+        static FrameResourceTreeBuilder<0> create() {
+            return FrameResourceTreeBuilder<0>();
+        }
+
+    private:
+        FrameResourceTree() {
+        }
+
+        std::unique_ptr<protocol::Page::Frame> m_frame;
+        Maybe<protocol::Array<protocol::Page::FrameResourceTree>> m_childFrames;
+        std::unique_ptr<protocol::Array<protocol::Page::FrameResource>> m_resources;
+};
+
+
+// Search result for resource.
+class  SearchResult {
+        PROTOCOL_DISALLOW_COPY(SearchResult);
+    public:
+        static std::unique_ptr<SearchResult> parse(protocol::Value* value, ErrorSupport* errors);
+
+        ~SearchResult() { }
+
+        String getUrl() {
+            return m_url;
+        }
+        void setUrl(const String& value) {
+            m_url = value;
+        }
+
+        String getFrameId() {
+            return m_frameId;
+        }
+        void setFrameId(const String& value) {
+            m_frameId = value;
+        }
+
+        double getMatchesCount() {
+            return m_matchesCount;
+        }
+        void setMatchesCount(double value) {
+            m_matchesCount = value;
+        }
+
+        bool hasRequestId() {
+            return m_requestId.isJust();
+        }
+        String getRequestId(const String& defaultValue) {
+            return m_requestId.isJust() ? m_requestId.fromJust() : defaultValue;
+        }
+        void setRequestId(const String& value) {
+            m_requestId = value;
+        }
+
+        std::unique_ptr<protocol::DictionaryValue> serialize() const;
+        std::unique_ptr<SearchResult> clone() const;
+
+        template<int STATE>
+        class SearchResultBuilder {
+            public:
+                enum {
+                    NoFieldsSet = 0,
+                    UrlSet = 1 << 1,
+                    FrameIdSet = 1 << 2,
+                    MatchesCountSet = 1 << 3,
+                    AllFieldsSet = (UrlSet | FrameIdSet | MatchesCountSet | 0)
+                };
+
+
+                SearchResultBuilder<STATE | UrlSet>& setUrl(const String& value) {
+                    static_assert(!(STATE & UrlSet), "property url should not be set yet");
+                    m_result->setUrl(value);
+                    return castState<UrlSet>();
+                }
+
+                SearchResultBuilder<STATE | FrameIdSet>& setFrameId(const String& value) {
+                    static_assert(!(STATE & FrameIdSet), "property frameId should not be set yet");
+                    m_result->setFrameId(value);
+                    return castState<FrameIdSet>();
+                }
+
+                SearchResultBuilder<STATE | MatchesCountSet>& setMatchesCount(double value) {
+                    static_assert(!(STATE & MatchesCountSet), "property matchesCount should not be set yet");
+                    m_result->setMatchesCount(value);
+                    return castState<MatchesCountSet>();
+                }
+
+                SearchResultBuilder<STATE>& setRequestId(const String& value) {
+                    m_result->setRequestId(value);
+                    return *this;
+                }
+
+                std::unique_ptr<SearchResult> build() {
+                    static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+                    return std::move(m_result);
+                }
+
+            private:
+                friend class SearchResult;
+                SearchResultBuilder() : m_result(new SearchResult()) { }
+
+                template<int STEP> SearchResultBuilder<STATE | STEP>& castState() {
+                    return *reinterpret_cast<SearchResultBuilder<STATE | STEP>*>(this);
+                }
+
+                std::unique_ptr<protocol::Page::SearchResult> m_result;
+        };
+
+        static SearchResultBuilder<0> create() {
+            return SearchResultBuilder<0>();
+        }
+
+    private:
+        SearchResult() {
+            m_matchesCount = 0;
+        }
+
+        String m_url;
+        String m_frameId;
+        double m_matchesCount;
+        Maybe<String> m_requestId;
+};
+
+
+// Cookie object
+class  Cookie {
+        PROTOCOL_DISALLOW_COPY(Cookie);
+    public:
+        static std::unique_ptr<Cookie> parse(protocol::Value* value, ErrorSupport* errors);
+
+        ~Cookie() { }
+
+        String getName() {
+            return m_name;
+        }
+        void setName(const String& value) {
+            m_name = value;
+        }
+
+        String getValue() {
+            return m_value;
+        }
+        void setValue(const String& value) {
+            m_value = value;
+        }
+
+        String getDomain() {
+            return m_domain;
+        }
+        void setDomain(const String& value) {
+            m_domain = value;
+        }
+
+        String getPath() {
+            return m_path;
+        }
+        void setPath(const String& value) {
+            m_path = value;
+        }
+
+        double getExpires() {
+            return m_expires;
+        }
+        void setExpires(double value) {
+            m_expires = value;
+        }
+
+        int getSize() {
+            return m_size;
+        }
+        void setSize(int value) {
+            m_size = value;
+        }
+
+        bool getHttpOnly() {
+            return m_httpOnly;
+        }
+        void setHttpOnly(bool value) {
+            m_httpOnly = value;
+        }
+
+        bool getSecure() {
+            return m_secure;
+        }
+        void setSecure(bool value) {
+            m_secure = value;
+        }
+
+        bool getSession() {
+            return m_session;
+        }
+        void setSession(bool value) {
+            m_session = value;
+        }
+
+        std::unique_ptr<protocol::DictionaryValue> serialize() const;
+        std::unique_ptr<Cookie> clone() const;
+
+        template<int STATE>
+        class CookieBuilder {
+            public:
+                enum {
+                    NoFieldsSet = 0,
+                    NameSet = 1 << 1,
+                    ValueSet = 1 << 2,
+                    DomainSet = 1 << 3,
+                    PathSet = 1 << 4,
+                    ExpiresSet = 1 << 5,
+                    SizeSet = 1 << 6,
+                    HttpOnlySet = 1 << 7,
+                    SecureSet = 1 << 8,
+                    SessionSet = 1 << 9,
+                    AllFieldsSet = (NameSet | ValueSet | DomainSet | PathSet | ExpiresSet | SizeSet | HttpOnlySet | SecureSet | SessionSet | 0)
+                };
+
+
+                CookieBuilder<STATE | NameSet>& setName(const String& value) {
+                    static_assert(!(STATE & NameSet), "property name should not be set yet");
+                    m_result->setName(value);
+                    return castState<NameSet>();
+                }
+
+                CookieBuilder<STATE | ValueSet>& setValue(const String& value) {
+                    static_assert(!(STATE & ValueSet), "property value should not be set yet");
+                    m_result->setValue(value);
+                    return castState<ValueSet>();
+                }
+
+                CookieBuilder<STATE | DomainSet>& setDomain(const String& value) {
+                    static_assert(!(STATE & DomainSet), "property domain should not be set yet");
+                    m_result->setDomain(value);
+                    return castState<DomainSet>();
+                }
+
+                CookieBuilder<STATE | PathSet>& setPath(const String& value) {
+                    static_assert(!(STATE & PathSet), "property path should not be set yet");
+                    m_result->setPath(value);
+                    return castState<PathSet>();
+                }
+
+                CookieBuilder<STATE | ExpiresSet>& setExpires(double value) {
+                    static_assert(!(STATE & ExpiresSet), "property expires should not be set yet");
+                    m_result->setExpires(value);
+                    return castState<ExpiresSet>();
+                }
+
+                CookieBuilder<STATE | SizeSet>& setSize(int value) {
+                    static_assert(!(STATE & SizeSet), "property size should not be set yet");
+                    m_result->setSize(value);
+                    return castState<SizeSet>();
+                }
+
+                CookieBuilder<STATE | HttpOnlySet>& setHttpOnly(bool value) {
+                    static_assert(!(STATE & HttpOnlySet), "property httpOnly should not be set yet");
+                    m_result->setHttpOnly(value);
+                    return castState<HttpOnlySet>();
+                }
+
+                CookieBuilder<STATE | SecureSet>& setSecure(bool value) {
+                    static_assert(!(STATE & SecureSet), "property secure should not be set yet");
+                    m_result->setSecure(value);
+                    return castState<SecureSet>();
+                }
+
+                CookieBuilder<STATE | SessionSet>& setSession(bool value) {
+                    static_assert(!(STATE & SessionSet), "property session should not be set yet");
+                    m_result->setSession(value);
+                    return castState<SessionSet>();
+                }
+
+                std::unique_ptr<Cookie> build() {
+                    static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+                    return std::move(m_result);
+                }
+
+            private:
+                friend class Cookie;
+                CookieBuilder() : m_result(new Cookie()) { }
+
+                template<int STEP> CookieBuilder<STATE | STEP>& castState() {
+                    return *reinterpret_cast<CookieBuilder<STATE | STEP>*>(this);
+                }
+
+                std::unique_ptr<protocol::Page::Cookie> m_result;
+        };
+
+        static CookieBuilder<0> create() {
+            return CookieBuilder<0>();
+        }
+
+    private:
+        Cookie() {
+            m_expires = 0;
+            m_size = 0;
+            m_httpOnly = false;
+            m_secure = false;
+            m_session = false;
+        }
+
+        String m_name;
+        String m_value;
+        String m_domain;
+        String m_path;
+        double m_expires;
+        int m_size;
+        bool m_httpOnly;
+        bool m_secure;
+        bool m_session;
+};
+
+
+// ------------- Backend interface.
+
+class  Backend {
+    public:
+        virtual ~Backend() { }
+
+        virtual void enable(ErrorString*) = 0;
+        virtual void disable(ErrorString*) = 0;
+        virtual void addScriptToEvaluateOnLoad(ErrorString*, const String& in_scriptSource, String* out_identifier) = 0;
+        virtual void removeScriptToEvaluateOnLoad(ErrorString*, const String& in_identifier) = 0;
+        virtual void reload(ErrorString*, const Maybe<bool>& in_ignoreCache, const Maybe<String>& in_scriptToEvaluateOnLoad) = 0;
+        virtual void navigate(ErrorString*, const String& in_url) = 0;
+        virtual void getCookies(ErrorString*, std::unique_ptr<protocol::Array<protocol::Page::Cookie>>* out_cookies) = 0;
+        virtual void deleteCookie(ErrorString*, const String& in_cookieName, const String& in_url) = 0;
+        virtual void getResourceTree(ErrorString*, std::unique_ptr<protocol::Page::FrameResourceTree>* out_frameTree) = 0;
+        virtual void getResourceContent(ErrorString*, const String& in_frameId, const String& in_url, String* out_content, bool* out_base64Encoded) = 0;
+        virtual void searchInResource(ErrorString*, const String& in_frameId, const String& in_url, const String& in_query, const Maybe<bool>& in_caseSensitive, const Maybe<bool>& in_isRegex, const Maybe<String>& in_requestId, std::unique_ptr<protocol::Array<protocol::GenericTypes::SearchMatch>>* out_result) = 0;
+        virtual void searchInResources(ErrorString*, const String& in_text, const Maybe<bool>& in_caseSensitive, const Maybe<bool>& in_isRegex, std::unique_ptr<protocol::Array<protocol::Page::SearchResult>>* out_result) = 0;
+        virtual void setDocumentContent(ErrorString*, const String& in_frameId, const String& in_html) = 0;
+        virtual void setShowPaintRects(ErrorString*, bool in_result) = 0;
+        virtual void getScriptExecutionStatus(ErrorString*, String* out_result) = 0;
+        virtual void setScriptExecutionDisabled(ErrorString*, bool in_value) = 0;
+        virtual void setTouchEmulationEnabled(ErrorString*, bool in_enabled) = 0;
+        virtual void setEmulatedMedia(ErrorString*, const String& in_media) = 0;
+        virtual void getCompositingBordersVisible(ErrorString*, bool* out_result) = 0;
+        virtual void setCompositingBordersVisible(ErrorString*, bool in_visible) = 0;
+        virtual void snapshotNode(ErrorString*, int in_nodeId, String* out_dataURL) = 0;
+        virtual void snapshotRect(ErrorString*, int in_x, int in_y, int in_width, int in_height, const String& in_coordinateSystem, String* out_dataURL) = 0;
+        virtual void handleJavaScriptDialog(ErrorString*, bool in_accept, const Maybe<String>& in_promptText) = 0;
+        virtual void archive(ErrorString*, String* out_data) = 0;
+
+};
+
+// ------------- Frontend interface.
+
+class  Frontend {
+    public:
+        Frontend(FrontendChannel* frontendChannel) : m_frontendChannel(frontendChannel) { }
+        void domContentEventFired(double timestamp);
+        void loadEventFired(double timestamp);
+        void frameNavigated(std::unique_ptr<protocol::Page::Frame> frame);
+        void frameDetached(const String& frameId);
+        void frameStartedLoading(const String& frameId);
+        void frameStoppedLoading(const String& frameId);
+        void frameScheduledNavigation(const String& frameId, double delay);
+        void frameClearedScheduledNavigation(const String& frameId);
+        void javascriptDialogOpening(const String& message);
+        void javascriptDialogClosed();
+        void scriptsEnabled(bool isEnabled);
+
+        void flush();
+    private:
+        FrontendChannel* m_frontendChannel;
+};
+
+// ------------- Dispatcher.
+
+class  Dispatcher {
+    public:
+        static void wire(UberDispatcher*, Backend*);
+
+    private:
+        Dispatcher() { }
+};
+
+// ------------- Metainfo.
+
+class  Metainfo {
+    public:
+        using BackendClass = Backend;
+        using FrontendClass = Frontend;
+        using DispatcherClass = Dispatcher;
+        static const char domainName[];
+        static const char commandPrefix[];
+        static const char version[];
+};
+
+} // namespace Page
+} // namespace v8_inspector
+} // namespace protocol
+
+#endif // !defined(v8_inspector_protocol_Page_h)

--- a/runtime/src/main/jni/v8_inspector/src/inspector/protocol/Page.h
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/protocol/Page.h
@@ -29,8 +29,6 @@ class FrameResource;
 class FrameResourceTree;
 // Search result for resource.
 class SearchResult;
-// Cookie object
-class Cookie;
 // Unique script identifier.
 using ScriptIdentifier = String;
 
@@ -49,14 +47,6 @@ namespace CoordinateSystemEnum {
 extern const char* Viewport;
 extern const char* Page;
 } // namespace CoordinateSystemEnum
-
-namespace GetScriptExecutionStatus {
-namespace ResultEnum {
-extern const char* Allowed;
-extern const char* Disabled;
-extern const char* Forbidden;
-} // ResultEnum
-} // GetScriptExecutionStatus
 
 // ------------- Type and builder declarations.
 
@@ -556,193 +546,6 @@ class  SearchResult {
 };
 
 
-// Cookie object
-class  Cookie {
-        PROTOCOL_DISALLOW_COPY(Cookie);
-    public:
-        static std::unique_ptr<Cookie> parse(protocol::Value* value, ErrorSupport* errors);
-
-        ~Cookie() { }
-
-        String getName() {
-            return m_name;
-        }
-        void setName(const String& value) {
-            m_name = value;
-        }
-
-        String getValue() {
-            return m_value;
-        }
-        void setValue(const String& value) {
-            m_value = value;
-        }
-
-        String getDomain() {
-            return m_domain;
-        }
-        void setDomain(const String& value) {
-            m_domain = value;
-        }
-
-        String getPath() {
-            return m_path;
-        }
-        void setPath(const String& value) {
-            m_path = value;
-        }
-
-        double getExpires() {
-            return m_expires;
-        }
-        void setExpires(double value) {
-            m_expires = value;
-        }
-
-        int getSize() {
-            return m_size;
-        }
-        void setSize(int value) {
-            m_size = value;
-        }
-
-        bool getHttpOnly() {
-            return m_httpOnly;
-        }
-        void setHttpOnly(bool value) {
-            m_httpOnly = value;
-        }
-
-        bool getSecure() {
-            return m_secure;
-        }
-        void setSecure(bool value) {
-            m_secure = value;
-        }
-
-        bool getSession() {
-            return m_session;
-        }
-        void setSession(bool value) {
-            m_session = value;
-        }
-
-        std::unique_ptr<protocol::DictionaryValue> serialize() const;
-        std::unique_ptr<Cookie> clone() const;
-
-        template<int STATE>
-        class CookieBuilder {
-            public:
-                enum {
-                    NoFieldsSet = 0,
-                    NameSet = 1 << 1,
-                    ValueSet = 1 << 2,
-                    DomainSet = 1 << 3,
-                    PathSet = 1 << 4,
-                    ExpiresSet = 1 << 5,
-                    SizeSet = 1 << 6,
-                    HttpOnlySet = 1 << 7,
-                    SecureSet = 1 << 8,
-                    SessionSet = 1 << 9,
-                    AllFieldsSet = (NameSet | ValueSet | DomainSet | PathSet | ExpiresSet | SizeSet | HttpOnlySet | SecureSet | SessionSet | 0)
-                };
-
-
-                CookieBuilder<STATE | NameSet>& setName(const String& value) {
-                    static_assert(!(STATE & NameSet), "property name should not be set yet");
-                    m_result->setName(value);
-                    return castState<NameSet>();
-                }
-
-                CookieBuilder<STATE | ValueSet>& setValue(const String& value) {
-                    static_assert(!(STATE & ValueSet), "property value should not be set yet");
-                    m_result->setValue(value);
-                    return castState<ValueSet>();
-                }
-
-                CookieBuilder<STATE | DomainSet>& setDomain(const String& value) {
-                    static_assert(!(STATE & DomainSet), "property domain should not be set yet");
-                    m_result->setDomain(value);
-                    return castState<DomainSet>();
-                }
-
-                CookieBuilder<STATE | PathSet>& setPath(const String& value) {
-                    static_assert(!(STATE & PathSet), "property path should not be set yet");
-                    m_result->setPath(value);
-                    return castState<PathSet>();
-                }
-
-                CookieBuilder<STATE | ExpiresSet>& setExpires(double value) {
-                    static_assert(!(STATE & ExpiresSet), "property expires should not be set yet");
-                    m_result->setExpires(value);
-                    return castState<ExpiresSet>();
-                }
-
-                CookieBuilder<STATE | SizeSet>& setSize(int value) {
-                    static_assert(!(STATE & SizeSet), "property size should not be set yet");
-                    m_result->setSize(value);
-                    return castState<SizeSet>();
-                }
-
-                CookieBuilder<STATE | HttpOnlySet>& setHttpOnly(bool value) {
-                    static_assert(!(STATE & HttpOnlySet), "property httpOnly should not be set yet");
-                    m_result->setHttpOnly(value);
-                    return castState<HttpOnlySet>();
-                }
-
-                CookieBuilder<STATE | SecureSet>& setSecure(bool value) {
-                    static_assert(!(STATE & SecureSet), "property secure should not be set yet");
-                    m_result->setSecure(value);
-                    return castState<SecureSet>();
-                }
-
-                CookieBuilder<STATE | SessionSet>& setSession(bool value) {
-                    static_assert(!(STATE & SessionSet), "property session should not be set yet");
-                    m_result->setSession(value);
-                    return castState<SessionSet>();
-                }
-
-                std::unique_ptr<Cookie> build() {
-                    static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
-                    return std::move(m_result);
-                }
-
-            private:
-                friend class Cookie;
-                CookieBuilder() : m_result(new Cookie()) { }
-
-                template<int STEP> CookieBuilder<STATE | STEP>& castState() {
-                    return *reinterpret_cast<CookieBuilder<STATE | STEP>*>(this);
-                }
-
-                std::unique_ptr<protocol::Page::Cookie> m_result;
-        };
-
-        static CookieBuilder<0> create() {
-            return CookieBuilder<0>();
-        }
-
-    private:
-        Cookie() {
-            m_expires = 0;
-            m_size = 0;
-            m_httpOnly = false;
-            m_secure = false;
-            m_session = false;
-        }
-
-        String m_name;
-        String m_value;
-        String m_domain;
-        String m_path;
-        double m_expires;
-        int m_size;
-        bool m_httpOnly;
-        bool m_secure;
-        bool m_session;
-};
-
-
 // ------------- Backend interface.
 
 class  Backend {
@@ -754,25 +557,11 @@ class  Backend {
         virtual void addScriptToEvaluateOnLoad(ErrorString*, const String& in_scriptSource, String* out_identifier) = 0;
         virtual void removeScriptToEvaluateOnLoad(ErrorString*, const String& in_identifier) = 0;
         virtual void reload(ErrorString*, const Maybe<bool>& in_ignoreCache, const Maybe<String>& in_scriptToEvaluateOnLoad) = 0;
-        virtual void navigate(ErrorString*, const String& in_url) = 0;
-        virtual void getCookies(ErrorString*, std::unique_ptr<protocol::Array<protocol::Page::Cookie>>* out_cookies) = 0;
-        virtual void deleteCookie(ErrorString*, const String& in_cookieName, const String& in_url) = 0;
         virtual void getResourceTree(ErrorString*, std::unique_ptr<protocol::Page::FrameResourceTree>* out_frameTree) = 0;
         virtual void getResourceContent(ErrorString*, const String& in_frameId, const String& in_url, String* out_content, bool* out_base64Encoded) = 0;
         virtual void searchInResource(ErrorString*, const String& in_frameId, const String& in_url, const String& in_query, const Maybe<bool>& in_caseSensitive, const Maybe<bool>& in_isRegex, const Maybe<String>& in_requestId, std::unique_ptr<protocol::Array<protocol::GenericTypes::SearchMatch>>* out_result) = 0;
         virtual void searchInResources(ErrorString*, const String& in_text, const Maybe<bool>& in_caseSensitive, const Maybe<bool>& in_isRegex, std::unique_ptr<protocol::Array<protocol::Page::SearchResult>>* out_result) = 0;
         virtual void setDocumentContent(ErrorString*, const String& in_frameId, const String& in_html) = 0;
-        virtual void setShowPaintRects(ErrorString*, bool in_result) = 0;
-        virtual void getScriptExecutionStatus(ErrorString*, String* out_result) = 0;
-        virtual void setScriptExecutionDisabled(ErrorString*, bool in_value) = 0;
-        virtual void setTouchEmulationEnabled(ErrorString*, bool in_enabled) = 0;
-        virtual void setEmulatedMedia(ErrorString*, const String& in_media) = 0;
-        virtual void getCompositingBordersVisible(ErrorString*, bool* out_result) = 0;
-        virtual void setCompositingBordersVisible(ErrorString*, bool in_visible) = 0;
-        virtual void snapshotNode(ErrorString*, int in_nodeId, String* out_dataURL) = 0;
-        virtual void snapshotRect(ErrorString*, int in_x, int in_y, int in_width, int in_height, const String& in_coordinateSystem, String* out_dataURL) = 0;
-        virtual void handleJavaScriptDialog(ErrorString*, bool in_accept, const Maybe<String>& in_promptText) = 0;
-        virtual void archive(ErrorString*, String* out_data) = 0;
 
 };
 
@@ -781,17 +570,10 @@ class  Backend {
 class  Frontend {
     public:
         Frontend(FrontendChannel* frontendChannel) : m_frontendChannel(frontendChannel) { }
-        void domContentEventFired(double timestamp);
         void loadEventFired(double timestamp);
-        void frameNavigated(std::unique_ptr<protocol::Page::Frame> frame);
         void frameDetached(const String& frameId);
         void frameStartedLoading(const String& frameId);
         void frameStoppedLoading(const String& frameId);
-        void frameScheduledNavigation(const String& frameId, double delay);
-        void frameClearedScheduledNavigation(const String& frameId);
-        void javascriptDialogOpening(const String& message);
-        void javascriptDialogClosed();
-        void scriptsEnabled(bool isEnabled);
 
         void flush();
     private:

--- a/runtime/src/main/jni/v8_inspector/src/inspector/utils/base64.cpp
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/utils/base64.cpp
@@ -1,0 +1,133 @@
+/*
+   base64.cpp and base64.h
+
+   Copyright (C) 2004-2017 René Nyffenegger
+
+   This source code is provided 'as-is', without any express or implied
+   warranty. In no event will the author be held liable for any damages
+   arising from the use of this software.
+
+   Permission is granted to anyone to use this software for any purpose,
+   including commercial applications, and to alter it and redistribute it
+   freely, subject to the following restrictions:
+
+   1. The origin of this source code must not be misrepresented; you must not
+      claim that you wrote the original source code. If you use this source code
+      in a product, an acknowledgment in the product documentation would be
+      appreciated but is not required.
+
+   2. Altered source versions must be plainly marked as such, and must not be
+      misrepresented as being the original source code.
+
+   3. This notice may not be removed or altered from any source distribution.
+
+   René Nyffenegger rene.nyffenegger@adp-gmbh.ch
+
+*/
+
+#include "base64.h"
+#include <iostream>
+
+static const std::string base64_chars =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "abcdefghijklmnopqrstuvwxyz"
+    "0123456789+/";
+
+
+static inline bool is_base64(unsigned char c) {
+    return (isalnum(c) || (c == '+') || (c == '/'));
+}
+
+std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_len) {
+    std::string ret;
+    int i = 0;
+    int j = 0;
+    unsigned char char_array_3[3];
+    unsigned char char_array_4[4];
+
+    while (in_len--) {
+        char_array_3[i++] = *(bytes_to_encode++);
+        if (i == 3) {
+            char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
+            char_array_4[1] = ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
+            char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
+            char_array_4[3] = char_array_3[2] & 0x3f;
+
+            for (i = 0; (i <4) ; i++) {
+                ret += base64_chars[char_array_4[i]];
+            }
+            i = 0;
+        }
+    }
+
+    if (i) {
+        for (j = i; j < 3; j++) {
+            char_array_3[j] = '\0';
+        }
+
+        char_array_4[0] = ( char_array_3[0] & 0xfc) >> 2;
+        char_array_4[1] = ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
+        char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
+        char_array_4[3] =   char_array_3[2] & 0x3f;
+
+        for (j = 0; (j < i + 1); j++) {
+            ret += base64_chars[char_array_4[j]];
+        }
+
+        while ((i++ < 3)) {
+            ret += '=';
+        }
+
+    }
+
+    return ret;
+
+}
+
+std::string base64_decode(std::string const& encoded_string) {
+    int in_len = encoded_string.size();
+    int i = 0;
+    int j = 0;
+    int in_ = 0;
+    unsigned char char_array_4[4], char_array_3[3];
+    std::string ret;
+
+    while (in_len-- && ( encoded_string[in_] != '=') && is_base64(encoded_string[in_])) {
+        char_array_4[i++] = encoded_string[in_];
+        in_++;
+        if (i ==4) {
+            for (i = 0; i <4; i++) {
+                char_array_4[i] = base64_chars.find(char_array_4[i]);
+            }
+
+            char_array_3[0] = ( char_array_4[0] << 2       ) + ((char_array_4[1] & 0x30) >> 4);
+            char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
+            char_array_3[2] = ((char_array_4[2] & 0x3) << 6) +   char_array_4[3];
+
+            for (i = 0; (i < 3); i++) {
+                ret += char_array_3[i];
+            }
+            i = 0;
+        }
+    }
+
+    if (i) {
+        for (j = i; j <4; j++) {
+            char_array_4[j] = 0;
+        }
+
+        for (j = 0; j <4; j++) {
+            char_array_4[j] = base64_chars.find(char_array_4[j]);
+        }
+
+        char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
+        char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
+        char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+
+        for (j = 0; (j < i - 1); j++) {
+            ret += char_array_3[j];
+        }
+    }
+
+    return ret;
+}

--- a/runtime/src/main/jni/v8_inspector/src/inspector/utils/base64.h
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/utils/base64.h
@@ -1,0 +1,4 @@
+#include <string>
+
+std::string base64_encode(unsigned char const*, unsigned int len);
+std::string base64_decode(std::string const& s);

--- a/runtime/src/main/jni/v8_inspector/src/inspector/utils/v8-page-resources.cpp
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/utils/v8-page-resources.cpp
@@ -112,16 +112,10 @@ std::map<std::string, const char*> PageResource::s_mimeTypeMap = {
     { "application/xml", v8_inspector::protocol::Page::ResourceTypeEnum::Document },
     // text/css mime type is regarded as document so as to display in the Sources tab
     { "text/css", v8_inspector::protocol::Page::ResourceTypeEnum::Document },
-    // regarding javascript files as Scripts will prevent them from being displayed in the Sources
-    // tab of DevTools, at least according to the FrontEnd implementation
     { "text/javascript", v8_inspector::protocol::Page::ResourceTypeEnum::Script },
     { "application/javascript", v8_inspector::protocol::Page::ResourceTypeEnum::Script },
     { "application/json", v8_inspector::protocol::Page::ResourceTypeEnum::Document },
-    // regarding typescript files as Scripts will prevent them from being displayed in the Sources
-    // tab of DevTools, at least according to the FrontEnd implementation :-/
-    // Enable typescripts as documents so that breakpoints may be set in code that has yet to be reached.
-    // Will result in duplicate of the same typescript fiels in the Sources tab
-    { "text/typescript", v8_inspector::protocol::Page::ResourceTypeEnum::Document },
+    { "text/typescript", v8_inspector::protocol::Page::ResourceTypeEnum::Script },
     { "image/jpeg", v8_inspector::protocol::Page::ResourceTypeEnum::Image },
     { "image/png", v8_inspector::protocol::Page::ResourceTypeEnum::Image },
     { "application/binary", v8_inspector::protocol::Page::ResourceTypeEnum::Other }

--- a/runtime/src/main/jni/v8_inspector/src/inspector/utils/v8-page-resources.cpp
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/utils/v8-page-resources.cpp
@@ -1,0 +1,137 @@
+//
+// Created by pkanev on 2/2/2017.
+//
+
+#include <cstdlib>
+#include <jni.h>
+#include <assert.h>
+#include <NativeScriptAssert.h>
+#include <fstream>
+#include <iostream>
+#include "base64.h"
+#include "v8_inspector/src/inspector/utils/v8-page-resources.h"
+#include "JEnv.h"
+#include "ArgConverter.h"
+
+namespace v8_inspector {
+namespace utils {
+PageResource::PageResource(std::string filePath, std::string mimeType)
+    : m_filePath(filePath),
+      m_mimeType(mimeType),
+      m_content("") {
+
+    m_type = PageResource::resourceTypeByMimeType(m_mimeType);
+}
+
+std::map<std::string, v8_inspector::utils::PageResource> PageResource::getPageResources() {
+    auto result = std::map<std::string, v8_inspector::utils::PageResource>();
+    tns::JEnv env;
+    jclass inspectorClass = env.FindClass("com/tns/AndroidJsV8Inspector");
+    assert(inspectorClass != nullptr);
+
+    jclass pairClass = env.FindClass("android/util/Pair");
+    assert(pairClass != nullptr);
+
+    jfieldID pairFirst = env.GetFieldID(pairClass, "first", "Ljava/lang/Object;");
+    assert(pairFirst != nullptr);
+
+    jfieldID pairSecond = env.GetFieldID(pairClass, "second", "Ljava/lang/Object;");
+    assert(pairSecond != nullptr);
+
+    jmethodID getResourcesMethod = env.GetStaticMethodID(inspectorClass, "getPageResources", "()[Landroid/util/Pair;");
+    jobject arrayOfPairs = env.CallStaticObjectMethod(inspectorClass, getResourcesMethod);
+    jobjectArray pairs = static_cast<jobjectArray>(arrayOfPairs);
+    int arrSize = env.GetArrayLength(pairs);
+
+    for (int i = 0; i < arrSize; ++i) {
+        auto pair = env.GetObjectArrayElement(pairs, i);
+        auto pairFilePath = (jstring) env.GetObjectField(pair, pairFirst);
+        auto pairMimeType = (jstring) env.GetObjectField(pair, pairSecond);
+
+        auto filePath = tns::ArgConverter::jstringToString(pairFilePath);
+        auto mimeType = tns::ArgConverter::jstringToString(pairMimeType);
+
+        utils::PageResource pageResource(filePath, mimeType);
+        result.insert(std::make_pair(filePath, pageResource));
+
+        env.DeleteLocalRef(pairFilePath);
+        env.DeleteLocalRef(pairMimeType);
+        env.DeleteLocalRef(pair);
+    }
+
+    env.DeleteLocalRef(pairs);
+
+    s_cachedPageResources = result;
+
+    return result;
+}
+
+String16 PageResource::getContent(protocol::ErrorString* errorString) {
+    if (m_content.empty()) {
+        auto filePath = m_filePath;
+        auto shouldEncode = !hasTextContent();
+        filePath.erase(0, 7); // deletes the 'file://' part before the full file path
+        FILE* file = fopen(filePath.c_str(), "r+");
+        if (file == nullptr) {
+            *errorString = "Resource not found";
+            return "";
+        }
+
+        fseek(file, 0, SEEK_END);
+        long int size = ftell(file);
+        rewind(file);
+        unsigned char* buff = (unsigned char*) malloc(sizeof(unsigned char)*size);
+        long bytesRead = fread(buff, sizeof(unsigned char), size, file);
+        fclose(file);
+        buff[bytesRead] = '\0';
+
+        if (shouldEncode) {
+            auto base64EncodedString = base64_encode(buff, size);
+            m_content = base64EncodedString;
+        } else {
+            m_content = std::string(reinterpret_cast<char*>(buff));
+        }
+
+        free(buff);
+    }
+
+    return m_content.c_str();
+}
+
+const char* PageResource::resourceTypeByMimeType(std::string mimeType) {
+    auto result = protocol::Page::ResourceTypeEnum::Document;
+
+    if (!mimeType.empty()) {
+        auto it = s_mimeTypeMap.find(mimeType);
+        if (it != s_mimeTypeMap.end()) {
+            result = s_mimeTypeMap.at(mimeType);
+        }
+    }
+
+    return result;
+}
+
+std::map<std::string, const char*> PageResource::s_mimeTypeMap = {
+    { "text/xml", v8_inspector::protocol::Page::ResourceTypeEnum::Document },
+    { "text/plain", v8_inspector::protocol::Page::ResourceTypeEnum::Document },
+    { "application/xml", v8_inspector::protocol::Page::ResourceTypeEnum::Document },
+    // text/css mime type is regarded as document so as to display in the Sources tab
+    { "text/css", v8_inspector::protocol::Page::ResourceTypeEnum::Document },
+    // regarding javascript files as Scripts will prevent them from being displayed in the Sources
+    // tab of DevTools, at least according to the FrontEnd implementation
+    { "text/javascript", v8_inspector::protocol::Page::ResourceTypeEnum::Script },
+    { "application/javascript", v8_inspector::protocol::Page::ResourceTypeEnum::Script },
+    { "application/json", v8_inspector::protocol::Page::ResourceTypeEnum::Document },
+    // regarding typescript files as Scripts will prevent them from being displayed in the Sources
+    // tab of DevTools, at least according to the FrontEnd implementation :-/
+    // Enable typescripts as documents so that breakpoints may be set in code that has yet to be reached.
+    // Will result in duplicate of the same typescript fiels in the Sources tab
+    { "text/typescript", v8_inspector::protocol::Page::ResourceTypeEnum::Document },
+    { "image/jpeg", v8_inspector::protocol::Page::ResourceTypeEnum::Image },
+    { "image/png", v8_inspector::protocol::Page::ResourceTypeEnum::Image },
+    { "application/binary", v8_inspector::protocol::Page::ResourceTypeEnum::Other }
+};
+
+std::map<std::string, v8_inspector::utils::PageResource> PageResource::s_cachedPageResources;
+}
+}

--- a/runtime/src/main/jni/v8_inspector/src/inspector/utils/v8-page-resources.h
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/utils/v8-page-resources.h
@@ -1,0 +1,62 @@
+//
+// Created by pkanev on 2/2/2017.
+//
+
+#ifndef V8_PAGE_RESOURCES_H
+#define V8_PAGE_RESOURCES_H
+
+#include <map>
+#include <v8_inspector/src/inspector/protocol/Page.h>
+
+namespace v8_inspector {
+namespace utils {
+
+class PageResource {
+    public:
+        PageResource(std::string filePath, std::string mimeType);
+        bool hasTextContent() {
+            return strcmp(m_type, protocol::Page::ResourceTypeEnum::Document) == 0 ||
+                   strcmp(m_type, protocol::Page::ResourceTypeEnum::Stylesheet) == 0 ||
+                   strcmp(m_type, protocol::Page::ResourceTypeEnum::Script) == 0;
+
+        };
+        const char* getMimeType() {
+            return m_mimeType.c_str();
+        };
+        const char* getFilePath() {
+            return m_filePath.c_str();
+        };
+        const char*  getType() {
+            return m_type;
+        };
+
+        /*
+         * Get string representation of the resource (file) contents
+         * String is base64-encoded if the resource's MIME type isn't a Document | Stylesheet | Script
+         */
+        String16 getContent(protocol::ErrorString*);
+
+        /*
+         * Gets all file paths available in the application's files/app directory
+         * Java returns an array of pairs containing the file url and its MIME type
+         */
+        static std::map<std::string, v8_inspector::utils::PageResource> getPageResources();
+        static std::map<std::string, v8_inspector::utils::PageResource> s_cachedPageResources;
+
+    private:
+        std::string m_filePath;
+        std::string m_mimeType;
+        std::string m_content;
+        const char* m_type;
+
+        static std::map<std::string, const char*> s_mimeTypeMap;
+        /*
+         * Maps MIME type strings to their v8 ResourceType counterparts
+         * e.g. image/jpeg -> Image; text/javascript -> Script
+         */
+        static const char* resourceTypeByMimeType(std::string mimeType);
+};
+}
+}
+
+#endif //V8_PAGE_RESOURCES_H

--- a/runtime/src/main/jni/v8_inspector/src/inspector/utils/v8-search-utils-public.cpp
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/utils/v8-search-utils-public.cpp
@@ -1,0 +1,41 @@
+//
+// Created by pkanev on 2/9/2017.
+//
+
+#include <v8_inspector/src/inspector/utils/v8-search-utils-public.h>
+#include <v8_inspector/src/inspector/v8-page-agent-impl.h>
+
+namespace v8_inspector {
+namespace utils {
+namespace ResourceContentSearchUtils {
+std::unique_ptr<protocol::Array<protocol::Page::SearchResult>> getSearchMatches(V8InspectorSessionImpl* session, std::vector<utils::PageResource>& resources, const String16& frameIdentifier, const String16& text, bool isCaseSensitive, bool isRegex) {
+    auto inspector = static_cast<V8InspectorSessionImpl*>(session)->inspector();
+
+    auto regex = createSearchRegex(inspector, text, isCaseSensitive, isRegex);
+
+    auto result = protocol::Array<protocol::Page::SearchResult>::create();
+
+    for (PageResource& resource : resources) {
+        ErrorString* errorString;
+        String content = resource.getContent(errorString);
+        if (errorString->isEmpty()) {
+            int matchesCount = scriptRegexpMatchesByLines(*regex, content).size();
+            if (matchesCount) {
+                result->addItem(std::move(buildObjectForSearchResult(frameIdentifier, resource.getFilePath(), matchesCount)));
+            }
+        }
+    }
+
+    return result;
+}
+
+std::unique_ptr<protocol::Page::SearchResult> buildObjectForSearchResult(const String16& frameId, const String16& url, int matchesCount) {
+    return protocol::Page::SearchResult::create()
+           .setUrl(url)
+           .setFrameId(frameId)
+           .setMatchesCount(matchesCount)
+           .build();
+}
+}
+}
+}

--- a/runtime/src/main/jni/v8_inspector/src/inspector/utils/v8-search-utils-public.h
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/utils/v8-search-utils-public.h
@@ -1,0 +1,130 @@
+//
+// Created by pkanev on 2/9/2017.
+//
+
+#ifndef V8_SEARCH_UTILS_PUBLIC_H
+#define V8_SEARCH_UTILS_PUBLIC_H
+
+#include <v8_inspector/src/inspector/string-16.h>
+#include <v8_inspector/src/inspector/v8-regex.h>
+#include <v8_inspector/src/inspector/v8-inspector-session-impl.h>
+#include <v8_inspector/src/inspector/protocol-platform.h>
+#include <v8_inspector/src/inspector/protocol/Debugger.h>
+#include "v8-page-resources.h"
+
+namespace v8_inspector {
+namespace utils {
+namespace ResourceContentSearchUtils {
+// Implementation taken from v8_inspector/src/inspector/search-util
+String16 createSearchRegexSource(const String16& text) {
+    String16Builder result;
+
+    for (size_t i = 0; i < text.length(); i++) {
+        UChar c = text[i];
+        if (c == '[' || c == ']' || c == '(' || c == ')' || c == '{' || c == '}' ||
+                c == '+' || c == '-' || c == '*' || c == '.' || c == ',' || c == '?' ||
+                c == '\\' || c == '^' || c == '$' || c == '|') {
+            result.append('\\');
+        }
+        result.append(c);
+    }
+
+    return result.toString();
+}
+
+// Implementation taken from v8_inspector/src/inspector/search-util
+std::unique_ptr<std::vector<size_t>> lineEndings(const String16& text) {
+    std::unique_ptr<std::vector<size_t>> result(new std::vector<size_t>());
+
+    const String16 lineEndString = "\n";
+    size_t start = 0;
+    while (start < text.length()) {
+        size_t lineEnd = text.find(lineEndString, start);
+        if (lineEnd == String16::kNotFound) {
+            break;
+        }
+
+        result->push_back(lineEnd);
+        start = lineEnd + 1;
+    }
+    result->push_back(text.length());
+
+    return result;
+}
+
+// Implementation taken from v8_inspector/src/inspector/search-util
+std::vector<std::pair<int, String16>> scriptRegexpMatchesByLines(
+const V8Regex& regex, const String16& text) {
+    std::vector<std::pair<int, String16>> result;
+    if (text.isEmpty()) {
+        return result;
+    }
+
+    std::unique_ptr<std::vector<size_t>> endings(lineEndings(text));
+    size_t size = endings->size();
+    size_t start = 0;
+    for (size_t lineNumber = 0; lineNumber < size; ++lineNumber) {
+        size_t lineEnd = endings->at(lineNumber);
+        String16 line = text.substring(start, lineEnd - start);
+        if (line.length() && line[line.length() - 1] == '\r') {
+            line = line.substring(0, line.length() - 1);
+        }
+
+        int matchLength;
+        if (regex.match(line, 0, &matchLength) != -1) {
+            result.push_back(std::pair<int, String16>(lineNumber, line));
+        }
+
+        start = lineEnd + 1;
+    }
+    return result;
+}
+
+// Implementation taken from v8_inspector/src/inspector/search-util
+std::unique_ptr<V8Regex> createSearchRegex(V8InspectorImpl* inspector,
+        const String16& query,
+        bool caseSensitive, bool isRegex) {
+    String16 regexSource = isRegex ? query : createSearchRegexSource(query);
+    return wrapUnique(new V8Regex(inspector, regexSource, caseSensitive));
+}
+
+// Implementation taken from v8_inspector/src/inspector/search-util
+// modified return type to protocol::GenericTypes::SearchMatch (originally protocol::Debugger::SearchMatch)
+std::unique_ptr<protocol::GenericTypes::SearchMatch> buildObjectForSearchMatch(
+    int lineNumber, const String16& lineContent) {
+    return protocol::GenericTypes::SearchMatch::create()
+           .setLineNumber(lineNumber)
+           .setLineContent(lineContent)
+           .build();
+}
+
+// Implementation taken from v8_inspector/src/inspector/search-util
+std::vector<std::unique_ptr<protocol::GenericTypes::SearchMatch>>
+        searchInTextByLinesImpl(V8InspectorSession* session, const String16& text,
+                                const String16& query, const bool caseSensitive,
+const bool isRegex) {
+    std::unique_ptr<V8Regex> regex = createSearchRegex(
+                                         static_cast<V8InspectorSessionImpl*>(session)->inspector(), query,
+                                         caseSensitive, isRegex);
+    std::vector<std::pair<int, String16>> matches =
+                                           scriptRegexpMatchesByLines(*regex.get(), text);
+
+    std::vector<std::unique_ptr<protocol::GenericTypes::SearchMatch>> result;
+    for (const auto& match : matches) {
+        result.push_back(buildObjectForSearchMatch(match.first, match.second));
+    }
+    return result;
+}
+
+std::unique_ptr<protocol::Array<protocol::Page::SearchResult>> getSearchMatches(
+            V8InspectorSessionImpl* inspector, std::vector<utils::PageResource>& resources,
+            const String16& frameIdentifier, const String16& text, bool isCaseSensitive,
+            bool isRegex);
+
+std::unique_ptr<protocol::Page::SearchResult> buildObjectForSearchResult(
+    const String16& frameId, const String16& url, int matchesCount);
+}
+}
+}
+
+#endif //V8_SEARCH_UTILS_PUBLIC_H

--- a/runtime/src/main/jni/v8_inspector/src/inspector/v8-inspector-session-impl.cc
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/v8-inspector-session-impl.cc
@@ -18,6 +18,7 @@
 #include "src/inspector/v8-profiler-agent-impl.h"
 #include "src/inspector/v8-runtime-agent-impl.h"
 #include "src/inspector/v8-schema-agent-impl.h"
+#include "src/inspector/v8-page-agent-impl.h"
 
 namespace v8_inspector {
 
@@ -34,7 +35,9 @@ bool V8InspectorSession::canDispatchMethod(const StringView& method) {
          stringViewStartsWith(method,
                               protocol::Console::Metainfo::commandPrefix) ||
          stringViewStartsWith(method,
-                              protocol::Schema::Metainfo::commandPrefix);
+                              protocol::Schema::Metainfo::commandPrefix) ||
+         stringViewStartsWith(method,
+                               protocol::Page::Metainfo::commandPrefix);
 }
 
 std::unique_ptr<V8InspectorSessionImpl> V8InspectorSessionImpl::create(
@@ -59,7 +62,8 @@ V8InspectorSessionImpl::V8InspectorSessionImpl(V8InspectorImpl* inspector,
       m_heapProfilerAgent(nullptr),
       m_profilerAgent(nullptr),
       m_consoleAgent(nullptr),
-      m_schemaAgent(nullptr) {
+      m_schemaAgent(nullptr),
+      m_pageAgent(nullptr) {
   if (savedState.length()) {
     std::unique_ptr<protocol::Value> state =
         protocol::parseJSON(toString16(savedState));
@@ -94,12 +98,17 @@ V8InspectorSessionImpl::V8InspectorSessionImpl(V8InspectorImpl* inspector,
       this, this, agentState(protocol::Schema::Metainfo::domainName)));
   protocol::Schema::Dispatcher::wire(&m_dispatcher, m_schemaAgent.get());
 
+  m_pageAgent = wrapUnique(new V8PageAgentImpl(
+      this, this, agentState(protocol::Page::Metainfo::domainName)));
+  protocol::Page::Dispatcher::wire(&m_dispatcher, m_pageAgent.get());
+
   if (savedState.length()) {
     m_runtimeAgent->restore();
     m_debuggerAgent->restore();
     m_heapProfilerAgent->restore();
     m_profilerAgent->restore();
     m_consoleAgent->restore();
+    m_pageAgent->restore();
   }
 }
 
@@ -110,6 +119,7 @@ V8InspectorSessionImpl::~V8InspectorSessionImpl() {
   m_heapProfilerAgent->disable(&errorString);
   m_debuggerAgent->disable(&errorString);
   m_runtimeAgent->disable(&errorString);
+  m_pageAgent->disable(&errorString);
 
   discardInjectedScripts();
   m_inspector->disconnect(this);
@@ -352,6 +362,10 @@ V8InspectorSessionImpl::supportedDomainsImpl() {
   result.push_back(protocol::Schema::Domain::create()
                        .setName(protocol::Schema::Metainfo::domainName)
                        .setVersion(protocol::Schema::Metainfo::version)
+                       .build());
+  result.push_back(protocol::Schema::Domain::create()
+                       .setName(protocol::Page::Metainfo::domainName)
+                       .setVersion(protocol::Page::Metainfo::version)
                        .build());
   return result;
 }

--- a/runtime/src/main/jni/v8_inspector/src/inspector/v8-inspector-session-impl.h
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/v8-inspector-session-impl.h
@@ -11,6 +11,7 @@
 #include "src/inspector/protocol/Forward.h"
 #include "src/inspector/protocol/Runtime.h"
 #include "src/inspector/protocol/Schema.h"
+#include "src/inspector/protocol/Page.h"
 
 #include "include/v8-inspector.h"
 
@@ -25,100 +26,119 @@ class V8HeapProfilerAgentImpl;
 class V8ProfilerAgentImpl;
 class V8RuntimeAgentImpl;
 class V8SchemaAgentImpl;
+class V8PageAgentImpl;
 
 using protocol::ErrorString;
 
 class V8InspectorSessionImpl : public V8InspectorSession,
-                               public protocol::FrontendChannel {
- public:
-  static std::unique_ptr<V8InspectorSessionImpl> create(
-      V8InspectorImpl*, int contextGroupId, V8Inspector::Channel*,
-      const StringView& state);
-  ~V8InspectorSessionImpl();
+    public protocol::FrontendChannel {
+    public:
+        static std::unique_ptr<V8InspectorSessionImpl> create(
+            V8InspectorImpl*, int contextGroupId, V8Inspector::Channel*,
+            const StringView& state);
+        ~V8InspectorSessionImpl();
 
-  V8InspectorImpl* inspector() const { return m_inspector; }
-  V8ConsoleAgentImpl* consoleAgent() { return m_consoleAgent.get(); }
-  V8DebuggerAgentImpl* debuggerAgent() { return m_debuggerAgent.get(); }
-  V8SchemaAgentImpl* schemaAgent() { return m_schemaAgent.get(); }
-  V8ProfilerAgentImpl* profilerAgent() { return m_profilerAgent.get(); }
-  V8RuntimeAgentImpl* runtimeAgent() { return m_runtimeAgent.get(); }
-  int contextGroupId() const { return m_contextGroupId; }
+        V8InspectorImpl* inspector() const {
+            return m_inspector;
+        }
+        V8ConsoleAgentImpl* consoleAgent() {
+            return m_consoleAgent.get();
+        }
+        V8DebuggerAgentImpl* debuggerAgent() {
+            return m_debuggerAgent.get();
+        }
+        V8SchemaAgentImpl* schemaAgent() {
+            return m_schemaAgent.get();
+        }
+        V8ProfilerAgentImpl* profilerAgent() {
+            return m_profilerAgent.get();
+        }
+        V8RuntimeAgentImpl* runtimeAgent() {
+            return m_runtimeAgent.get();
+        }
+        V8PageAgentImpl* pageAgent() {
+            return m_pageAgent.get();
+        }
+        int contextGroupId() const {
+            return m_contextGroupId;
+        }
 
-  InjectedScript* findInjectedScript(ErrorString*, int contextId);
-  InjectedScript* findInjectedScript(ErrorString*, RemoteObjectIdBase*);
-  void reset();
-  void discardInjectedScripts();
-  void reportAllContexts(V8RuntimeAgentImpl*);
-  void setCustomObjectFormatterEnabled(bool);
-  std::unique_ptr<protocol::Runtime::RemoteObject> wrapObject(
-      v8::Local<v8::Context>, v8::Local<v8::Value>, const String16& groupName,
-      bool generatePreview);
-  std::unique_ptr<protocol::Runtime::RemoteObject> wrapTable(
-      v8::Local<v8::Context>, v8::Local<v8::Value> table,
-      v8::Local<v8::Value> columns);
-  std::vector<std::unique_ptr<protocol::Schema::Domain>> supportedDomainsImpl();
-  bool unwrapObject(ErrorString*, const String16& objectId,
-                    v8::Local<v8::Value>*, v8::Local<v8::Context>*,
-                    String16* objectGroup);
-  void releaseObjectGroup(const String16& objectGroup);
+        InjectedScript* findInjectedScript(ErrorString*, int contextId);
+        InjectedScript* findInjectedScript(ErrorString*, RemoteObjectIdBase*);
+        void reset();
+        void discardInjectedScripts();
+        void reportAllContexts(V8RuntimeAgentImpl*);
+        void setCustomObjectFormatterEnabled(bool);
+        std::unique_ptr<protocol::Runtime::RemoteObject> wrapObject(
+            v8::Local<v8::Context>, v8::Local<v8::Value>, const String16& groupName,
+            bool generatePreview);
+        std::unique_ptr<protocol::Runtime::RemoteObject> wrapTable(
+            v8::Local<v8::Context>, v8::Local<v8::Value> table,
+            v8::Local<v8::Value> columns);
+        std::vector<std::unique_ptr<protocol::Schema::Domain>> supportedDomainsImpl();
+        bool unwrapObject(ErrorString*, const String16& objectId,
+                          v8::Local<v8::Value>*, v8::Local<v8::Context>*,
+                          String16* objectGroup);
+        void releaseObjectGroup(const String16& objectGroup);
 
-  // V8InspectorSession implementation.
-  void dispatchProtocolMessage(const StringView& message) override;
-  std::unique_ptr<StringBuffer> stateJSON() override;
-  std::vector<std::unique_ptr<protocol::Schema::API::Domain>> supportedDomains()
-      override;
-  void addInspectedObject(
-      std::unique_ptr<V8InspectorSession::Inspectable>) override;
-  void schedulePauseOnNextStatement(const StringView& breakReason,
-                                    const StringView& breakDetails) override;
-  void cancelPauseOnNextStatement() override;
-  void breakProgram(const StringView& breakReason,
-                    const StringView& breakDetails) override;
-  void setSkipAllPauses(bool) override;
-  void resume() override;
-  void stepOver() override;
-  std::vector<std::unique_ptr<protocol::Debugger::API::SearchMatch>>
-  searchInTextByLines(const StringView& text, const StringView& query,
-                      bool caseSensitive, bool isRegex) override;
-  void releaseObjectGroup(const StringView& objectGroup) override;
-  bool unwrapObject(std::unique_ptr<StringBuffer>*, const StringView& objectId,
-                    v8::Local<v8::Value>*, v8::Local<v8::Context>*,
-                    std::unique_ptr<StringBuffer>* objectGroup) override;
-  std::unique_ptr<protocol::Runtime::API::RemoteObject> wrapObject(
-      v8::Local<v8::Context>, v8::Local<v8::Value>,
-      const StringView& groupName) override;
+        // V8InspectorSession implementation.
+        void dispatchProtocolMessage(const StringView& message) override;
+        std::unique_ptr<StringBuffer> stateJSON() override;
+        std::vector<std::unique_ptr<protocol::Schema::API::Domain>> supportedDomains()
+                override;
+        void addInspectedObject(
+            std::unique_ptr<V8InspectorSession::Inspectable>) override;
+        void schedulePauseOnNextStatement(const StringView& breakReason,
+                                          const StringView& breakDetails) override;
+        void cancelPauseOnNextStatement() override;
+        void breakProgram(const StringView& breakReason,
+                          const StringView& breakDetails) override;
+        void setSkipAllPauses(bool) override;
+        void resume() override;
+        void stepOver() override;
+        std::vector<std::unique_ptr<protocol::Debugger::API::SearchMatch>>
+                searchInTextByLines(const StringView& text, const StringView& query,
+                                    bool caseSensitive, bool isRegex) override;
+        void releaseObjectGroup(const StringView& objectGroup) override;
+        bool unwrapObject(std::unique_ptr<StringBuffer>*, const StringView& objectId,
+                          v8::Local<v8::Value>*, v8::Local<v8::Context>*,
+                          std::unique_ptr<StringBuffer>* objectGroup) override;
+        std::unique_ptr<protocol::Runtime::API::RemoteObject> wrapObject(
+            v8::Local<v8::Context>, v8::Local<v8::Value>,
+            const StringView& groupName) override;
 
-  V8InspectorSession::Inspectable* inspectedObject(unsigned num);
-  static const unsigned kInspectedObjectBufferSize = 5;
+        V8InspectorSession::Inspectable* inspectedObject(unsigned num);
+        static const unsigned kInspectedObjectBufferSize = 5;
 
- private:
-  V8InspectorSessionImpl(V8InspectorImpl*, int contextGroupId,
-                         V8Inspector::Channel*, const StringView& state);
-  protocol::DictionaryValue* agentState(const String16& name);
+    private:
+        V8InspectorSessionImpl(V8InspectorImpl*, int contextGroupId,
+                               V8Inspector::Channel*, const StringView& state);
+        protocol::DictionaryValue* agentState(const String16& name);
 
-  // protocol::FrontendChannel implementation.
-  void sendProtocolResponse(int callId, const String16& message) override;
-  void sendProtocolNotification(const String16& message) override;
-  void flushProtocolNotifications() override;
+        // protocol::FrontendChannel implementation.
+        void sendProtocolResponse(int callId, const String16& message) override;
+        void sendProtocolNotification(const String16& message) override;
+        void flushProtocolNotifications() override;
 
-  int m_contextGroupId;
-  V8InspectorImpl* m_inspector;
-  V8Inspector::Channel* m_channel;
-  bool m_customObjectFormatterEnabled;
+        int m_contextGroupId;
+        V8InspectorImpl* m_inspector;
+        V8Inspector::Channel* m_channel;
+        bool m_customObjectFormatterEnabled;
 
-  protocol::UberDispatcher m_dispatcher;
-  std::unique_ptr<protocol::DictionaryValue> m_state;
+        protocol::UberDispatcher m_dispatcher;
+        std::unique_ptr<protocol::DictionaryValue> m_state;
 
-  std::unique_ptr<V8RuntimeAgentImpl> m_runtimeAgent;
-  std::unique_ptr<V8DebuggerAgentImpl> m_debuggerAgent;
-  std::unique_ptr<V8HeapProfilerAgentImpl> m_heapProfilerAgent;
-  std::unique_ptr<V8ProfilerAgentImpl> m_profilerAgent;
-  std::unique_ptr<V8ConsoleAgentImpl> m_consoleAgent;
-  std::unique_ptr<V8SchemaAgentImpl> m_schemaAgent;
-  std::vector<std::unique_ptr<V8InspectorSession::Inspectable>>
-      m_inspectedObjects;
+        std::unique_ptr<V8RuntimeAgentImpl> m_runtimeAgent;
+        std::unique_ptr<V8DebuggerAgentImpl> m_debuggerAgent;
+        std::unique_ptr<V8HeapProfilerAgentImpl> m_heapProfilerAgent;
+        std::unique_ptr<V8ProfilerAgentImpl> m_profilerAgent;
+        std::unique_ptr<V8ConsoleAgentImpl> m_consoleAgent;
+        std::unique_ptr<V8SchemaAgentImpl> m_schemaAgent;
+        std::unique_ptr<V8PageAgentImpl> m_pageAgent;
+        std::vector<std::unique_ptr<V8InspectorSession::Inspectable>>
+                m_inspectedObjects;
 
-  DISALLOW_COPY_AND_ASSIGN(V8InspectorSessionImpl);
+        DISALLOW_COPY_AND_ASSIGN(V8InspectorSessionImpl);
 };
 
 }  // namespace v8_inspector

--- a/runtime/src/main/jni/v8_inspector/src/inspector/v8-page-agent-impl.cpp
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/v8-page-agent-impl.cpp
@@ -1,0 +1,257 @@
+//
+// Created by pkanev on 1/31/2017.
+//
+
+#include <v8_inspector/src/inspector/utils/v8-search-utils-public.h>
+#include "v8-page-agent-impl.h"
+#include "v8_inspector/src/inspector/utils/v8-page-resources.h"
+#include "search-util.h"
+
+namespace v8_inspector {
+
+namespace PageAgentState {
+static const char pageEnabled[] = "pageEnabled";
+}
+
+V8PageAgentImpl::V8PageAgentImpl(
+    V8InspectorSessionImpl* session, protocol::FrontendChannel* frontendChannel,
+    protocol::DictionaryValue* state)
+    : m_session(session), m_frontend(frontendChannel),
+      m_state(state),
+      m_enabled(false),
+      m_frameIdentifier("NSFrameIdentifier"),
+      m_frameUrl("file://") {}
+
+V8PageAgentImpl::~V8PageAgentImpl() {}
+
+void V8PageAgentImpl::enable(ErrorString*) {
+    if (m_enabled) {
+        return;
+    }
+
+    m_state->setBoolean(PageAgentState::pageEnabled, true);
+
+    m_enabled = true;
+}
+
+void V8PageAgentImpl::disable(ErrorString*) {
+    if (!m_enabled) {
+        return;
+    }
+
+    m_state->setBoolean(PageAgentState::pageEnabled, false);
+
+    m_enabled = false;
+}
+
+void V8PageAgentImpl::restore() {
+    if (!m_state->booleanProperty(PageAgentState::pageEnabled, false)) {
+        return;
+    }
+
+    ErrorString ignored;
+    enable(&ignored);
+}
+
+void V8PageAgentImpl::getResourceTree(
+    ErrorString*, std::unique_ptr<protocol::Page::FrameResourceTree>* out_frameTree) {
+    std::unique_ptr<protocol::Page::Frame> frameObject = protocol::Page::Frame::create()
+            .setId(m_frameIdentifier.c_str())
+            .setLoaderId("Loader Identifier")
+            .setMimeType("text/directory")
+            .setSecurityOrigin("")
+            .setUrl(m_frameUrl.c_str())
+            .build();
+
+    auto subresources = protocol::Array<protocol::Page::FrameResource>::create();
+
+    auto resources = v8_inspector::utils::PageResource::getPageResources();
+
+    for (auto const& resource : resources) {
+        auto pageResource = resource.second;
+        std::unique_ptr<protocol::Page::FrameResource> frameResource = protocol::Page::FrameResource::create()
+                .setUrl(pageResource.getFilePath())
+                .setType(pageResource.getType())
+                .setMimeType(pageResource.getMimeType())
+                .build();
+
+        subresources->addItem(std::move(frameResource));
+    }
+
+    *out_frameTree = protocol::Page::FrameResourceTree::create()
+                     .setFrame(std::move(frameObject))
+                     .setResources(std::move(subresources))
+                     .build();
+
+}
+
+void V8PageAgentImpl::getResourceContent(ErrorString* errorString, const String& in_frameId,
+        const String& in_url, String* out_content,
+        bool* out_base64Encoded) {
+    if (in_url.utf8().compare(m_frameUrl) == 0) {
+        *out_content = "";
+        *out_base64Encoded = false;
+
+        return;
+    }
+
+    std::map<std::string, v8_inspector::utils::PageResource> cachedPageResources = utils::PageResource::s_cachedPageResources;
+    if (utils::PageResource::s_cachedPageResources.size() == 0) {
+        cachedPageResources = utils::PageResource::getPageResources();
+    }
+
+    auto it = cachedPageResources.find(in_url.utf8());
+    if (it == cachedPageResources.end()) {
+        *errorString = "Resource not found.";
+
+        return;
+    }
+
+    auto resource = it->second;
+
+    *out_base64Encoded = !resource.hasTextContent();
+
+    *out_content = resource.getContent(errorString);
+}
+
+void V8PageAgentImpl::searchInResource(ErrorString* errorString, const String& in_frameId,
+                                       const String& in_url,
+                                       const String& in_query,
+                                       const Maybe<bool>& in_caseSensitive,
+                                       const Maybe<bool>& in_isRegex,
+                                       const Maybe<String>& in_requestId,
+                                       std::unique_ptr<protocol::Array<protocol::GenericTypes::SearchMatch>>* out_result) {
+    bool isRegex = in_isRegex.fromMaybe(false);
+    bool isCaseSensitive = in_caseSensitive.fromMaybe(false);
+
+    std::map<std::string, v8_inspector::utils::PageResource> cachedPageResources = utils::PageResource::s_cachedPageResources;
+    if (utils::PageResource::s_cachedPageResources.size() == 0) {
+        cachedPageResources = utils::PageResource::getPageResources();
+    }
+
+    auto result = protocol::Array<protocol::GenericTypes::SearchMatch>::create();
+
+    auto it = cachedPageResources.find(in_url.utf8());
+    if (it == cachedPageResources.end()) {
+        *out_result = std::move(result);
+        return;
+    }
+
+    auto resource = it->second;
+    auto content = resource.getContent(errorString);
+    if (errorString->isEmpty()) {
+        auto matches = v8_inspector::utils::ResourceContentSearchUtils::searchInTextByLinesImpl(m_session, content, in_query, isCaseSensitive, isRegex);
+        for (auto& match : matches) {
+            result->addItem(std::move(match));
+        }
+
+        *out_result = std::move(result);
+    }
+}
+
+void V8PageAgentImpl::searchInResources(ErrorString*, const String& in_text,
+                                        const Maybe<bool>& in_caseSensitive,
+                                        const Maybe<bool>& in_isRegex,
+                                        std::unique_ptr<protocol::Array<protocol::Page::SearchResult>>* out_result) {
+    bool isRegex = in_isRegex.fromMaybe(false);
+    bool isCaseSensitive = in_caseSensitive.fromMaybe(false);
+
+    std::map<std::string, v8_inspector::utils::PageResource> cachedPageResources = utils::PageResource::s_cachedPageResources;
+    if (utils::PageResource::s_cachedPageResources.size() == 0) {
+        cachedPageResources = utils::PageResource::getPageResources();
+    }
+
+    std::vector<utils::PageResource> resourceObjects;
+
+    for (auto const& mapKVP : cachedPageResources) {
+        resourceObjects.push_back(mapKVP.second);
+    }
+
+    *out_result = utils::ResourceContentSearchUtils::getSearchMatches(m_session, resourceObjects, m_frameUrl.c_str(), in_text, isCaseSensitive, isRegex);
+}
+
+void V8PageAgentImpl::addScriptToEvaluateOnLoad(ErrorString*, const String& in_scriptSource,
+        String* out_identifier) {
+
+}
+
+void V8PageAgentImpl::removeScriptToEvaluateOnLoad(ErrorString*, const String& in_identifier) {
+
+}
+
+
+void V8PageAgentImpl::reload(ErrorString*, const Maybe<bool>& in_ignoreCache,
+                             const Maybe<String>& in_scriptToEvaluateOnLoad) {
+
+}
+
+void V8PageAgentImpl::navigate(ErrorString*, const String& in_url) {
+
+}
+
+void V8PageAgentImpl::getCookies(ErrorString*,
+                                 std::unique_ptr<protocol::Array<protocol::Page::Cookie>>* out_cookies) {
+
+}
+
+void V8PageAgentImpl::deleteCookie(ErrorString*, const String& in_cookieName,
+                                   const String& in_url) {
+
+}
+
+void V8PageAgentImpl::setDocumentContent(ErrorString*, const String& in_frameId,
+        const String& in_html) {
+
+}
+
+void V8PageAgentImpl::setShowPaintRects(ErrorString*, bool in_result) {
+
+}
+
+void V8PageAgentImpl::getScriptExecutionStatus(ErrorString*, String* out_result) {
+
+}
+
+void V8PageAgentImpl::setScriptExecutionDisabled(ErrorString*, bool in_value) {
+
+}
+
+void V8PageAgentImpl::setTouchEmulationEnabled(ErrorString*, bool in_enabled) {
+
+}
+
+void V8PageAgentImpl::setEmulatedMedia(ErrorString*, const String& in_media) {
+
+}
+
+void V8PageAgentImpl::getCompositingBordersVisible(ErrorString*, bool* out_result) {
+
+}
+
+void V8PageAgentImpl::setCompositingBordersVisible(ErrorString*, bool in_visible) {
+
+}
+
+void V8PageAgentImpl::snapshotNode(ErrorString*, int in_nodeId, String* out_dataURL) {
+
+}
+
+void V8PageAgentImpl::snapshotRect(ErrorString*, int in_x, int in_y, int in_width,
+                                   int in_height, const String& in_coordinateSystem,
+                                   String* out_dataURL) {
+
+}
+
+void V8PageAgentImpl::handleJavaScriptDialog(ErrorString*, bool in_accept,
+        const Maybe<String>& in_promptText) {
+
+}
+
+void V8PageAgentImpl::archive(ErrorString*, String* out_data) {
+
+}
+
+void V8PageAgentImpl::reset() {
+
+}
+}

--- a/runtime/src/main/jni/v8_inspector/src/inspector/v8-page-agent-impl.cpp
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/v8-page-agent-impl.cpp
@@ -4,7 +4,6 @@
 
 #include <v8_inspector/src/inspector/utils/v8-search-utils-public.h>
 #include "v8-page-agent-impl.h"
-#include "v8_inspector/src/inspector/utils/v8-page-resources.h"
 #include "search-util.h"
 
 namespace v8_inspector {
@@ -185,71 +184,11 @@ void V8PageAgentImpl::reload(ErrorString*, const Maybe<bool>& in_ignoreCache,
 
 }
 
-void V8PageAgentImpl::navigate(ErrorString*, const String& in_url) {
-
-}
-
-void V8PageAgentImpl::getCookies(ErrorString*,
-                                 std::unique_ptr<protocol::Array<protocol::Page::Cookie>>* out_cookies) {
-
-}
-
-void V8PageAgentImpl::deleteCookie(ErrorString*, const String& in_cookieName,
-                                   const String& in_url) {
-
-}
-
 void V8PageAgentImpl::setDocumentContent(ErrorString*, const String& in_frameId,
         const String& in_html) {
 
 }
 
-void V8PageAgentImpl::setShowPaintRects(ErrorString*, bool in_result) {
-
-}
-
-void V8PageAgentImpl::getScriptExecutionStatus(ErrorString*, String* out_result) {
-
-}
-
-void V8PageAgentImpl::setScriptExecutionDisabled(ErrorString*, bool in_value) {
-
-}
-
-void V8PageAgentImpl::setTouchEmulationEnabled(ErrorString*, bool in_enabled) {
-
-}
-
-void V8PageAgentImpl::setEmulatedMedia(ErrorString*, const String& in_media) {
-
-}
-
-void V8PageAgentImpl::getCompositingBordersVisible(ErrorString*, bool* out_result) {
-
-}
-
-void V8PageAgentImpl::setCompositingBordersVisible(ErrorString*, bool in_visible) {
-
-}
-
-void V8PageAgentImpl::snapshotNode(ErrorString*, int in_nodeId, String* out_dataURL) {
-
-}
-
-void V8PageAgentImpl::snapshotRect(ErrorString*, int in_x, int in_y, int in_width,
-                                   int in_height, const String& in_coordinateSystem,
-                                   String* out_dataURL) {
-
-}
-
-void V8PageAgentImpl::handleJavaScriptDialog(ErrorString*, bool in_accept,
-        const Maybe<String>& in_promptText) {
-
-}
-
-void V8PageAgentImpl::archive(ErrorString*, String* out_data) {
-
-}
 
 void V8PageAgentImpl::reset() {
 

--- a/runtime/src/main/jni/v8_inspector/src/inspector/v8-page-agent-impl.cpp
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/v8-page-agent-impl.cpp
@@ -103,7 +103,7 @@ void V8PageAgentImpl::getResourceContent(ErrorString* errorString, const String&
     auto it = cachedPageResources.find(in_url.utf8());
     if (it == cachedPageResources.end()) {
         *errorString = "Resource not found.";
-
+        *out_content = "";
         return;
     }
 

--- a/runtime/src/main/jni/v8_inspector/src/inspector/v8-page-agent-impl.h
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/v8-page-agent-impl.h
@@ -33,21 +33,7 @@ class V8PageAgentImpl : public protocol::Page::Backend {
         void addScriptToEvaluateOnLoad(ErrorString*, const String& in_scriptSource, String* out_identifier) override;
         void removeScriptToEvaluateOnLoad(ErrorString*, const String& in_identifier) override;
         void reload(ErrorString*, const Maybe<bool>& in_ignoreCache, const Maybe<String>& in_scriptToEvaluateOnLoad) override;
-        void navigate(ErrorString*, const String& in_url) override;
-        void getCookies(ErrorString*, std::unique_ptr<protocol::Array<protocol::Page::Cookie>>* out_cookies) override;
-        void deleteCookie(ErrorString*, const String& in_cookieName, const String& in_url) override;
         void setDocumentContent(ErrorString*, const String& in_frameId, const String& in_html) override;
-        void setShowPaintRects(ErrorString*, bool in_result) override;
-        void getScriptExecutionStatus(ErrorString*, String* out_result) override;
-        void setScriptExecutionDisabled(ErrorString*, bool in_value) override;
-        void setTouchEmulationEnabled(ErrorString*, bool in_enabled) override;
-        void setEmulatedMedia(ErrorString*, const String& in_media) override;
-        void getCompositingBordersVisible(ErrorString*, bool* out_result) override;
-        void setCompositingBordersVisible(ErrorString*, bool in_visible) override;
-        void snapshotNode(ErrorString*, int in_nodeId, String* out_dataURL) override;
-        void snapshotRect(ErrorString*, int in_x, int in_y, int in_width, int in_height, const String& in_coordinateSystem, String* out_dataURL) override;
-        void handleJavaScriptDialog(ErrorString*, bool in_accept, const Maybe<String>& in_promptText) override;
-        void archive(ErrorString*, String* out_data) override;
 
         void restore();
         void reset();

--- a/runtime/src/main/jni/v8_inspector/src/inspector/v8-page-agent-impl.h
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/v8-page-agent-impl.h
@@ -1,0 +1,71 @@
+//
+// Created by pkanev on 1/31/2017.
+//
+
+#ifndef V8_INSPECTOR_V8PAGEAGENTIMPL_H
+#define V8_INSPECTOR_V8PAGEAGENTIMPL_H
+
+#include <v8_inspector/src/inspector/protocol/Forward.h>
+#include <v8_inspector/src/inspector/protocol/Page.h>
+#include <v8_inspector/src/inspector/protocol/Protocol.h>
+#include <v8_inspector/src/inspector/v8-inspector-session-impl.h>
+
+namespace v8_inspector {
+
+class V8InspectorSessionImpl;
+
+using protocol::ErrorString;
+using v8_inspector::protocol::Maybe;
+using String = v8_inspector::String16;
+
+class V8PageAgentImpl : public protocol::Page::Backend {
+    public:
+        V8PageAgentImpl(V8InspectorSessionImpl*, protocol::FrontendChannel*,
+                        protocol::DictionaryValue* state);
+        ~V8PageAgentImpl() override;
+
+        void enable(ErrorString*) override;
+        void disable(ErrorString*) override;
+        void getResourceTree(ErrorString*, std::unique_ptr<protocol::Page::FrameResourceTree>* out_frameTree) override;
+        void getResourceContent(ErrorString*, const String& in_frameId, const String& in_url, String* out_content, bool* out_base64Encoded) override;
+        void searchInResource(ErrorString*, const String& in_frameId, const String& in_url, const String& in_query, const Maybe<bool>& in_caseSensitive, const Maybe<bool>& in_isRegex, const Maybe<String>& in_requestId, std::unique_ptr<protocol::Array<protocol::GenericTypes::SearchMatch>>* out_result) override;
+        void searchInResources(ErrorString*, const String& in_text, const Maybe<bool>& in_caseSensitive, const Maybe<bool>& in_isRegex, std::unique_ptr<protocol::Array<protocol::Page::SearchResult>>* out_result) override;
+        void addScriptToEvaluateOnLoad(ErrorString*, const String& in_scriptSource, String* out_identifier) override;
+        void removeScriptToEvaluateOnLoad(ErrorString*, const String& in_identifier) override;
+        void reload(ErrorString*, const Maybe<bool>& in_ignoreCache, const Maybe<String>& in_scriptToEvaluateOnLoad) override;
+        void navigate(ErrorString*, const String& in_url) override;
+        void getCookies(ErrorString*, std::unique_ptr<protocol::Array<protocol::Page::Cookie>>* out_cookies) override;
+        void deleteCookie(ErrorString*, const String& in_cookieName, const String& in_url) override;
+        void setDocumentContent(ErrorString*, const String& in_frameId, const String& in_html) override;
+        void setShowPaintRects(ErrorString*, bool in_result) override;
+        void getScriptExecutionStatus(ErrorString*, String* out_result) override;
+        void setScriptExecutionDisabled(ErrorString*, bool in_value) override;
+        void setTouchEmulationEnabled(ErrorString*, bool in_enabled) override;
+        void setEmulatedMedia(ErrorString*, const String& in_media) override;
+        void getCompositingBordersVisible(ErrorString*, bool* out_result) override;
+        void setCompositingBordersVisible(ErrorString*, bool in_visible) override;
+        void snapshotNode(ErrorString*, int in_nodeId, String* out_dataURL) override;
+        void snapshotRect(ErrorString*, int in_x, int in_y, int in_width, int in_height, const String& in_coordinateSystem, String* out_dataURL) override;
+        void handleJavaScriptDialog(ErrorString*, bool in_accept, const Maybe<String>& in_promptText) override;
+        void archive(ErrorString*, String* out_data) override;
+
+        void restore();
+        void reset();
+        const bool enabled() {
+            return m_enabled;
+        };
+
+    private:
+        V8InspectorSessionImpl* m_session;
+        protocol::DictionaryValue* m_state;
+        protocol::Page::Frontend m_frontend;
+        const std::string m_frameUrl;
+        const std::string m_frameIdentifier;
+        bool m_enabled;
+
+        DISALLOW_COPY_AND_ASSIGN(V8PageAgentImpl);
+};
+
+}
+
+#endif //V8_INSPECTOR_V8PAGEAGENTIMPL_H

--- a/tools/astyle.js
+++ b/tools/astyle.js
@@ -8,7 +8,7 @@ const validFiles = ['c', 'cpp', 'h', 'java'];
 // let dateString = `${date.getDay() + 1}-${date.getMonth() + 1}-${date.getFullYear()}--${date.getHours()}:${date.getMinutes()}`
 // let backupDir = `formatbackup-${dateString}`;
 
-let astyleOptions = "--style=java -H -k1 -j -C -s4 -xi -n --exclude=\"runtime/src/main/jni/include\" --exclude=\"runtime/src/main/jni/v8_inspector\"" // "--options=tools\\.astyle"
+let astyleOptions = "--style=java -H -k1 -j -C -s4 -xi -n --exclude=\"runtime/src/main/jni/include runtime/src/main/jni/v8_inspector\"" // "--options=tools\\.astyle"
 let astyle = "astyle";
 
 if (process.platform.indexOf("win") === 0) {

--- a/tools/astyle.js
+++ b/tools/astyle.js
@@ -8,7 +8,7 @@ const validFiles = ['c', 'cpp', 'h', 'java'];
 // let dateString = `${date.getDay() + 1}-${date.getMonth() + 1}-${date.getFullYear()}--${date.getHours()}:${date.getMinutes()}`
 // let backupDir = `formatbackup-${dateString}`;
 
-let astyleOptions = "--style=java -H -k1 -j -C -s4 -xi -n --exclude=\"runtime/src/main/jni/include runtime/src/main/jni/v8_inspector\"" // "--options=tools\\.astyle"
+let astyleOptions = "--style=java -H -k1 -j -C -s4 -xi -n --exclude=\"runtime/src/main/jni/include\"" // "--options=tools\\.astyle"
 let astyle = "astyle";
 
 if (process.platform.indexOf("win") === 0) {


### PR DESCRIPTION
This is a partial implementation of the Page Agent (Domain) that enables displaying of application resources like stylesheets, fonts, text documents, and images in the Source tree tab. 

Current limitations:
- JavaScript and TypeScript files that have not yet been parsed by v8 will not display in the Sources tab. Developers wishing to break in a script that is yet to be parsed should add a _`debugger`_ statement instead. (_Working as intended_)
- When a resource from the Source tab is opened, but the resource no longer exists on the device an error should be logged in the Chrome DevTools's console, but is instead regarded as a ServerError, and will not display. The resource's contents will remain blank. (_Unlikely to occur_)

Part of the https://github.com/NativeScript/android-runtime/issues/563 effort