### PR TITLE
Use existing context in debugger instead of creating a new one

### DIFF
--- a/runtime/src/main/jni/JsV8InspectorClient.cpp
+++ b/runtime/src/main/jni/JsV8InspectorClient.cpp
@@ -69,8 +69,11 @@ void JsV8InspectorClient::disconnect() {
 
 
 void JsV8InspectorClient::dispatchMessage(const std::string& message) {
-    this->doDispatchMessage(isolate_, message);
+    Isolate::Scope isolate_scope(isolate_);
+    v8::HandleScope handleScope(isolate_);
+    Context::Scope context_scope(isolate_->GetCurrentContext());
 
+    this->doDispatchMessage(isolate_, message);
 }
 
 void JsV8InspectorClient::runMessageLoopOnPause(int context_group_id) {
@@ -169,7 +172,7 @@ void JsV8InspectorClient::init() {
 
     v8::HandleScope handle_scope(isolate_);
 
-    v8::Local<Context> context = Context::New(isolate_);
+    v8::Local<Context> context = isolate_->GetCurrentContext();
     v8::Context::Scope context_scope(context);
 
     inspector_ = V8Inspector::create(isolate_, this);
@@ -179,7 +182,7 @@ void JsV8InspectorClient::init() {
     v8::Persistent<v8::Context> persistentContext(context->GetIsolate(), context);
     context_.Reset(isolate_, persistentContext);
 
-    this->createInspectorSession(isolate_, JsV8InspectorClient::PersistentToLocal(isolate_, context_));
+    this->createInspectorSession(isolate_, context);
 }
 
 JsV8InspectorClient* JsV8InspectorClient::GetInstance() {

--- a/runtime/src/main/jni/Runtime.cpp
+++ b/runtime/src/main/jni/Runtime.cpp
@@ -489,7 +489,9 @@ Isolate* Runtime::PrepareV8Runtime(const string& filesPath, jstring nativeLibDir
 
     __android_log_print(ANDROID_LOG_DEBUG, "TNS.Native", "V8 version %s", V8::GetVersion());
 
-    auto globalTemplate = ObjectTemplate::New();
+    auto globalFunctionTemplate = FunctionTemplate::New(isolate);
+    globalFunctionTemplate->SetClassName(ArgConverter::ConvertToV8String(isolate, "NativeScriptGlobalObject"));
+    auto globalTemplate = ObjectTemplate::New(isolate, globalFunctionTemplate);
 
     const auto readOnlyFlags = static_cast<PropertyAttribute>(PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
 


### PR DESCRIPTION
**Problem:** Debugger Runtime evaluating objects inside a pristine context and not that of the running app.

**Cause:** During initialization of the debugger the inspector client would create a new script context instead of using the one currently used by the application which resulted in unexpected behavior.

**Solution:** Pass a reference to the current V8 Context at the time of debugger initialization