### PR TITLE
metadata-generator: Fix missing interface static fields in implementing class when the interface extends another interface

### DIFF
--- a/android-metadata-generator/src/src/com/telerik/metadata/Builder.java
+++ b/android-metadata-generator/src/src/com/telerik/metadata/Builder.java
@@ -220,6 +220,9 @@ public class Builder {
                 if (interfaceClass != null) {
                     fields = interfaceClass.getFields();
 
+                    // If the interface iteself extends other interfaces - add their fields too
+                    getFieldsFromImplementedInterfaces(interfaceClass, node, root, fields);
+
                     //if interface and implementing class declare the same static field name the class take precedence
                     if (originalClassFields.size() > 0) {
                         for (FieldDescriptor f : fields) {


### PR DESCRIPTION
When generating metadata for a class which implements interfaces, add fields interfaces extended by these interfaces. 
Fixes #726 .