### PR TITLE
Update build-tools in runtime build scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ android:
   components:
   - platform-tools
   - tools
-  - build-tools-23.0.3
+  - build-tools-25.0.2
   - android-23
   - extra-android-support
   - extra-android-m2repository

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The source in this repo is organized in Android Studio projects.
 * Install Android API Level 22 from Android Studio -> Tools -> Android -> SDK Manager
 * Install the Android NDK from Android Studio -> Tools -> Android -> SDK Manager
 * Download Android Support Repository through the Android SDK Manager
-* Download Build Tools 22 through the Android SDK Manager.
+* Download Build Tools 25.0.2 through the Android SDK Manager.
 
 # How to build
 

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -192,7 +192,7 @@ if (!ndkDebuggable)
 }
 
 
-project.ext._buildToolsVersion = "23.0.3"
+project.ext._buildToolsVersion = "25.0.2"
 
 model {
     android {

--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -16,7 +16,7 @@ def runOnDeviceOrEmulator = runOnDevice ? "-d" : "-e";
 model {
     android {
         compileSdkVersion = 23
-        buildToolsVersion = "23.0.3"
+        buildToolsVersion = "25.0.2"
 
         defaultConfig.with {
             applicationId = "com.tns.android_runtime_testapp"


### PR DESCRIPTION
Updated build-tools requirement to `25.0.2` up from the previous `23.0.3` for the `runtime` and `android_testapp` Android Studio projects.