### PR TITLE
relative search starts from project directory

### DIFF
--- a/build-artifacts/project-template-gradle/build.gradle
+++ b/build-artifacts/project-template-gradle/build.gradle
@@ -494,7 +494,7 @@ task copyAarDependencies (type: Copy) {
 	}
 
 	Object[] files = Files.find(
-				Paths.get("$nodeModulesDir"),
+				Paths.get("$projectDir", "$nodeModulesDir"),
 				Integer.MAX_VALUE,
 				filterAarFilesFn
 			)


### PR DESCRIPTION
_Problem_
Windows machines fail to construct the correct path

_Solution_
Always start relative search from the native project location.

Related issue: https://github.com/NativeScript/android-runtime/issues/733