### PR TITLE
Fix SBG (#753) and string replacement

### DIFF
--- a/android-static-binding-generator/project/staticbindinggenerator/src/main/java/org/nativescript/staticbindinggenerator/Generator.java
+++ b/android-static-binding-generator/project/staticbindinggenerator/src/main/java/org/nativescript/staticbindinggenerator/Generator.java
@@ -9,6 +9,7 @@ import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -141,6 +142,9 @@ public class Generator {
             String classname = dataRow.getBaseClassname();
             boolean isJavaExtend = classes.containsKey(classname);
             if (isJavaExtend) {
+
+//                System.out.println("SBG: DataRow: baseClassName: " + classname + ", suffix: " + dataRow.getSuffix() + ", interfaces: " + String.join(", ", Arrays.asList(dataRow.getInterfaces())) + ", jsFileName: " + dataRow.getJsFilename());
+
                 Binding binding = generateBinding(dataRow, interfaceNames);
 
                 if (binding != null) {
@@ -193,6 +197,9 @@ public class Generator {
             for (Method m : currentClass.getMethods()) {
                 methods.add(m);
             }
+
+//            System.out.println("SBG: getPublicApi:collectInterfaceMethods classname: " + currentClassname);
+
             collectInterfaceMethods(clazz, methods);
             for (Method m : methods) {
                 if (!m.isSynthetic() && (m.isPublic() || m.isProtected()) && !m.isStatic()) {
@@ -222,7 +229,8 @@ public class Generator {
             if (currentClassname.equals("java.lang.Object")) {
                 break;
             } else {
-                currentClass = classes.get(currentClass.getSuperclassName());
+                String superClassName = currentClass.getSuperclassName();
+                currentClass = classes.get(superClassName.replace('$', '.'));
             }
         }
         return api;
@@ -640,7 +648,14 @@ public class Generator {
 
     private void collectInterfaceMethods(JavaClass clazz, List<Method> methods) {
         JavaClass currentClass = clazz;
+
         while (true) {
+            if (currentClass == null) {
+                System.out.println("Contains android.support.v7.widget.RecyclerView$Adapter: " + classes.keySet().contains("android.support.v7.widget.RecyclerView$Adapter"));
+
+                System.out.println("Contains android.support.v7.widget.RecyclerView.Adapter: " + classes.keySet().contains("android.support.v7.widget.RecyclerView.Adapter"));
+            }
+
             String currentClassname = currentClass.getClassName();
 
             Queue<String> queue = new ArrayDeque<String>();
@@ -663,7 +678,8 @@ public class Generator {
             if (currentClassname.equals("java.lang.Object")) {
                 break;
             } else {
-                currentClass = classes.get(currentClass.getSuperclassName());
+                String superClassName = currentClass.getSuperclassName();
+                currentClass = classes.get(superClassName.replace('$', '.'));
             }
         }
     }
@@ -686,7 +702,8 @@ public class Generator {
                 break;
             }
 
-            currentClass = classes.get(currentClass.getSuperclassName());
+            String superClassName = currentClass.getSuperclassName();
+            currentClass = classes.get(superClassName.replace('$', '.'));
         }
 
         return isApplicationClass;

--- a/android-static-binding-generator/project/staticbindinggenerator/src/test/java/com/example/ListView.java
+++ b/android-static-binding-generator/project/staticbindinggenerator/src/test/java/com/example/ListView.java
@@ -1,0 +1,11 @@
+package com.example;
+
+/**
+ * Created by pkanev on 4/27/2017.
+ */
+
+public class ListView extends View {
+    public ListView createView() {
+        return new ListView();
+    }
+}

--- a/android-static-binding-generator/project/staticbindinggenerator/src/test/java/com/example/View.java
+++ b/android-static-binding-generator/project/staticbindinggenerator/src/test/java/com/example/View.java
@@ -1,0 +1,11 @@
+package com.example;
+
+/**
+ * Created by pkanev on 4/27/2017.
+ */
+
+public abstract class View {
+    public View createView() {
+        return null;
+    }
+}

--- a/android-static-binding-generator/project/staticbindinggenerator/src/test/java/org/nativescript/staticbindinggenerator/test/GeneratorTest.java
+++ b/android-static-binding-generator/project/staticbindinggenerator/src/test/java/org/nativescript/staticbindinggenerator/test/GeneratorTest.java
@@ -1,5 +1,6 @@
 package org.nativescript.staticbindinggenerator.test;
 
+import com.example.ListView;
 import com.example.MyInterface;
 
 import org.apache.commons.io.IOUtils;
@@ -102,5 +103,30 @@ public class GeneratorTest {
 
         Assert.assertNotNull(ComplexClass);
         Assert.assertEquals(5, ComplexClass.getInterfaces().length); // 4 + 1 (hashcodeprovider)
+    }
+
+    @Test
+    public void testCanCompileBindingClassExtendingAnExtendedClassWithMethodsWithTheSameSignature() throws Exception {
+        URL u = ListView.class.getResource('/' + ListView.class.getName().replace('.', '/') + ".class");
+        File f = new File(u.toURI()).getParentFile().getParentFile().getParentFile();
+
+        String dataRowString = "com.example.ListView*_fapp_l9_c29__*createView*com.example.MyListView**";
+        DataRow dataRow = new DataRow(dataRowString);
+
+        System.out.println(dataRowString);
+
+        String outputDir = null;
+        String[] libs = {runtimePath, f.getAbsolutePath()};
+        Generator generator = new Generator(outputDir, libs);
+        Binding binding = generator.generateBinding(dataRow);
+
+        StringBuffer sourceCode = new StringBuffer();
+        sourceCode.append(binding.getContent());
+
+        Iterable<String> options = new ArrayList<String>(Arrays.asList("-cp", dependenciesDir));
+        Class<?> ComplexClass = InMemoryJavaCompiler.compile(binding.getClassname(), sourceCode.toString(), options);
+
+        Assert.assertNotNull(ComplexClass);
+        Assert.assertEquals(4, ComplexClass.getDeclaredMethods().length); // 1 + constructor + (equals + hashcode)
     }
 }

--- a/android-static-binding-generator/project/staticbindinggenerator/src/test/resources/org/nativescript/staticbindinggenerator/test/datarow-extend-class-with-same-method-signature.txt
+++ b/android-static-binding-generator/project/staticbindinggenerator/src/test/resources/org/nativescript/staticbindinggenerator/test/datarow-extend-class-with-same-method-signature.txt
@@ -1,0 +1,1 @@
+"com.example.ListView*_fapp_l9_c29__*createView*com.example.MyListView**"


### PR DESCRIPTION
### Problem:
Described in https://github.com/NativeScript/android-runtime/issues/753

### Proposed solution:
Don't generate abstract parent class's methods to avoid compilation issues where a child class has 2 methods, of the same type, with just a return type/parameter type that differs by being of a superclass of the class being extended. 

Test included in the PR.