### PR TITLE
Support displaying Scope variables and properties in DevTools

### DIFF
--- a/runtime/src/main/jni/v8_inspector/src/inspector/v8-debugger.cc
+++ b/runtime/src/main/jni/v8_inspector/src/inspector/v8-debugger.cc
@@ -51,7 +51,7 @@ V8Debugger::V8Debugger(v8::Isolate* isolate, V8InspectorImpl* inspector)
     : m_isolate(isolate),
       m_inspector(inspector),
 
-      m_lastContextId(-1),
+      m_lastContextId(0),
       m_enableCount(0),
       m_breakpointsActivated(true),
       m_runningNestedMessageLoop(false),
@@ -701,7 +701,6 @@ void V8Debugger::compileDebuggerScript() {
                               v8::NewStringType::kInternalized,
                               sizeof(DebuggerScript_js))
           .ToLocalChecked();
-
 
     v8::Local<v8::Value> value;
   if (!m_inspector->compileAndRunInternalScript(debuggerContext(), scriptValue)


### PR DESCRIPTION
Fixed `contextId` indexing in the debugger implementation that broke some ternary checks, and as a result the `chainScope` properties of the response to the front end client (Chrome DevTools) were always empty.

With the changes if a JavaScriptCallFrame object belongs to a context that is currently inspected its properties will be populated.