### PR TITLE
respect abi versions when such are provided in configuration

### DIFF
--- a/build-artifacts/project-template-gradle/build.gradle
+++ b/build-artifacts/project-template-gradle/build.gradle
@@ -87,7 +87,11 @@ def renameResultApks (variant) {
 	def name
 	variant.outputs.each { output ->
 		def apkDirectory = output.packageApplication.outputFile.parentFile
-		def apkNamePrefix = rootProject.name + "-" + variant.buildType.name
+		def abiName = "";
+		if(output.getFilter(com.android.build.OutputFile.ABI)) {
+			abiName = "-" + output.getFilter(com.android.build.OutputFile.ABI);
+		}
+		def apkNamePrefix = rootProject.name + "-" + variant.buildType.name + abiName
 		name = apkNamePrefix + ".apk"
 		output.packageApplication.outputFile = new File(apkDirectory, name);
 	}    


### PR DESCRIPTION
_problem_
previously when abi split is used in the gradle configuration, it's not respected in the resulting apk.

_solution_
when abi split is provided in the gradle configuration, it's respected when naming the resulting apk files. 
example for using split:
in folder `<app_name>/app/App_Resources/Android/app.gradle` add:
```
android {  
.....
    splits {
        abi {
            enable true //enables the ABIs split mechanism
            reset() //reset the list of ABIs to be included to an empty string
            include 'armeabi-v7a', 'x86' //what abi to spliy by
            universalApk false //don't include an apk that uses all abis combined
        }
    }
}
```
The file name convention is: 
`[project-name]-[build_type]-[abi].apk` and the resulting apk file in `<app_name>/platforms/android/build/outputs/apk` would be: testapp-debug-x86.apk


