### PR TITLE
Fix console messages not displaying when app is built in debug

### DIFF
--- a/runtime/src/main/jni/JsV8InspectorClient.cpp
+++ b/runtime/src/main/jni/JsV8InspectorClient.cpp
@@ -1,9 +1,4 @@
 #include "JsV8InspectorClient.h"
-//#include "V8GlobalHelpers.h"
-//#include "ArgConverter.h"
-//#include "JniLocalRef.h"
-//#include "NativeScriptException.h"
-//#include "NativeScriptAssert.h"
 #include <sstream>
 #include <assert.h>
 #include <include/libplatform/libplatform.h>
@@ -173,13 +168,12 @@ void JsV8InspectorClient::init() {
     v8::HandleScope handle_scope(isolate_);
 
     v8::Local<Context> context = isolate_->GetCurrentContext();
-    v8::Context::Scope context_scope(context);
 
     inspector_ = V8Inspector::create(isolate_, this);
 
     inspector_->contextCreated(v8_inspector::V8ContextInfo(context, 0, v8_inspector::StringView()));
 
-    v8::Persistent<v8::Context> persistentContext(context->GetIsolate(), context);
+    v8::Persistent<v8::Context> persistentContext(context->GetIsolate(), JsV8InspectorClient::PersistentToLocal(isolate_, context_));
     context_.Reset(isolate_, persistentContext);
 
     this->createInspectorSession(isolate_, context);


### PR DESCRIPTION
**Problem:**
The changes in commit https://github.com/NativeScript/android-runtime/commit/07fec7805d21e8c9719c53f1b489cea66cb0378c broke tns-core-modules' `console` implementation, and possibly other properties attached to the global object. That was caused by incorrectly scoping the Context where all of the users' code runs. By the time that modules start being bootstrapped, and properties attached to the global object, the main JavaScript context already has a `console` object attached, and calls to any of its functions will instead call the implementation provided by the Chrome DevTools (console log messages will output in the DevTools console). All that results in no log messages showing in device logcat and the CLI.

**Resolution**:
The main JS context no longer gets overwritten when initializing the devtools debugger context, meaning core modules' console code will be invoked instead that of the devtools.