### PR TITLE
Normalize anonymous extends file names

### DIFF
--- a/runtime/src/main/jni/CallbackHandlers.cpp
+++ b/runtime/src/main/jni/CallbackHandlers.cpp
@@ -552,7 +552,7 @@ jobjectArray CallbackHandlers::GetImplementedInterfaces(JEnv& env, const Local<O
                         if (element->IsFunction()) {
                             auto node = MetadataNode::GetTypeMetadataName(isolate, element);
 
-                            Util::ReplaceAll(node, std::string("/"), std::string("."));
+                            node = Util::ReplaceAll(node, std::string("/"), std::string("."));
 
                             jstring value = env.NewStringUTF(node.c_str());
                             interfacesToImplement.push_back(value);

--- a/runtime/src/main/jni/MetadataNode.cpp
+++ b/runtime/src/main/jni/MetadataNode.cpp
@@ -1319,7 +1319,6 @@ void MetadataNode::ExtendMethodCallback(const v8::FunctionCallbackInfo<v8::Value
 
         auto isolate = info.GetIsolate();
 
-
         //resolve class (pre-generated or generated runtime from dex generator)
         uint8_t nodeType = s_metadataReader.GetNodeType(node->m_treeNode);
         bool isInterface = s_metadataReader.IsNodeTypeInterface(nodeType);
@@ -1420,6 +1419,9 @@ bool MetadataNode::GetExtendLocation(string& extendLocation) {
             }
 
             string srcFileName = ArgConverter::ConvertToString(scriptName);
+            // trim 'file://' to normalize path to always begin with "/data/"
+            srcFileName = Util::ReplaceAll(srcFileName, "file://", "");
+
             string fullPathToFile;
             if (srcFileName == "<embedded>") {
                 // Corner case, extend call is coming from the heap snapshot script

--- a/runtime/src/main/jni/Util.cpp
+++ b/runtime/src/main/jni/Util.cpp
@@ -89,13 +89,16 @@ string Util::ConvertFromCanonicalToJniName(const std::string& name) {
     return converted;
 }
 
-void Util::ReplaceAll(std::string& str, const std::string& from, const std::string& to) {
+string Util::ReplaceAll(std::string& str, const std::string& from, const std::string& to) {
     if (from.empty()) {
-        return;
+        return str;
     }
+
     size_t start_pos = 0;
     while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
         str.replace(start_pos, from.length(), to);
         start_pos += to.length();
     }
+
+    return str;
 }

--- a/runtime/src/main/jni/Util.h
+++ b/runtime/src/main/jni/Util.h
@@ -18,7 +18,7 @@ class Util {
 
         static std::string ConvertFromCanonicalToJniName(const std::string& name);
 
-        static void ReplaceAll(std::string& str, const std::string& from, const std::string& to);
+        static std::string ReplaceAll(std::string& str, const std::string& from, const std::string& to);
 };
 }
 


### PR DESCRIPTION
When building the java class name of anonymous extended classes through javascript in the [ExtendMethodCallback](https://github.com/NativeScript/android-runtime/blob/d38f4f463ed213a7b79ad2f7a4bbc5df3aa40457/runtime/src/main/jni/MetadataNode.cpp#L1263) source file names would sometimes come with `file://` prepended to them, which would result in a file name different than the one sought after.

The reason the runtime didn't fail mid-flight was because the runtime binding-generator stepped in and generated bindings in place, with the faulty class and file name. 