### PR TITLE
Slight refactoring of the static binding generator

### DIFF
--- a/android-static-binding-generator/project/staticbindinggenerator/src/main/java/org/nativescript/staticbindinggenerator/Main.java
+++ b/android-static-binding-generator/project/staticbindinggenerator/src/main/java/org/nativescript/staticbindinggenerator/Main.java
@@ -4,14 +4,14 @@ import java.io.IOException;
 import java.util.Arrays;
 
 public class Main {
-    public static void main(String[] args) throws IOException {
-            if (args.length < 3) {
-                throw new IllegalArgumentException("Expects at least three arguments");
-            }
-            String inputBindingFilename = args[0];
-            String outputDir = args[1];
-            String[] libs = Arrays.copyOfRange(args, 2, args.length);
+    public static void main(String[] args) throws IOException, ClassNotFoundException {
+        if (args.length < 3) {
+            throw new IllegalArgumentException("Expects at least three arguments");
+        }
+        String inputBindingFilename = args[0];
+        String outputDir = args[1];
+        String[] libs = Arrays.copyOfRange(args, 2, args.length);
 
-            new Generator(outputDir, libs).writeBindings(inputBindingFilename);
+        new Generator(outputDir, libs).writeBindings(inputBindingFilename);
     }
 }


### PR DESCRIPTION
Throw exception with the missing class name when a class is null. - ideally this will make troubleshooting build errors easier.

Do a class string character replacement (`$` -> `.`) in a method to avoid inconsistencies.
