### PR TITLE
gradle will respect productionDependencies.json file

### DIFF
--- a/build-artifacts/project-template-gradle/build.gradle
+++ b/build-artifacts/project-template-gradle/build.gradle
@@ -478,7 +478,22 @@ task pluginExtend {
 // we need to copy all dependencies into a flat dir, as pointed by the repositories configurations at the top
 task copyAarDependencies (type: Copy) {
 	println "$configStage copyAarDependencies"
-	from fileTree(dir: nodeModulesDir, include: ["**/*.aar"], exclude: '**/.bin/**').files
+
+	def productionDependencies = new File("$projectDir/productionDependencies.json")
+	def transformedArr = [];
+	if(productionDependencies.exists()) {
+		String content = productionDependencies.getText("UTF-8")
+		def jsonSlurper = new JsonSlurper()
+		def packageJsonMap = jsonSlurper.parseText(content)
+
+		packageJsonMap.each { k ->
+			transformedArr.push(k + "/**/*.aar")
+		}
+	} else {
+		transformedArr.push("**/*.aar");
+	}
+
+	from fileTree(dir: nodeModulesDir, include: transformedArr, exclude: '**/.bin/**').files
 	into "$projectDir/libs/aar"
 }
 


### PR DESCRIPTION
_Problem_: 
3.0 cli, installs platform frameworks as dev-dependencies, so gradle shouldn't traverse them. 

_Solution_: 
CLI can pass the production dependencies as a json file, that gradle respects, and doesn't traverse unnecessary node_modules packages, searching for `.aar` files. This template update, does exactly that.

related CLI PR: https://github.com/NativeScript/nativescript-cli/pull/2532