### PR TITLE
Update build-tools in template build script to 25.0.2

### DIFF
--- a/build-artifacts/project-template-gradle/build.gradle
+++ b/build-artifacts/project-template-gradle/build.gradle
@@ -73,7 +73,7 @@ def computeBuildToolsVersion() {
 		return buildToolsVersion
 	}
 	else {
-		return "23.0.3"
+		return "25.0.2"
 	}
 }
 project.ext.selectedBuildType = project.hasProperty("release") ? "release" : "debug"


### PR DESCRIPTION
Update build-tools in template build.gradle script to 25.0.2 as per the minimal Android SDK build tools requirements for building Android applications with NativeScript.

For reference: [System Requirements](https://docs.nativescript.org/start/ns-setup-win#system-requirements)

To update/install a specific build-tools version start the android SDK manager located in `%ANDROID_HOME%/tools/` and check the corresponding item from the `Tools` section