### PR TITLE
Use Java to search recursively for the *.aar files

### DIFF
--- a/build-artifacts/project-template-gradle/build.gradle
+++ b/build-artifacts/project-template-gradle/build.gradle
@@ -19,6 +19,11 @@
 */
 
 import groovy.json.JsonSlurper //used to parse package.json
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.regex.Pattern;
+
 buildscript {
     repositories {
         jcenter()
@@ -477,9 +482,27 @@ task pluginExtend {
 
 // we need to copy all dependencies into a flat dir, as pointed by the repositories configurations at the top
 task copyAarDependencies (type: Copy) {
-	println "$configStage copyAarDependencies"
-	from fileTree(dir: nodeModulesDir, include: ["**/*.aar"], exclude: '**/.bin/**').files
+	def filterAarFilesFn = { path, attrs ->
+		String pathString = path.toString();
+		def isBin = Pattern.matches(".*/\\.bin/.*", pathString);
+		def isAar =  Pattern.matches(".*\\.aar\$", pathString);
+		return !isBin && isAar;
+	}
+
+	def mapToStringFn = { path ->
+		return path.toString();
+	}
+
+	Object[] files = Files.find(
+				Paths.get("$nodeModulesDir"),
+				Integer.MAX_VALUE,
+				filterAarFilesFn
+			)
+			.map(mapToStringFn)
+			.toArray();
+
 	into "$projectDir/libs/aar"
+	from files
 }
 
 task addAarDependencies {


### PR DESCRIPTION
Use Java to Traverse all files from the directory, as fileTree cannot fail when there are broken symoblic links in the directory being traversed.

See more here: https://issues.gradle.org/browse/GRADLE-1843