### PR TITLE
Manual instrumentation

### DIFF
--- a/build-artifacts/project-template-gradle/src/main/java/com/tns/NativeScriptApplication.java
+++ b/build-artifacts/project-template-gradle/src/main/java/com/tns/NativeScriptApplication.java
@@ -11,10 +11,15 @@ public class NativeScriptApplication extends android.app.Application {
     }
 
     public void onCreate() {
-        super.onCreate();
-        com.tns.Runtime runtime = RuntimeHelper.initRuntime(this);
-        if (runtime !=null) {
-            runtime.run();
+        ManualInstrumentation.Frame frame = ManualInstrumentation.start("NaitveScriptApplication.onCreate");
+        try {
+            super.onCreate();
+            com.tns.Runtime runtime = RuntimeHelper.initRuntime(this);
+            if (runtime != null) {
+                runtime.run();
+            }
+        } finally {
+            frame.close();
         }
     }
 

--- a/build-artifacts/project-template-gradle/src/main/java/com/tns/RuntimeHelper.java
+++ b/build-artifacts/project-template-gradle/src/main/java/com/tns/RuntimeHelper.java
@@ -53,157 +53,180 @@ public final class RuntimeHelper {
             return Runtime.getCurrentRuntime();
         }
 
-        System.loadLibrary("NativeScript");
-
-        Logger logger = new LogcatLogger(app);
-
-        Runtime runtime = null;
-        boolean showErrorIntent = hasErrorIntent(app);
-        if (!showErrorIntent) {
-            NativeScriptUncaughtExceptionHandler exHandler = new NativeScriptUncaughtExceptionHandler(logger, app);
-
-            Thread.setDefaultUncaughtExceptionHandler(exHandler);
-
-            DefaultExtractPolicy extractPolicy = new DefaultExtractPolicy(logger);
-            boolean skipAssetExtraction = Util.runPlugin(logger, app);
-
-            String appName = app.getPackageName();
-            File rootDir = new File(app.getApplicationInfo().dataDir);
-            File appDir = app.getFilesDir();
-
+        ManualInstrumentation.Frame frame = ManualInstrumentation.start("RuntimeHelper.initRuntime");
+        try {
+            ManualInstrumentation.Frame loadLibraryFrame = ManualInstrumentation.start("loadLibrary NativeScript");
             try {
-                appDir = appDir.getCanonicalFile();
-            } catch (IOException e1) {
+                System.loadLibrary("NativeScript");
+            } finally {
+                loadLibraryFrame.close();
             }
 
-            if (!skipAssetExtraction) {
-                if (logger.isEnabled()) {
-                    logger.write("Extracting assets...");
-                }
+            Logger logger = new LogcatLogger(app);
 
-                AssetExtractor aE = new AssetExtractor(null, logger);
+            Runtime runtime = null;
+            boolean showErrorIntent = hasErrorIntent(app);
+            if (!showErrorIntent) {
+                NativeScriptUncaughtExceptionHandler exHandler = new NativeScriptUncaughtExceptionHandler(logger, app);
 
-                String outputDir = app.getFilesDir().getPath() + File.separator;
+                Thread.setDefaultUncaughtExceptionHandler(exHandler);
 
-                // will force deletion of previously extracted files in app/files directories
-                // see https://github.com/NativeScript/NativeScript/issues/4137 for reference
-                boolean removePreviouslyInstalledAssets = true;
-                aE.extractAssets(app, "app", outputDir, extractPolicy, removePreviouslyInstalledAssets);
-                aE.extractAssets(app, "internal", outputDir, extractPolicy, removePreviouslyInstalledAssets);
-                aE.extractAssets(app, "metadata", outputDir, extractPolicy, false);
+                DefaultExtractPolicy extractPolicy = new DefaultExtractPolicy(logger);
+                boolean skipAssetExtraction = Util.runPlugin(logger, app);
 
-                boolean shouldExtractSnapshots = true;
+                String appName = app.getPackageName();
+                File rootDir = new File(app.getApplicationInfo().dataDir);
+                File appDir = app.getFilesDir();
 
-                // will extract snapshot of the device appropriate architecture
-                if (shouldExtractSnapshots) {
-                    if (logger.isEnabled()) {
-                        logger.write("Extracting snapshot blob");
-                    }
-
-                    aE.extractAssets(app, "snapshots/" + Build.CPU_ABI, outputDir, extractPolicy, removePreviouslyInstalledAssets);
-                }
-
-                extractPolicy.setAssetsThumb(app);
-            }
-
-            AppConfig appConfig = new AppConfig(appDir);
-
-            ClassLoader classLoader = app.getClassLoader();
-            File dexDir = new File(rootDir, "code_cache/secondary-dexes");
-            String dexThumb = null;
-            try {
-                dexThumb = Util.getDexThumb(app);
-            } catch (NameNotFoundException e) {
-                if (logger.isEnabled()) {
-                    logger.write("Error while getting current proxy thumb");
-                }
-                e.printStackTrace();
-            }
-
-            String nativeLibDir = null;
-            try {
-                nativeLibDir = app.getPackageManager().getApplicationInfo(appName, 0).nativeLibraryDir;
-            } catch (android.content.pm.PackageManager.NameNotFoundException e) {
-                e.printStackTrace();
-            }
-
-            boolean isDebuggable = Util.isDebuggableApp(app);
-            StaticConfiguration config = new StaticConfiguration(logger, appName, nativeLibDir, rootDir,
-                    appDir, classLoader, dexDir, dexThumb, appConfig, isDebuggable);
-
-            runtime = Runtime.initializeRuntimeWithConfiguration(config);
-            if (isDebuggable) {
                 try {
-                    v8Inspector = new AndroidJsV8Inspector(app.getFilesDir().getAbsolutePath(), app.getPackageName());
-                    v8Inspector.start();
+                    appDir = appDir.getCanonicalFile();
+                } catch (IOException e1) {
+                }
 
-                    // the following snippet is used as means to notify the VSCode extension
-                    // debugger that the debugger agent has started
-                    File debuggerStartedFile = new File("/data/local/tmp", app.getPackageName() + "-debugger-started");
-                    if (debuggerStartedFile.exists() && !debuggerStartedFile.isDirectory() && debuggerStartedFile.length() == 0) {
-                        java.io.FileWriter fileWriter = new java.io.FileWriter(debuggerStartedFile);
-                        fileWriter.write("started");
-                        fileWriter.close();
+                if (!skipAssetExtraction) {
+                    ManualInstrumentation.Frame extractionFrame = ManualInstrumentation.start("Extracting assets");
+                    try {
+                        if (logger.isEnabled()) {
+                            logger.write("Extracting assets...");
+                        }
+
+                        AssetExtractor aE = new AssetExtractor(null, logger);
+
+                        String outputDir = app.getFilesDir().getPath() + File.separator;
+
+                        // will force deletion of previously extracted files in app/files directories
+                        // see https://github.com/NativeScript/NativeScript/issues/4137 for reference
+                        boolean removePreviouslyInstalledAssets = true;
+                        aE.extractAssets(app, "app", outputDir, extractPolicy, removePreviouslyInstalledAssets);
+                        aE.extractAssets(app, "internal", outputDir, extractPolicy, removePreviouslyInstalledAssets);
+                        aE.extractAssets(app, "metadata", outputDir, extractPolicy, false);
+
+                        boolean shouldExtractSnapshots = true;
+
+                        // will extract snapshot of the device appropriate architecture
+                        if (shouldExtractSnapshots) {
+                            if (logger.isEnabled()) {
+                                logger.write("Extracting snapshot blob");
+                            }
+
+                            aE.extractAssets(app, "snapshots/" + Build.CPU_ABI, outputDir, extractPolicy, removePreviouslyInstalledAssets);
+                        }
+
+                        extractPolicy.setAssetsThumb(app);
+                    } finally {
+                        extractionFrame.close();
                     }
+                }
 
-                    // check if --debug-brk flag has been set. If positive:
-                    // write to the file to invalidate the flag
-                    // inform the v8Inspector to pause the main thread
-                    File debugBreakFile = new File("/data/local/tmp", app.getPackageName() + "-debugbreak");
-                    boolean shouldBreak = false;
-                    if (debugBreakFile.exists() && !debugBreakFile.isDirectory() && debugBreakFile.length() == 0) {
-                        java.io.FileWriter fileWriter = new java.io.FileWriter(debugBreakFile);
-                        fileWriter.write("started");
-                        fileWriter.close();
+                AppConfig appConfig = new AppConfig(appDir);
+                switch (appConfig.getProfilingMode()) {
+                    case "timeline":
+                        ManualInstrumentation.setMode(ManualInstrumentation.Mode.Timeline);
+                        break;
+                    default:
+                        ManualInstrumentation.setMode(ManualInstrumentation.Mode.Disabled);
+                }
+                Runtime.SetManualInstrumentationMode(appConfig.getProfilingMode());
 
-                        shouldBreak = true;
+                ClassLoader classLoader = app.getClassLoader();
+                File dexDir = new File(rootDir, "code_cache/secondary-dexes");
+                String dexThumb = null;
+                try {
+                    dexThumb = Util.getDexThumb(app);
+                } catch (NameNotFoundException e) {
+                    if (logger.isEnabled()) {
+                        logger.write("Error while getting current proxy thumb");
                     }
+                    e.printStackTrace();
+                }
 
-                    v8Inspector.waitForDebugger(shouldBreak);
-                } catch (IOException e) {
+                String nativeLibDir = null;
+                try {
+                    nativeLibDir = app.getPackageManager().getApplicationInfo(appName, 0).nativeLibraryDir;
+                } catch (android.content.pm.PackageManager.NameNotFoundException e) {
+                    e.printStackTrace();
+                }
+
+                boolean isDebuggable = Util.isDebuggableApp(app);
+                StaticConfiguration config = new StaticConfiguration(logger, appName, nativeLibDir, rootDir,
+                        appDir, classLoader, dexDir, dexThumb, appConfig, isDebuggable);
+
+                runtime = Runtime.initializeRuntimeWithConfiguration(config);
+                if (isDebuggable) {
+                    try {
+                        v8Inspector = new AndroidJsV8Inspector(app.getFilesDir().getAbsolutePath(), app.getPackageName());
+                        v8Inspector.start();
+
+                        // the following snippet is used as means to notify the VSCode extension
+                        // debugger that the debugger agent has started
+                        File debuggerStartedFile = new File("/data/local/tmp", app.getPackageName() + "-debugger-started");
+                        if (debuggerStartedFile.exists() && !debuggerStartedFile.isDirectory() && debuggerStartedFile.length() == 0) {
+                            java.io.FileWriter fileWriter = new java.io.FileWriter(debuggerStartedFile);
+                            fileWriter.write("started");
+                            fileWriter.close();
+                        }
+
+                        // check if --debug-brk flag has been set. If positive:
+                        // write to the file to invalidate the flag
+                        // inform the v8Inspector to pause the main thread
+                        File debugBreakFile = new File("/data/local/tmp", app.getPackageName() + "-debugbreak");
+                        boolean shouldBreak = false;
+                        if (debugBreakFile.exists() && !debugBreakFile.isDirectory() && debugBreakFile.length() == 0) {
+                            java.io.FileWriter fileWriter = new java.io.FileWriter(debugBreakFile);
+                            fileWriter.write("started");
+                            fileWriter.close();
+
+                            shouldBreak = true;
+                        }
+
+                        v8Inspector.waitForDebugger(shouldBreak);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                }
+
+                // runtime needs to be initialized before the NativeScriptSyncService is enabled because it uses runtime.runScript(...)
+                if (NativeScriptSyncService.isSyncEnabled(app)) {
+                    NativeScriptSyncService syncService = new NativeScriptSyncService(runtime, logger, app);
+
+                    syncService.sync();
+                    syncService.startServer();
+
+                    // preserve this instance as strong reference
+                    // do not preserve in NativeScriptApplication field inorder to
+                    // make the code more portable
+                    // @@@
+                    // Runtime.getOrCreateJavaObjectID(syncService);
+                } else {
+                    if (logger.isEnabled()) {
+                        logger.write("NativeScript LiveSync is not enabled.");
+                    }
+                }
+
+                runtime.runScript(new File(appDir, "internal/ts_helpers.js"));
+
+                File javaClassesModule = new File(appDir, "app/tns-java-classes.js");
+                if (javaClassesModule.exists()) {
+                    runtime.runModule(javaClassesModule);
+                }
+
+                try {
+                    // put this call in a try/catch block because with the latest changes in the modules it is not granted that NativeScriptApplication is extended through JavaScript.
+                    JavaScriptImplementation jsImpl = app.getClass().getAnnotation(JavaScriptImplementation.class);
+                    if (jsImpl != null) {
+                        Runtime.initInstance(app);
+                    }
+                } catch (Exception e) {
+                    if (logger.isEnabled()) {
+                        logger.write("Cannot initialize application instance.");
+                    }
                     e.printStackTrace();
                 }
             }
-
-            // runtime needs to be initialized before the NativeScriptSyncService is enabled because it uses runtime.runScript(...)
-            if (NativeScriptSyncService.isSyncEnabled(app)) {
-                NativeScriptSyncService syncService = new NativeScriptSyncService(runtime, logger, app);
-
-                syncService.sync();
-                syncService.startServer();
-
-                // preserve this instance as strong reference
-                // do not preserve in NativeScriptApplication field inorder to
-                // make the code more portable
-                // @@@
-                // Runtime.getOrCreateJavaObjectID(syncService);
-            } else {
-                if (logger.isEnabled()) {
-                    logger.write("NativeScript LiveSync is not enabled.");
-                }
-            }
-
-            runtime.runScript(new File(appDir, "internal/ts_helpers.js"));
-
-            File javaClassesModule = new File(appDir, "app/tns-java-classes.js");
-            if (javaClassesModule.exists()) {
-                runtime.runModule(javaClassesModule);
-            }
-
-            try {
-                // put this call in a try/catch block because with the latest changes in the modules it is not granted that NativeScriptApplication is extended through JavaScript.
-                JavaScriptImplementation jsImpl = app.getClass().getAnnotation(JavaScriptImplementation.class);
-                if (jsImpl != null) {
-                    Runtime.initInstance(app);
-                }
-            } catch (Exception e) {
-                if (logger.isEnabled()) {
-                    logger.write("Cannot initialize application instance.");
-                }
-                e.printStackTrace();
-            }
+            return runtime;
+        } finally {
+            frame.close();
         }
-        return runtime;
     }
 
     private static final String logTag = "MyApp";

--- a/build-artifacts/project-template-gradle/src/main/java/com/tns/RuntimeHelper.java
+++ b/build-artifacts/project-template-gradle/src/main/java/com/tns/RuntimeHelper.java
@@ -119,14 +119,7 @@ public final class RuntimeHelper {
                 }
 
                 AppConfig appConfig = new AppConfig(appDir);
-                switch (appConfig.getProfilingMode()) {
-                    case "timeline":
-                        ManualInstrumentation.setMode(ManualInstrumentation.Mode.Timeline);
-                        break;
-                    default:
-                        ManualInstrumentation.setMode(ManualInstrumentation.Mode.Disabled);
-                }
-                Runtime.SetManualInstrumentationMode(appConfig.getProfilingMode());
+                ManualInstrumentation.setMode(appConfig.getProfilingMode());
 
                 ClassLoader classLoader = app.getClassLoader();
                 File dexDir = new File(rootDir, "code_cache/secondary-dexes");

--- a/runtime/src/main/java/com/tns/GcListener.java
+++ b/runtime/src/main/java/com/tns/GcListener.java
@@ -143,8 +143,13 @@ public class GcListener {
 
     private void notifyGc() {
         synchronized (instance) {
-            for (Runtime runtime: subscribers.keySet()) {
-                runtime.notifyGc();
+            ManualInstrumentation.Frame frame = ManualInstrumentation.start("GcListener.notifyGc");
+            try {
+                for (Runtime runtime : subscribers.keySet()) {
+                    runtime.notifyGc();
+                }
+            } finally {
+                frame.close();
             }
         }
     }

--- a/runtime/src/main/java/com/tns/ManualInstrumentation.java
+++ b/runtime/src/main/java/com/tns/ManualInstrumentation.java
@@ -1,0 +1,145 @@
+package com.tns;
+
+import android.util.Log;
+
+import java.util.Stack;
+
+/**
+ * Created by cankov on 01/06/2017.
+ */
+public class ManualInstrumentation {
+    private static Mode mode = Mode.Pending;
+
+    public static void setMode(Mode mode) {
+        if (ManualInstrumentation.mode == Mode.Pending) {
+            switch(mode) {
+                case Timeline:
+                    Mode.PendingFrame.printPending();
+                    break;
+                case Disabled:
+                    Mode.PendingFrame.discardPending();
+                    break;
+            }
+        }
+        ManualInstrumentation.mode = mode;
+    }
+
+    public interface Frame {
+        void close();
+    }
+
+    public static Frame start(String name) {
+        return mode.start(name);
+    }
+
+    public enum Mode {
+        /**
+         * This mode is used to collect inital frames in pre package.json parsing.
+         */
+        Pending {
+            protected Frame start(String name) {
+                return new PendingFrame(name);
+            }
+        },
+        /**
+         * This mode will provide void frame implementation for fast performance in release builds.
+         */
+        Disabled {
+            protected Frame start(String name) {
+                return DisabledFrame.instance;
+            }
+        },
+        /**
+         * This mode creates frames that when closed will simply log in the android log frames that consume time longer than reasonable threshold.
+         */
+        Timeline {
+            protected Frame start(String name) {
+                LogFrame frame = LogFrame.frames.isEmpty() ? new LogFrame() : LogFrame.frames.pop();
+                frame.start = System.currentTimeMillis();
+                frame.name = name;
+                return frame;
+            }
+        };
+
+        protected abstract Frame start(String name);
+
+        private static class DisabledFrame implements Frame {
+            static DisabledFrame instance = new DisabledFrame();
+            public void close() {}
+        }
+
+        private static class LogFrame implements Frame {
+            private static Stack<LogFrame> frames = new Stack<LogFrame>();
+
+            private long start;
+            private StringBuilder builder = new StringBuilder();
+            private String name;
+
+            public void close() {
+                try {
+                    long end = System.currentTimeMillis();
+                    if ((end - start) >= 16) {
+                        builder.append("Timeline: Runtime: ");
+                        builder.append(name);
+                        builder.append("  (");
+                        builder.append(start);
+                        builder.append("ms. - ");
+                        builder.append(end);
+                        builder.append("ms.)");
+                        Log.v("JS", builder.toString());
+                        builder.setLength(0); // Recycle the builder
+                    }
+                } finally {
+                    frames.push(this); // Recycle the frame
+                }
+            }
+        }
+
+        private static class PendingFrame implements Frame {
+            private static Stack<Mode.PendingFrame> pendingFrames = new Stack<Mode.PendingFrame>();
+
+            private long start;
+            private long end;
+            private String name;
+
+            private PendingFrame(String name) {
+                this.name = name;
+                start = System.currentTimeMillis();
+            }
+
+            public void close() {
+                end = System.currentTimeMillis();
+                if (end - start > 16) {
+                    if (mode == Timeline) {
+                        print();
+                    } else if (mode == Pending) {
+                        pendingFrames.add(this);
+                    }
+                }
+            }
+
+            private void print() {
+                StringBuilder builder = new StringBuilder();
+                builder.append("Timeline: Runtime: ");
+                builder.append(name);
+                builder.append("  (");
+                builder.append(start);
+                builder.append("ms. - ");
+                builder.append(end);
+                builder.append("ms.)");
+                Log.v("JS", builder.toString());
+            }
+
+            public static void printPending() {
+                for (PendingFrame f : pendingFrames) {
+                    f.print();
+                }
+                pendingFrames.clear();
+            }
+
+            public static void discardPending() {
+                pendingFrames.clear();
+            }
+        }
+    }
+}

--- a/runtime/src/main/java/com/tns/ManualInstrumentation.java
+++ b/runtime/src/main/java/com/tns/ManualInstrumentation.java
@@ -10,6 +10,17 @@ import java.util.Stack;
 public class ManualInstrumentation {
     private static Mode mode = Mode.Pending;
 
+    public static void setMode(String mode) {
+        switch (mode) {
+            case "timeline":
+                ManualInstrumentation.setMode(ManualInstrumentation.Mode.Timeline);
+                break;
+            default:
+                ManualInstrumentation.setMode(ManualInstrumentation.Mode.Disabled);
+        }
+        Runtime.SetManualInstrumentationMode(mode);
+    }
+
     public static void setMode(Mode mode) {
         if (ManualInstrumentation.mode == Mode.Pending) {
             switch(mode) {

--- a/runtime/src/main/jni/ManualInstrumentation.cpp
+++ b/runtime/src/main/jni/ManualInstrumentation.cpp
@@ -5,4 +5,4 @@
 #include "ManualInstrumentation.h"
 
 bool tns::instrumentation::Frame::disabled = true;
-const std::chrono::steady_clock::time_point tns::instrumentation::Frame::disabled_time = std::chrono::steady_clock::now();
+const std::chrono::steady_clock::time_point tns::instrumentation::Frame::disabled_time = std::chrono::steady_clock::time_point();

--- a/runtime/src/main/jni/ManualInstrumentation.cpp
+++ b/runtime/src/main/jni/ManualInstrumentation.cpp
@@ -1,0 +1,8 @@
+//
+// Created by Panayot Cankov on 26/05/2017.
+//
+
+#include "ManualInstrumentation.h"
+
+bool tns::instrumentation::Frame::disabled = true;
+const std::chrono::steady_clock::time_point tns::instrumentation::Frame::disabled_time = std::chrono::steady_clock::now();

--- a/runtime/src/main/jni/ManualInstrumentation.h
+++ b/runtime/src/main/jni/ManualInstrumentation.h
@@ -1,0 +1,66 @@
+//
+// Created by Panayot Cankov on 26/05/2017.
+//
+
+#ifndef TEST_APP_MANUALINSTRUMENTATION_H
+#define TEST_APP_MANUALINSTRUMENTATION_H
+
+#include "v8.h"
+#import <chrono>
+#import <NativeScriptAssert.h>
+
+namespace tns {
+    namespace instrumentation {
+        class Frame {
+        public:
+            inline Frame() : Frame(nullptr) { }
+            inline Frame(const char *name) : name(name), start(disabled ? disabled_time : std::chrono::steady_clock::now()) {}
+
+            inline ~Frame() {
+                if (name && check()) {
+                    log(name);
+                }
+            }
+
+            inline bool check() {
+                if (disabled) {
+                    return false;
+                }
+                std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+                auto duration = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::operator-(end, start)).count();
+                return duration >= 16000;
+            }
+
+            inline void log(const char * message) {
+                if (disabled) {
+                    return;
+                }
+                std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+                auto duration = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::operator-(end, start)).count();
+                auto startMilis = std::chrono::time_point_cast<std::chrono::microseconds>(start).time_since_epoch().count() / 1000.0;
+                auto endMilis = std::chrono::time_point_cast<std::chrono::microseconds>(end).time_since_epoch().count() / 1000.0;
+                __android_log_print(ANDROID_LOG_DEBUG, "JS", "Timeline: %.3fms: Runtime: %s  (%.3fms - %.3fms)", duration / 1000.0, message, startMilis, endMilis);
+            }
+
+            static inline void enable() { disabled = false; }
+            static inline void disable() { disabled = true; }
+
+        private:
+            static bool disabled;
+            static const std::chrono::steady_clock::time_point disabled_time; // Couldn't find reasonable constant
+
+            const std::chrono::steady_clock::time_point start;
+            const char *name;
+
+            Frame(const Frame &) = delete;
+            Frame &operator=(const Frame &) = delete;
+        };
+    };
+};
+
+/**
+ * Place at the start of a method. Will log to android using the "JS" tag methods that execute relatively slow.
+ */
+#define TNSPERF() tns::instrumentation::Frame __tns_manual_instrumentation(__func__)
+
+#endif //TEST_APP_MANUALINSTRUMENTATION_H

--- a/runtime/src/main/jni/ManualInstrumentation.h
+++ b/runtime/src/main/jni/ManualInstrumentation.h
@@ -2,22 +2,23 @@
 // Created by Panayot Cankov on 26/05/2017.
 //
 
-#ifndef TEST_APP_MANUALINSTRUMENTATION_H
-#define TEST_APP_MANUALINSTRUMENTATION_H
+#ifndef MANUALINSTRUMENTATION_H
+#define MANUALINSTRUMENTATION_H
 
 #include "v8.h"
 #import <chrono>
 #import <NativeScriptAssert.h>
+#include <string>
 
 namespace tns {
     namespace instrumentation {
         class Frame {
         public:
-            inline Frame() : Frame(nullptr) { }
-            inline Frame(const char *name) : name(name), start(disabled ? disabled_time : std::chrono::steady_clock::now()) {}
+            inline Frame() : Frame("") { }
+            inline Frame(std::string name) : name(name), start(disabled ? disabled_time : std::chrono::steady_clock::now()) {}
 
             inline ~Frame() {
-                if (name && check()) {
+                if (!name.empty() && check()) {
                     log(name);
                 }
             }
@@ -42,6 +43,10 @@ namespace tns {
                 __android_log_print(ANDROID_LOG_DEBUG, "JS", "Timeline: %.3fms: Runtime: %s  (%.3fms - %.3fms)", duration / 1000.0, message, startMilis, endMilis);
             }
 
+            inline void log(const std::string& message) {
+                log(message.c_str());
+            }
+
             static inline void enable() { disabled = false; }
             static inline void disable() { disabled = true; }
 
@@ -50,7 +55,7 @@ namespace tns {
             static const std::chrono::steady_clock::time_point disabled_time; // Couldn't find reasonable constant
 
             const std::chrono::steady_clock::time_point start;
-            const char *name;
+            const std::string name;
 
             Frame(const Frame &) = delete;
             Frame &operator=(const Frame &) = delete;
@@ -63,4 +68,4 @@ namespace tns {
  */
 #define TNSPERF() tns::instrumentation::Frame __tns_manual_instrumentation(__func__)
 
-#endif //TEST_APP_MANUALINSTRUMENTATION_H
+#endif //MANUALINSTRUMENTATION_H

--- a/runtime/src/main/jni/MetadataNode.cpp
+++ b/runtime/src/main/jni/MetadataNode.cpp
@@ -756,8 +756,7 @@ Local<FunctionTemplate> MetadataNode::GetConstructorFunctionTemplate(Isolate* is
     SetTypeMetadata(isolate, wrappedCtorFunc, new TypeMetadata(s_metadataReader.ReadTypeName(treeNode)));
 
     if (frame.check()) {
-        std::string log = "Materizlizing class: " + node->m_name;
-        frame.log(log.c_str());
+        frame.log("Materizlizing class: " + node->m_name);
     }
 
     return ctorFuncTemplate;
@@ -896,8 +895,7 @@ void MetadataNode::InterfaceConstructorCallback(const v8::FunctionCallbackInfo<v
         auto success = CallbackHandlers::RegisterInstance(isolate, thiz, className, argWrapper, implementationObject, true);
 
         if (frame.check()) {
-            std::string msg = "Interface constructor: " + node->m_name;
-            frame.log(msg.c_str());
+            frame.log("Interface constructor: " + node->m_name);
         }
     } catch (NativeScriptException& e) {
         e.ReThrowToV8();
@@ -1377,8 +1375,7 @@ void MetadataNode::ExtendMethodCallback(const v8::FunctionCallbackInfo<v8::Value
         cache->ExtendedCtorFuncCache.insert(make_pair(fullExtendedName, cacheData));
 
         if (frame.check()) {
-            std::string msg = "Extending: " + node->m_name;
-            frame.log(msg.c_str());
+            frame.log("Extending: " + node->m_name);
         }
     } catch (NativeScriptException& e) {
         e.ReThrowToV8();

--- a/runtime/src/main/jni/MetadataNode.cpp
+++ b/runtime/src/main/jni/MetadataNode.cpp
@@ -11,6 +11,7 @@
 #include "Runtime.h"
 #include <sstream>
 #include <cctype>
+#include "ManualInstrumentation.h"
 
 #include "v8.h"
 
@@ -681,6 +682,7 @@ Local<FunctionTemplate> MetadataNode::GetConstructorFunctionTemplate(Isolate* is
 
 Local<FunctionTemplate> MetadataNode::GetConstructorFunctionTemplate(Isolate* isolate, MetadataTreeNode* treeNode, vector<MethodCallbackData*>& instanceMethodsCallbackData) {
     SET_PROFILER_FRAME();
+    tns::instrumentation::Frame frame;
 
     //try get cached "ctorFuncTemplate"
     Local<FunctionTemplate> ctorFuncTemplate;
@@ -753,6 +755,11 @@ Local<FunctionTemplate> MetadataNode::GetConstructorFunctionTemplate(Isolate* is
 
     SetTypeMetadata(isolate, wrappedCtorFunc, new TypeMetadata(s_metadataReader.ReadTypeName(treeNode)));
 
+    if (frame.check()) {
+        std::string log = "Materizlizing class: " + node->m_name;
+        frame.log(log.c_str());
+    }
+
     return ctorFuncTemplate;
 }
 
@@ -807,6 +814,7 @@ void MetadataNode::SetInstanceMetadata(Isolate* isolate, Local<Object> object, M
 }
 
 void MetadataNode::ExtendedClassConstructorCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
+    TNSPERF();
     try {
         SET_PROFILER_FRAME();
 
@@ -843,6 +851,7 @@ void MetadataNode::ExtendedClassConstructorCallback(const v8::FunctionCallbackIn
 }
 
 void MetadataNode::InterfaceConstructorCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
+    tns::instrumentation::Frame frame;
     try {
         SET_PROFILER_FRAME();
 
@@ -885,6 +894,11 @@ void MetadataNode::InterfaceConstructorCallback(const v8::FunctionCallbackInfo<v
         ArgsWrapper argWrapper(info, ArgType::Interface);
 
         auto success = CallbackHandlers::RegisterInstance(isolate, thiz, className, argWrapper, implementationObject, true);
+
+        if (frame.check()) {
+            std::string msg = "Interface constructor: " + node->m_name;
+            frame.log(msg.c_str());
+        }
     } catch (NativeScriptException& e) {
         e.ReThrowToV8();
     } catch (std::exception e) {
@@ -899,6 +913,7 @@ void MetadataNode::InterfaceConstructorCallback(const v8::FunctionCallbackInfo<v
 }
 
 void MetadataNode::ClassConstructorCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
+    TNSPERF();
     try {
         SET_PROFILER_FRAME();
 
@@ -1041,6 +1056,7 @@ void MetadataNode::ArrayIndexedPropertySetterCallback(uint32_t index, Local<Valu
 }
 
 Local<Object> MetadataNode::GetImplementationObject(Isolate* isolate, const Local<Object>& object) {
+    TNSPERF();
     DEBUG_WRITE("GetImplementationObject called  on object:%d", object->GetIdentityHash());
 
     auto target = object;
@@ -1247,6 +1263,7 @@ string MetadataNode::CreateFullClassName(const std::string& className, const std
 }
 
 void MetadataNode::ExtendMethodCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
+    tns::instrumentation::Frame frame;
     try {
         if (info.IsConstructCall()) {
             string exMsg("Can't call 'extend' as constructor");
@@ -1358,6 +1375,11 @@ void MetadataNode::ExtendMethodCallback(const v8::FunctionCallbackInfo<v8::Value
         ExtendedClassCacheData cacheData(extendFunc, fullExtendedName, node);
         auto cache = GetMetadataNodeCache(isolate);
         cache->ExtendedCtorFuncCache.insert(make_pair(fullExtendedName, cacheData));
+
+        if (frame.check()) {
+            std::string msg = "Extending: " + node->m_name;
+            frame.log(msg.c_str());
+        }
     } catch (NativeScriptException& e) {
         e.ReThrowToV8();
     } catch (std::exception e) {

--- a/runtime/src/main/jni/ModuleInternal.cpp
+++ b/runtime/src/main/jni/ModuleInternal.cpp
@@ -157,8 +157,7 @@ void ModuleInternal::RequireCallbackImpl(const v8::FunctionCallbackInfo<v8::Valu
     }
 
     string moduleName = ArgConverter::ConvertToString(args[0].As<String>());
-    string frameName("RequireCallback " + moduleName);
-    tns::instrumentation::Frame frame(frameName.c_str());
+    tns::instrumentation::Frame frame(("RequireCallback " + moduleName).c_str());
     string callingModuleDirName = ArgConverter::ConvertToString(args[1].As<String>());
     auto isData = false;
 

--- a/runtime/src/main/jni/ObjectManager.cpp
+++ b/runtime/src/main/jni/ObjectManager.cpp
@@ -520,14 +520,9 @@ void ObjectManager::MarkReachableObjects(Isolate* isolate, const Local<Object>& 
 
     if (frame.check()) {
         auto cls = fromJsInfo->ObjectClazz;
-        JEnv env;
-        jclass clsClazz = env.GetObjectClass(cls);
-        jmethodID methodId = env.GetMethodID(clsClazz, "getSimpleName", "()Ljava/lang/String;");
-        jstring className = (jstring) env.CallObjectMethod(cls, methodId);
-        const char* str = env.GetStringUTFChars(className, NULL);
-        auto jsObjClassName = "MarkReachableObjects: " + std::string(str);
-        frame.log(jsObjClassName.c_str());
-        env.ReleaseStringUTFChars(className, str);
+        jclass clsClazz = m_env.GetObjectClass(cls);
+        jstring className = (jstring) m_env.CallObjectMethod(cls, GET_NAME_METHOD_ID);
+        frame.log("MarkReachableObjects: " + ArgConverter::jstringToString(className));
     }
 }
 

--- a/runtime/src/main/jni/Runtime.cpp
+++ b/runtime/src/main/jni/Runtime.cpp
@@ -25,6 +25,7 @@
 #include "NetworkDomainCallbackHandlers.h"
 #include "sys/system_properties.h"
 #include "JsV8InspectorClient.h"
+#include "ManualInstrumentation.h"
 
 using namespace v8;
 using namespace std;
@@ -607,6 +608,12 @@ jobject Runtime::ConvertJsValueToJavaObject(JEnv& env, const Local<Value>& value
     return javaResult;
 }
 
+void Runtime::SetManualInstrumentationMode(jstring mode) {
+    auto modeStr = ArgConverter::jstringToString(mode);
+    if (modeStr == "timeline") {
+        tns::instrumentation::Frame::enable();
+    }
+}
 
 void Runtime::DestroyRuntime() {
     s_id2RuntimeCache.erase(m_id);

--- a/runtime/src/main/jni/Runtime.h
+++ b/runtime/src/main/jni/Runtime.h
@@ -31,6 +31,8 @@ class Runtime {
 
         static void Init(JNIEnv* _env, jobject obj, int runtimeId, jstring filesPath, jstring nativeLibsDir, jboolean verboseLoggingEnabled, jboolean isDebuggable, jstring packageName, jobjectArray args, jstring callingDir);
 
+        static void SetManualInstrumentationMode(jstring mode);
+
         void Init(jstring filesPath, jstring nativeLibsDir, bool verboseLoggingEnabled, bool isDebuggable, jstring packageName, jobjectArray args, jstring callingDir);
 
         v8::Isolate* GetIsolate() const;

--- a/runtime/src/main/jni/com_tns_Runtime.cpp
+++ b/runtime/src/main/jni/com_tns_Runtime.cpp
@@ -25,6 +25,15 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
     return JNI_VERSION_1_6;
 }
 
+extern "C" JNIEXPORT void Java_com_tns_Runtime_SetManualInstrumentationMode(JNIEnv* _env, jobject obj, jstring mode) {
+    try {
+        Runtime::SetManualInstrumentationMode(mode);
+    } catch(...) {
+        NativeScriptException nsEx(std::string("Error: c++ exception!"));
+        nsEx.ReThrowToJava();
+    }
+}
+
 extern "C" JNIEXPORT void Java_com_tns_Runtime_initNativeScript(JNIEnv* _env, jobject obj, jint runtimeId, jstring filesPath, jstring nativeLibDir, jboolean verboseLoggingEnabled, jboolean isDebuggable, jstring packageName, jobjectArray args, jstring callingDir) {
     try {
         Runtime::Init(_env, obj, runtimeId, filesPath, nativeLibDir, verboseLoggingEnabled, isDebuggable, packageName, args, callingDir);

--- a/test-app/app/src/main/java/com/tns/NativeScriptApplication.java
+++ b/test-app/app/src/main/java/com/tns/NativeScriptApplication.java
@@ -12,10 +12,15 @@ public class NativeScriptApplication extends android.app.Application {
     }
 
     public void onCreate() {
-        super.onCreate();
-        com.tns.Runtime runtime = RuntimeHelper.initRuntime(this);
-        if (runtime !=null) {
-            runtime.run();
+        ManualInstrumentation.Frame frame = ManualInstrumentation.start("NaitveScriptApplication.onCreate");
+        try {
+            super.onCreate();
+            com.tns.Runtime runtime = RuntimeHelper.initRuntime(this);
+            if (runtime != null) {
+                runtime.run();
+            }
+        } finally {
+            frame.close();
         }
     }
 

--- a/test-app/app/src/main/java/com/tns/RuntimeHelper.java
+++ b/test-app/app/src/main/java/com/tns/RuntimeHelper.java
@@ -53,157 +53,180 @@ public final class RuntimeHelper {
             return Runtime.getCurrentRuntime();
         }
 
-        System.loadLibrary("NativeScript");
-
-        Logger logger = new LogcatLogger(app);
-
-        Runtime runtime = null;
-        boolean showErrorIntent = hasErrorIntent(app);
-        if (!showErrorIntent) {
-            NativeScriptUncaughtExceptionHandler exHandler = new NativeScriptUncaughtExceptionHandler(logger, app);
-
-            Thread.setDefaultUncaughtExceptionHandler(exHandler);
-
-            DefaultExtractPolicy extractPolicy = new DefaultExtractPolicy(logger);
-            boolean skipAssetExtraction = Util.runPlugin(logger, app);
-
-            String appName = app.getPackageName();
-            File rootDir = new File(app.getApplicationInfo().dataDir);
-            File appDir = app.getFilesDir();
-
+        ManualInstrumentation.Frame frame = ManualInstrumentation.start("RuntimeHelper.initRuntime");
+        try {
+            ManualInstrumentation.Frame loadLibraryFrame = ManualInstrumentation.start("loadLibrary NativeScript");
             try {
-                appDir = appDir.getCanonicalFile();
-            } catch (IOException e1) {
+                System.loadLibrary("NativeScript");
+            } finally {
+                loadLibraryFrame.close();
             }
 
-            if (!skipAssetExtraction) {
-                if (logger.isEnabled()) {
-                    logger.write("Extracting assets...");
-                }
+            Logger logger = new LogcatLogger(app);
 
-                AssetExtractor aE = new AssetExtractor(null, logger);
+            Runtime runtime = null;
+            boolean showErrorIntent = hasErrorIntent(app);
+            if (!showErrorIntent) {
+                NativeScriptUncaughtExceptionHandler exHandler = new NativeScriptUncaughtExceptionHandler(logger, app);
 
-                String outputDir = app.getFilesDir().getPath() + File.separator;
+                Thread.setDefaultUncaughtExceptionHandler(exHandler);
 
-                // will force deletion of previously extracted files in app/files directories
-                // see https://github.com/NativeScript/NativeScript/issues/4137 for reference
-                boolean removePreviouslyInstalledAssets = true;
-                aE.extractAssets(app, "app", outputDir, extractPolicy, removePreviouslyInstalledAssets);
-                aE.extractAssets(app, "internal", outputDir, extractPolicy, removePreviouslyInstalledAssets);
-                aE.extractAssets(app, "metadata", outputDir, extractPolicy, false);
+                DefaultExtractPolicy extractPolicy = new DefaultExtractPolicy(logger);
+                boolean skipAssetExtraction = Util.runPlugin(logger, app);
 
-                boolean shouldExtractSnapshots = true;
+                String appName = app.getPackageName();
+                File rootDir = new File(app.getApplicationInfo().dataDir);
+                File appDir = app.getFilesDir();
 
-                // will extract snapshot of the device appropriate architecture
-                if (shouldExtractSnapshots) {
-                    if (logger.isEnabled()) {
-                        logger.write("Extracting snapshot blob");
-                    }
-
-                    aE.extractAssets(app, "snapshots/" + Build.CPU_ABI, outputDir, extractPolicy, removePreviouslyInstalledAssets);
-                }
-
-                extractPolicy.setAssetsThumb(app);
-            }
-
-            AppConfig appConfig = new AppConfig(appDir);
-
-            ClassLoader classLoader = app.getClassLoader();
-            File dexDir = new File(rootDir, "code_cache/secondary-dexes");
-            String dexThumb = null;
-            try {
-                dexThumb = Util.getDexThumb(app);
-            } catch (NameNotFoundException e) {
-                if (logger.isEnabled()) {
-                    logger.write("Error while getting current proxy thumb");
-                }
-                e.printStackTrace();
-            }
-
-            String nativeLibDir = null;
-            try {
-                nativeLibDir = app.getPackageManager().getApplicationInfo(appName, 0).nativeLibraryDir;
-            } catch (android.content.pm.PackageManager.NameNotFoundException e) {
-                e.printStackTrace();
-            }
-
-            boolean isDebuggable = Util.isDebuggableApp(app);
-            StaticConfiguration config = new StaticConfiguration(logger, appName, nativeLibDir, rootDir,
-                    appDir, classLoader, dexDir, dexThumb, appConfig, isDebuggable);
-
-            runtime = Runtime.initializeRuntimeWithConfiguration(config);
-            if (isDebuggable) {
                 try {
-                    v8Inspector = new AndroidJsV8Inspector(app.getFilesDir().getAbsolutePath(), app.getPackageName());
-                    v8Inspector.start();
+                    appDir = appDir.getCanonicalFile();
+                } catch (IOException e1) {
+                }
 
-                    // the following snippet is used as means to notify the VSCode extension
-                    // debugger that the debugger agent has started
-                    File debuggerStartedFile = new File("/data/local/tmp", app.getPackageName() + "-debugger-started");
-                    if (debuggerStartedFile.exists() && !debuggerStartedFile.isDirectory() && debuggerStartedFile.length() == 0) {
-                        java.io.FileWriter fileWriter = new java.io.FileWriter(debuggerStartedFile);
-                        fileWriter.write("started");
-                        fileWriter.close();
+                if (!skipAssetExtraction) {
+                    ManualInstrumentation.Frame extractionFrame = ManualInstrumentation.start("Extracting assets");
+                    try {
+                        if (logger.isEnabled()) {
+                            logger.write("Extracting assets...");
+                        }
+
+                        AssetExtractor aE = new AssetExtractor(null, logger);
+
+                        String outputDir = app.getFilesDir().getPath() + File.separator;
+
+                        // will force deletion of previously extracted files in app/files directories
+                        // see https://github.com/NativeScript/NativeScript/issues/4137 for reference
+                        boolean removePreviouslyInstalledAssets = true;
+                        aE.extractAssets(app, "app", outputDir, extractPolicy, removePreviouslyInstalledAssets);
+                        aE.extractAssets(app, "internal", outputDir, extractPolicy, removePreviouslyInstalledAssets);
+                        aE.extractAssets(app, "metadata", outputDir, extractPolicy, false);
+
+                        boolean shouldExtractSnapshots = true;
+
+                        // will extract snapshot of the device appropriate architecture
+                        if (shouldExtractSnapshots) {
+                            if (logger.isEnabled()) {
+                                logger.write("Extracting snapshot blob");
+                            }
+
+                            aE.extractAssets(app, "snapshots/" + Build.CPU_ABI, outputDir, extractPolicy, removePreviouslyInstalledAssets);
+                        }
+
+                        extractPolicy.setAssetsThumb(app);
+                    } finally {
+                        extractionFrame.close();
                     }
+                }
 
-                    // check if --debug-brk flag has been set. If positive:
-                    // write to the file to invalidate the flag
-                    // inform the v8Inspector to pause the main thread
-                    File debugBreakFile = new File("/data/local/tmp", app.getPackageName() + "-debugbreak");
-                    boolean shouldBreak = false;
-                    if (debugBreakFile.exists() && !debugBreakFile.isDirectory() && debugBreakFile.length() == 0) {
-                        java.io.FileWriter fileWriter = new java.io.FileWriter(debugBreakFile);
-                        fileWriter.write("started");
-                        fileWriter.close();
+                AppConfig appConfig = new AppConfig(appDir);
+                switch (appConfig.getProfilingMode()) {
+                    case "timeline":
+                        ManualInstrumentation.setMode(ManualInstrumentation.Mode.Timeline);
+                        break;
+                    default:
+                        ManualInstrumentation.setMode(ManualInstrumentation.Mode.Disabled);
+                }
+                Runtime.SetManualInstrumentationMode(appConfig.getProfilingMode());
 
-                        shouldBreak = true;
+                ClassLoader classLoader = app.getClassLoader();
+                File dexDir = new File(rootDir, "code_cache/secondary-dexes");
+                String dexThumb = null;
+                try {
+                    dexThumb = Util.getDexThumb(app);
+                } catch (NameNotFoundException e) {
+                    if (logger.isEnabled()) {
+                        logger.write("Error while getting current proxy thumb");
                     }
+                    e.printStackTrace();
+                }
 
-                    v8Inspector.waitForDebugger(shouldBreak);
-                } catch (IOException e) {
+                String nativeLibDir = null;
+                try {
+                    nativeLibDir = app.getPackageManager().getApplicationInfo(appName, 0).nativeLibraryDir;
+                } catch (android.content.pm.PackageManager.NameNotFoundException e) {
+                    e.printStackTrace();
+                }
+
+                boolean isDebuggable = Util.isDebuggableApp(app);
+                StaticConfiguration config = new StaticConfiguration(logger, appName, nativeLibDir, rootDir,
+                        appDir, classLoader, dexDir, dexThumb, appConfig, isDebuggable);
+
+                runtime = Runtime.initializeRuntimeWithConfiguration(config);
+                if (isDebuggable) {
+                    try {
+                        v8Inspector = new AndroidJsV8Inspector(app.getFilesDir().getAbsolutePath(), app.getPackageName());
+                        v8Inspector.start();
+
+                        // the following snippet is used as means to notify the VSCode extension
+                        // debugger that the debugger agent has started
+                        File debuggerStartedFile = new File("/data/local/tmp", app.getPackageName() + "-debugger-started");
+                        if (debuggerStartedFile.exists() && !debuggerStartedFile.isDirectory() && debuggerStartedFile.length() == 0) {
+                            java.io.FileWriter fileWriter = new java.io.FileWriter(debuggerStartedFile);
+                            fileWriter.write("started");
+                            fileWriter.close();
+                        }
+
+                        // check if --debug-brk flag has been set. If positive:
+                        // write to the file to invalidate the flag
+                        // inform the v8Inspector to pause the main thread
+                        File debugBreakFile = new File("/data/local/tmp", app.getPackageName() + "-debugbreak");
+                        boolean shouldBreak = false;
+                        if (debugBreakFile.exists() && !debugBreakFile.isDirectory() && debugBreakFile.length() == 0) {
+                            java.io.FileWriter fileWriter = new java.io.FileWriter(debugBreakFile);
+                            fileWriter.write("started");
+                            fileWriter.close();
+
+                            shouldBreak = true;
+                        }
+
+                        v8Inspector.waitForDebugger(shouldBreak);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                }
+
+                // runtime needs to be initialized before the NativeScriptSyncService is enabled because it uses runtime.runScript(...)
+                if (NativeScriptSyncService.isSyncEnabled(app)) {
+                    NativeScriptSyncService syncService = new NativeScriptSyncService(runtime, logger, app);
+
+                    syncService.sync();
+                    syncService.startServer();
+
+                    // preserve this instance as strong reference
+                    // do not preserve in NativeScriptApplication field inorder to
+                    // make the code more portable
+                    // @@@
+                    // Runtime.getOrCreateJavaObjectID(syncService);
+                } else {
+                    if (logger.isEnabled()) {
+                        logger.write("NativeScript LiveSync is not enabled.");
+                    }
+                }
+
+                runtime.runScript(new File(appDir, "internal/ts_helpers.js"));
+
+                File javaClassesModule = new File(appDir, "app/tns-java-classes.js");
+                if (javaClassesModule.exists()) {
+                    runtime.runModule(javaClassesModule);
+                }
+
+                try {
+                    // put this call in a try/catch block because with the latest changes in the modules it is not granted that NativeScriptApplication is extended through JavaScript.
+                    JavaScriptImplementation jsImpl = app.getClass().getAnnotation(JavaScriptImplementation.class);
+                    if (jsImpl != null) {
+                        Runtime.initInstance(app);
+                    }
+                } catch (Exception e) {
+                    if (logger.isEnabled()) {
+                        logger.write("Cannot initialize application instance.");
+                    }
                     e.printStackTrace();
                 }
             }
-
-            // runtime needs to be initialized before the NativeScriptSyncService is enabled because it uses runtime.runScript(...)
-            if (NativeScriptSyncService.isSyncEnabled(app)) {
-                NativeScriptSyncService syncService = new NativeScriptSyncService(runtime, logger, app);
-
-                syncService.sync();
-                syncService.startServer();
-
-                // preserve this instance as strong reference
-                // do not preserve in NativeScriptApplication field inorder to
-                // make the code more portable
-                // @@@
-                // Runtime.getOrCreateJavaObjectID(syncService);
-            } else {
-                if (logger.isEnabled()) {
-                    logger.write("NativeScript LiveSync is not enabled.");
-                }
-            }
-
-            runtime.runScript(new File(appDir, "internal/ts_helpers.js"));
-
-            File javaClassesModule = new File(appDir, "app/tns-java-classes.js");
-            if (javaClassesModule.exists()) {
-                runtime.runModule(javaClassesModule);
-            }
-
-            try {
-                // put this call in a try/catch block because with the latest changes in the modules it is not granted that NativeScriptApplication is extended through JavaScript.
-                JavaScriptImplementation jsImpl = app.getClass().getAnnotation(JavaScriptImplementation.class);
-                if (jsImpl != null) {
-                    Runtime.initInstance(app);
-                }
-            } catch (Exception e) {
-                if (logger.isEnabled()) {
-                    logger.write("Cannot initialize application instance.");
-                }
-                e.printStackTrace();
-            }
+            return runtime;
+        } finally {
+            frame.close();
         }
-        return runtime;
     }
 
     private static final String logTag = "MyApp";

--- a/test-app/app/src/main/java/com/tns/RuntimeHelper.java
+++ b/test-app/app/src/main/java/com/tns/RuntimeHelper.java
@@ -119,14 +119,7 @@ public final class RuntimeHelper {
                 }
 
                 AppConfig appConfig = new AppConfig(appDir);
-                switch (appConfig.getProfilingMode()) {
-                    case "timeline":
-                        ManualInstrumentation.setMode(ManualInstrumentation.Mode.Timeline);
-                        break;
-                    default:
-                        ManualInstrumentation.setMode(ManualInstrumentation.Mode.Disabled);
-                }
-                Runtime.SetManualInstrumentationMode(appConfig.getProfilingMode());
+                ManualInstrumentation.setMode(appConfig.getProfilingMode());
 
                 ClassLoader classLoader = app.getClassLoader();
                 File dexDir = new File(rootDir, "code_cache/secondary-dexes");


### PR DESCRIPTION
Setting in app/package.json a:
```
{
  "main": "main.js",
  "profiling": "timeline"
}
```
Will enable tracing of slow manually instrumented methods.
The facility can trace both java and cpp frames, there is already a matching implementation in the modules. The complete feature lets us profile and trace times in cpp java and js in a single timeline.