### PR TITLE
Add high resolution, low overhead __time

### DIFF
--- a/runtime/src/main/jni/CallbackHandlers.cpp
+++ b/runtime/src/main/jni/CallbackHandlers.cpp
@@ -13,6 +13,7 @@
 #include <sstream>
 #include <fstream>
 #include <cstdio>
+#include <chrono>
 #include "MethodCache.h"
 #include "SimpleProfiler.h"
 #include "Runtime.h"
@@ -629,6 +630,12 @@ void CallbackHandlers::LogMethodCallback(const v8::FunctionCallbackInfo<v8::Valu
         NativeScriptException nsEx(std::string("Error: c++ exception!"));
         nsEx.ReThrowToV8();
     }
+}
+
+void CallbackHandlers::TimeCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
+    auto nano = std::chrono::time_point_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now());
+    double duration = nano.time_since_epoch().count() / 1000000.0;
+    args.GetReturnValue().Set(duration);
 }
 
 void CallbackHandlers::DumpReferenceTablesMethodCallback(

--- a/runtime/src/main/jni/CallbackHandlers.h
+++ b/runtime/src/main/jni/CallbackHandlers.h
@@ -56,6 +56,8 @@ class CallbackHandlers {
 
         static void LogMethodCallback(const v8::FunctionCallbackInfo<v8::Value>& args);
 
+        static void TimeCallback(const v8::FunctionCallbackInfo<v8::Value>& args);
+
         static void DumpReferenceTablesMethodCallback(const v8::FunctionCallbackInfo<v8::Value>& args);
 
         static void DumpReferenceTablesMethod();

--- a/runtime/src/main/jni/Runtime.cpp
+++ b/runtime/src/main/jni/Runtime.cpp
@@ -504,6 +504,7 @@ Isolate* Runtime::PrepareV8Runtime(const string& filesPath, const string& native
     globalTemplate->Set(ArgConverter::ConvertToV8String(isolate, "__disableVerboseLogging"), FunctionTemplate::New(isolate, CallbackHandlers::DisableVerboseLoggingMethodCallback));
     globalTemplate->Set(ArgConverter::ConvertToV8String(isolate, "__exit"), FunctionTemplate::New(isolate, CallbackHandlers::ExitMethodCallback));
     globalTemplate->Set(ArgConverter::ConvertToV8String(isolate, "__runtimeVersion"), ArgConverter::ConvertToV8String(isolate, NATIVE_SCRIPT_RUNTIME_VERSION), readOnlyFlags);
+    globalTemplate->Set(ArgConverter::ConvertToV8String(isolate, "__time"), FunctionTemplate::New(isolate, CallbackHandlers::TimeCallback));
 
     /*
      * Attach `Worker` object constructor only to the main thread (isolate)'s global object

--- a/test-app/app/src/main/assets/app/mainpage.js
+++ b/test-app/app/src/main/assets/app/mainpage.js
@@ -45,3 +45,4 @@ require("./tests/field-access-test");
 require("./tests/byte-buffer-test");
 require("./tests/dex-interface-implementation");
 require("./tests/testInterfaceImplementation");
+require("./tests/testRuntimeImplementedAPIs");

--- a/test-app/app/src/main/assets/app/tests/testRuntimeImplementedAPIs.js
+++ b/test-app/app/src/main/assets/app/tests/testRuntimeImplementedAPIs.js
@@ -1,0 +1,18 @@
+describe("Runtime exposes", function () {
+  it("__time a low overhead, high resolution, time in ms.", function() {
+    var dateTimeStart = Date.now();
+    var timeStart = __time();
+    var acc = 0;
+    var s = android.os.SystemClock.elapsedRealtime();
+    for (var i = 0; i < 1000; i++) {
+      var c = android.os.SystemClock.elapsedRealtime();
+      acc += (c - s);
+      s = c;
+    }
+    var dateTimeEnd = Date.now();
+    var timeEnd = __time();
+    var dateDelta = dateTimeEnd - dateTimeStart;
+    var timeDelta = timeEnd - timeStart;
+    expect(Math.abs(dateDelta - timeDelta) < dateDelta * 0.25).toBe(true);
+  });
+});


### PR DESCRIPTION
We plan to apply some manual instrumentation in the modules, Date.now() truncates the times to milliseconds and fast chatty calls can't be tracked well. We need something similar to `performance.now()`. This PR adds `__time()` function on the global object that returns time since 1840 in milliseconds but countrary to Date.now() has fraction part, it is more accurate and faster.

For example on real LG phone:
```
    var time1 = __time();
    var time2 = __time();
    var time3 = __time();
    android.util.Log.v("JS", "TIMES: " + time1 + " " + time2 + " " + time3);
```
yelds:
`TIMES: 1494935989526.983 1494935989526.9854 1494935989526.9866`