### PR TITLE
Implement debug-brk functionality support

### DIFF
--- a/runtime/src/main/jni/JsV8InspectorClient.cpp
+++ b/runtime/src/main/jni/JsV8InspectorClient.cpp
@@ -43,6 +43,13 @@ void JsV8InspectorClient::connect(jobject connection) {
     this->isConnected = true;
 }
 
+void JsV8InspectorClient::scheduleBreak() {
+    Isolate::Scope isolate_scope(isolate_);
+    v8::HandleScope handleScope(isolate_);
+
+    this->session_->schedulePauseOnNextStatement(v8_inspector::StringView(), v8_inspector::StringView());
+}
+
 void JsV8InspectorClient::createInspectorSession(v8::Isolate* isolate, const v8::Local<v8::Context>& context) {
     session_ = inspector_->connect(0, this, v8_inspector::StringView());
 }

--- a/runtime/src/main/jni/JsV8InspectorClient.h
+++ b/runtime/src/main/jni/JsV8InspectorClient.h
@@ -23,6 +23,7 @@ class JsV8InspectorClient : V8InspectorClient, v8_inspector::V8Inspector::Channe
 
         void init();
         void connect(jobject connection);
+        void scheduleBreak();
         void createInspectorSession(v8::Isolate* isolate, const v8::Local<v8::Context>& context);
         void disconnect();
         void dispatchMessage(const std::string& message);

--- a/runtime/src/main/jni/com_tns_AndroidJsV8Inspector.cpp
+++ b/runtime/src/main/jni/com_tns_AndroidJsV8Inspector.cpp
@@ -15,6 +15,10 @@ JNIEXPORT extern "C" void Java_com_tns_AndroidJsV8Inspector_connect(JNIEnv* env,
     JsV8InspectorClient::GetInstance()->connect(connection);
 }
 
+JNIEXPORT extern "C" void Java_com_tns_AndroidJsV8Inspector_scheduleBreak(JNIEnv* env, jobject instance) {
+    JsV8InspectorClient::GetInstance()->scheduleBreak();
+}
+
 JNIEXPORT extern "C" void Java_com_tns_AndroidJsV8Inspector_disconnect(JNIEnv* env, jobject instance) {
     JsV8InspectorClient::GetInstance()->disconnect();
 }

--- a/test-app/app/src/main/java/com/tns/RuntimeHelper.java
+++ b/test-app/app/src/main/java/com/tns/RuntimeHelper.java
@@ -132,17 +132,32 @@ public final class RuntimeHelper {
             runtime = Runtime.initializeRuntimeWithConfiguration(config);
             if (isDebuggable) {
                 try {
-                    v8Inspector = new AndroidJsV8Inspector(app, logger);
+                    v8Inspector = new AndroidJsV8Inspector(app.getFilesDir().getAbsolutePath(), app.getPackageName());
                     v8Inspector.start();
 
                     // the following snippet is used as means to notify the VSCode extension
                     // debugger that the debugger agent has started
-                    File debugBreakFile = new File("/data/local/tmp", app.getPackageName() + "-debugger-started");
+                    File debuggerStartedFile = new File("/data/local/tmp", app.getPackageName() + "-debugger-started");
+                    if (debuggerStartedFile.exists() && !debuggerStartedFile.isDirectory() && debuggerStartedFile.length() == 0) {
+                        java.io.FileWriter fileWriter = new java.io.FileWriter(debuggerStartedFile);
+                        fileWriter.write("started");
+                        fileWriter.close();
+                    }
+
+                    // check if --debug-brk flag has been set. If positive:
+                    // write to the file to invalidate the flag
+                    // inform the v8Inspector to pause the main thread
+                    File debugBreakFile = new File("/data/local/tmp", app.getPackageName() + "-debugbreak");
+                    boolean shouldBreak = false;
                     if (debugBreakFile.exists() && !debugBreakFile.isDirectory() && debugBreakFile.length() == 0) {
                         java.io.FileWriter fileWriter = new java.io.FileWriter(debugBreakFile);
                         fileWriter.write("started");
                         fileWriter.close();
+
+                        shouldBreak = true;
                     }
+
+                    v8Inspector.waitForDebugger(shouldBreak);
                 } catch (IOException e) {
                     e.printStackTrace();
                 }


### PR DESCRIPTION
Implement debug-brk support by reading a flag on app startup (in a debuggable application). If the check passes the app will be paused until the frontend DevTools client connects (opening the `chrome-devtools://devtools/bundled/inspector.html?experiments=true&ws=localhost:PORT` link in Chrome), or for as long as 30 seconds, after which the application will continue execution.

Addresses https://github.com/NativeScript/nativescript-cli/issues/2741