### PR TITLE
Add follow-links to the Files.find

### DIFF
--- a/build-artifacts/project-template-gradle/build.gradle
+++ b/build-artifacts/project-template-gradle/build.gradle
@@ -500,7 +500,8 @@ task copyAarDependencies (type: Copy) {
 	Object[] files = Files.find(
 				Paths.get("$projectDir", "$nodeModulesDir"),
 				Integer.MAX_VALUE,
-				filterAarFilesFn
+				filterAarFilesFn,
+				java.nio.file.FileVisitOption.FOLLOW_LINKS
 			)
 			.map(mapToStringFn)
 			.toArray();


### PR DESCRIPTION
Add follow links attribute to the Files.find method when searching for .aar dependencies.