### PR TITLE
Fix asset extraction

### DIFF
--- a/build-artifacts/project-template-gradle/src/main/java/com/tns/RuntimeHelper.java
+++ b/build-artifacts/project-template-gradle/src/main/java/com/tns/RuntimeHelper.java
@@ -85,11 +85,13 @@ public final class RuntimeHelper {
 
                 String outputDir = app.getFilesDir().getPath() + File.separator;
 
-                aE.extractAssets(app, "app", outputDir, extractPolicy);
-                aE.extractAssets(app, "internal", outputDir, extractPolicy);
-                aE.extractAssets(app, "metadata", outputDir, extractPolicy);
+                // will force deletion of previously extracted files in app/files directories
+                // see https://github.com/NativeScript/NativeScript/issues/4137 for reference
+                boolean removePreviouslyInstalledAssets = true;
+                aE.extractAssets(app, "app", outputDir, extractPolicy, removePreviouslyInstalledAssets);
+                aE.extractAssets(app, "internal", outputDir, extractPolicy, removePreviouslyInstalledAssets);
+                aE.extractAssets(app, "metadata", outputDir, extractPolicy, false);
 
-                // enable with flags?
                 boolean shouldExtractSnapshots = true;
 
                 // will extract snapshot of the device appropriate architecture
@@ -98,7 +100,7 @@ public final class RuntimeHelper {
                         logger.write("Extracting snapshot blob");
                     }
 
-                    aE.extractAssets(app, "snapshots/" + Build.CPU_ABI, outputDir, extractPolicy);
+                    aE.extractAssets(app, "snapshots/" + Build.CPU_ABI, outputDir, extractPolicy, removePreviouslyInstalledAssets);
                 }
 
                 extractPolicy.setAssetsThumb(app);

--- a/test-app/app/src/main/java/com/tns/DefaultExtractPolicy.java
+++ b/test-app/app/src/main/java/com/tns/DefaultExtractPolicy.java
@@ -29,7 +29,7 @@ public class DefaultExtractPolicy implements ExtractPolicy {
     }
 
     public boolean shouldExtract(Context context) {
-        String assetsThumbFilePath = context.getFilesDir().getPath() + File.separatorChar + ASSETS_THUMB_FILENAME;
+        String assetsThumbFilePath = getFilesDir(context) + File.separatorChar + ASSETS_THUMB_FILENAME;
         String oldAssetsThumb = getCachedAssetsThumb(assetsThumbFilePath);
         if (oldAssetsThumb == null) {
             return true;
@@ -47,7 +47,7 @@ public class DefaultExtractPolicy implements ExtractPolicy {
     public void setAssetsThumb(Context context) {
         String assetsThumb = generateAssetsThumb(context);
         if (assetsThumb != null) {
-            String assetsThumbFilePath = context.getFilesDir().getPath() + File.separatorChar + ASSETS_THUMB_FILENAME;
+            String assetsThumbFilePath = getFilesDir(context) + File.separatorChar + ASSETS_THUMB_FILENAME;
             saveNewAssetsThumb(assetsThumb, assetsThumbFilePath);
         }
     }
@@ -114,11 +114,25 @@ public class DefaultExtractPolicy implements ExtractPolicy {
                 out.close();
             }
         } catch (FileNotFoundException e) {
-            logger.write("Error while writting current assets thumb");
+            logger.write("Error while writing current assets thumb");
             e.printStackTrace();
         } catch (IOException e) {
-            logger.write("Error while writting current assets thumb");
+            logger.write("Error while writing current assets thumb");
             e.printStackTrace();
+        }
+    }
+
+    /*
+        Write assetsThumb file to a no-backup directory to prevent the thumb from being
+        backed up on devices of API Level 23 and up.
+        Devices Level 22 and lower don't support the Auto Backup feature,
+        so it is safe to keep the thumb in the /files directory
+     */
+    private static String getFilesDir(Context context) {
+        if (android.os.Build.VERSION.SDK_INT >= /* 21 */ android.os.Build.VERSION_CODES.LOLLIPOP) {
+            return context.getNoBackupFilesDir().getPath();
+        } else {
+            return context.getFilesDir().getPath();
         }
     }
 

--- a/test-app/app/src/main/java/com/tns/RuntimeHelper.java
+++ b/test-app/app/src/main/java/com/tns/RuntimeHelper.java
@@ -85,11 +85,13 @@ public final class RuntimeHelper {
 
                 String outputDir = app.getFilesDir().getPath() + File.separator;
 
-                aE.extractAssets(app, "app", outputDir, extractPolicy);
-                aE.extractAssets(app, "internal", outputDir, extractPolicy);
-                aE.extractAssets(app, "metadata", outputDir, extractPolicy);
+                // will force deletion of previously extracted files in app/files directories
+                // see https://github.com/NativeScript/NativeScript/issues/4137 for reference
+                boolean removePreviouslyInstalledAssets = true;
+                aE.extractAssets(app, "app", outputDir, extractPolicy, removePreviouslyInstalledAssets);
+                aE.extractAssets(app, "internal", outputDir, extractPolicy, removePreviouslyInstalledAssets);
+                aE.extractAssets(app, "metadata", outputDir, extractPolicy, false);
 
-                // enable with flags?
                 boolean shouldExtractSnapshots = true;
 
                 // will extract snapshot of the device appropriate architecture
@@ -98,7 +100,7 @@ public final class RuntimeHelper {
                         logger.write("Extracting snapshot blob");
                     }
 
-                    aE.extractAssets(app, "snapshots/" + Build.CPU_ABI, outputDir, extractPolicy);
+                    aE.extractAssets(app, "snapshots/" + Build.CPU_ABI, outputDir, extractPolicy, removePreviouslyInstalledAssets);
                 }
 
                 extractPolicy.setAssetsThumb(app);


### PR DESCRIPTION
Add additional logic to asset extraction so that whenever a new version of the application is pushed to the device, at startup the old assets will be wiped out and replaced with those of the new application package. 

This will also prevent Android's [Auto Backup ](https://developer.android.com/guide/topics/data/autobackup.html) feature (Android devices level 23 and up) from messing up the application with previously cached scripts, as the changes restored will be removed by the asset extraction mechanism in the runtime.

Also write the assetsThumb, used to check whether assets should be extracted, to a directory that is not backed up, to prevent the thumb from being cached.

**Note**: scripts and files stored in `context.getFilesDir()/app`, those downloaded either from a push plugin, http service, or just stored there, will naturally be removed when the extraction mechanism runs.

Addresses issue https://github.com/NativeScript/NativeScript/issues/4137