### PR TITLE
Force delete temporary livesync dir after syncing .xml or .css files

### DIFF
--- a/build-artifacts/project-template-gradle/src/main/java/com/tns/NativeScriptSyncService.java
+++ b/build-artifacts/project-template-gradle/src/main/java/com/tns/NativeScriptSyncService.java
@@ -128,7 +128,11 @@ public class NativeScriptSyncService {
                 int length = input.readInt();
                 input.readFully(new byte[length]); // ignore the payload
                 executePartialSync(context, syncDir);
+                // delete temporary /sync dir after syncing .xml/.css resources
+                deleteRecursive(syncDir);
                 executeRemovedSync(context, removedSyncDir);
+                // delete temporary /removedsync dir after removing files from the project
+                deleteRecursive(removedSyncDir);
 
                 runtime.runScript(new File(NativeScriptSyncService.this.context.getFilesDir(), "internal/livesync.js"));
                 try {
@@ -157,7 +161,11 @@ public class NativeScriptSyncService {
             }
         }
 
-        fileOrDirectory.delete();
+        boolean success = fileOrDirectory.delete();
+
+        if (!success && fileOrDirectory.isDirectory()) {
+            android.util.Log.d("Sync", "Failed to delete temp sync directory: " + fileOrDirectory.getAbsolutePath());
+        }
     }
 
     public static boolean isSyncEnabled(Context context) {

--- a/test-app/app/src/main/java/com/tns/NativeScriptSyncService.java
+++ b/test-app/app/src/main/java/com/tns/NativeScriptSyncService.java
@@ -128,7 +128,11 @@ public class NativeScriptSyncService {
                 int length = input.readInt();
                 input.readFully(new byte[length]); // ignore the payload
                 executePartialSync(context, syncDir);
+                // delete temporary /sync dir after syncing .xml/.css resources
+                deleteRecursive(syncDir);
                 executeRemovedSync(context, removedSyncDir);
+                // delete temporary /removedsync dir after removing files from the project
+                deleteRecursive(removedSyncDir);
 
                 runtime.runScript(new File(NativeScriptSyncService.this.context.getFilesDir(), "internal/livesync.js"));
                 try {
@@ -157,7 +161,11 @@ public class NativeScriptSyncService {
             }
         }
 
-        fileOrDirectory.delete();
+        boolean success = fileOrDirectory.delete();
+
+        if (!success && fileOrDirectory.isDirectory()) {
+            android.util.Log.d("Sync", "Failed to delete temp sync directory: " + fileOrDirectory.getAbsolutePath());
+        }
     }
 
     public static boolean isSyncEnabled(Context context) {


### PR DESCRIPTION
The NativeScriptLiveSyncService, part of the android project template, deletes temporary sync directories when app is first fired up, but would not be removed if xml or css files were synced. This could at times cause applications installed manually to appear with stale views and resources.

Also include debug log feedback if a folder fails to be removed for more easily diagnosing potential issues that may arise when synchronizing files.

Partially addresses https://github.com/NativeScript/android-runtime/issues/591