### PR TITLE
Fix #720 GC issue - No weak ref found

### DIFF
--- a/runtime/src/main/jni/ObjectManager.h
+++ b/runtime/src/main/jni/ObjectManager.h
@@ -49,11 +49,14 @@ class ObjectManager {
 
         v8::Local<v8::Object> GetEmptyObject(v8::Isolate* isolate);
 
+        static void MarkReachableArrayElements(v8::Local<v8::Object> &o, std::stack<v8::Local<v8::Value>> &s);
+
         enum class MetadataNodeKeys {
             JsInfo,
             CallSuper,
             END
         };
+
 
     private:
 

--- a/test-app/app/src/main/assets/app/tests/testGC.js
+++ b/test-app/app/src/main/assets/app/tests/testGC.js
@@ -264,6 +264,29 @@ describe("Tests garbage collection", function () {
 		gc();
 		java.lang.System.gc();
 	});
+
+	it("should keep array-enclosed objects alive after GC", function () {
+        function createObjects(name) {
+            var arr = new Array();
+            arr.push(new com.tns.tests.Class1());
+
+            var cb1 = new com.tns.tests.Class1.Callback1(name, {
+                getMessage: function() {
+                    var msg = arr[0].getMessage();
+                    return msg;
+                }
+            });
+
+            return com.tns.tests.Class1.Class2.printMessageWithDelay(cb1, 2 * 1000);
+        }
+
+        expect(createObjects("Callback1")).toBe(true);
+        expect(createObjects("Callback2")).toBe(true);
+        expect(createObjects("Callback3")).toBe(true);
+
+        gc();
+        java.lang.System.gc();
+    })
 	
 	it("should properly reintroduce Java object back in a callback", function () {
 		function getTestObject() {


### PR DESCRIPTION
The proposed changes address the problem described in issue #720 - having the GC trigger during navigation can sometimes collect children of composite views, before recursively iterating over said children. That could happen if real Java objects were considered unreachable, while their JS counterparts were still accessible as elements of view's children (js array) property, or vice versa. (Best explained in mslavcher's blog - https://iobservable.net/blog/2014/06/07/synchronizing-gc-in-java-and-v8/)

As an additional step now, during GC, array objects marked for collection will be iterated over to check whether references are reachable in JavaScript, in which case their Java proxies shouldn't be released.

**Implementation considerations**: Depending on the application, this modification can impose a slight performance hit where huge arrays are used inside implementation objects (extending classes and implementing interfaces)