### PR TITLE
Use HashSet for duplication detection

### DIFF
--- a/android-static-binding-generator/project/staticbindinggenerator/src/main/java/org/nativescript/staticbindinggenerator/Generator.java
+++ b/android-static-binding-generator/project/staticbindinggenerator/src/main/java/org/nativescript/staticbindinggenerator/Generator.java
@@ -48,10 +48,9 @@ public class Generator {
 
     public void writeBindings(String filename) throws IOException, ClassNotFoundException {
         Binding[] bindings = generateBindings(filename);
-        List<File> writenFiles = new ArrayList<File>();
+        Set<File> writtenFiles = new HashSet<File>();
         for (Binding b : bindings) {
-            if (!writenFiles.contains(b.getFile())) {
-                writenFiles.add(b.getFile());
+            if (writtenFiles.add(b.getFile())) {
                 try (PrintStream ps = new PrintStream(b.getFile())) {
                     ps.append(b.getContent());
                 }


### PR DESCRIPTION
### Description
The duplication detection is now amortized O(n) instead of O(n^2).

### Does your commit message include the wording below to reference a specific issue in this repo?
<!--Fixes/Implements #[Issue Number]. -->
No issue opened for this trivial change.

### Related Pull Requests
<!-- List links related to this Pull Request from other repos/branches: -->
Blame #693 for the crap implementation.

### Does your pull request have [unit tests](https://github.com/NativeScript/NativeScript/blob/master/running-tests.md)?
<!--If not, why?
If not, please tell us why tests are not included, and list all steps needed to test your pull request manually. -->
This is a performance fix and thus cannot be unit tested.

