### PR TITLE
Handle exceptions when trying to use reflection for UnhandledExceptions

### DIFF
--- a/build-artifacts/project-template-gradle/src/main/java/com/tns/NativeScriptUncaughtExceptionHandler.java
+++ b/build-artifacts/project-template-gradle/src/main/java/com/tns/NativeScriptUncaughtExceptionHandler.java
@@ -44,25 +44,19 @@ public class NativeScriptUncaughtExceptionHandler implements UncaughtExceptionHa
         boolean res = false;
 
         if (Util.isDebuggableApp(context)) {
-            Class<?> ErrReport = null;
-            java.lang.reflect.Method startActivity = null;
-
             try {
+                Class<?> ErrReport = null;
+                java.lang.reflect.Method startActivity = null;
+
                 ErrReport = java.lang.Class.forName("com.tns.ErrorReport");
-            } catch (ClassNotFoundException e) {
-                android.util.Log.d("ClassNotFoundException", e.toString());
-            }
 
-            try {
                 startActivity = ErrReport.getDeclaredMethod("startActivity", android.content.Context.class, String.class);
-            } catch (NoSuchMethodException e) {
-                android.util.Log.d("NoSuchMethodException", e.toString());
-            }
 
-            try {
                 res = (Boolean) startActivity.invoke(null, context, errorMessage);
             } catch (Exception e) {
-                android.util.Log.d("Exception", e.toString());
+                android.util.Log.v("Error", errorMessage);
+                e.printStackTrace();
+                android.util.Log.v("Application Error", "ErrorActivity default implementation not found. Reinstall android platform to fix.");
             }
         }
 


### PR DESCRIPTION
The additional logic in the project template concerning Uncaught Exceptions thrown from Java is not being checked for NPE. 

In the rare and unlikely event that the ErrorReport/Activity implementations are not found in the project template's debug directory during a debug run errors will be thrown, a helpful message should be printed informing the user how to deal with the error.