### PR TITLE
Static Binding Generator small changes

### DIFF
--- a/android-static-binding-generator/project/build.gradle
+++ b/android-static-binding-generator/project/build.gradle
@@ -170,6 +170,9 @@ task runAstParser(type: RunAstParserTask) {
 // 2. all subdirectories that do not have a package.json containing a "nativescript" key are skipped
 task traverseJsFiles () {
 	doFirst {
+		// invalidate previously generated bindings.txt file
+		// todo: remove when removing previously generated bindings is implemented
+		new File(bindingsFileP).delete()
 		traverseDirectory(jsCodeAbsolutePath, false)
 	}
 }

--- a/android-static-binding-generator/project/staticbindinggenerator/src/main/java/org/nativescript/staticbindinggenerator/Generator.java
+++ b/android-static-binding-generator/project/staticbindinggenerator/src/main/java/org/nativescript/staticbindinggenerator/Generator.java
@@ -63,9 +63,9 @@ public class Generator {
                 // Compare text contents for equality
                 String content = new String(Files.readAllBytes(Paths.get(b.getFile().toString())));
                 if (content.equals(b.getContent())) {
-                    System.out.println("Warning: File already exists. This could mean the same code has been parsed more than once from two or more different files.");
+                    System.out.println("Warning: File already exists. This could mean the same code has been parsed more than once from two or more different files. \nFile:" + b.getFile());
                 } else {
-                    throw new IOException("File already exists. This may lead to undesired behavior.\nPlease change the name of one of the extended classes.\n" + b.getFile());
+                    throw new IOException("File already exists. This may lead to undesired behavior.\nPlease change the name of one of the extended classes.\nFile:" + b.getFile() + " Class: " + b.getClassname());
                 }
             }
         }


### PR DESCRIPTION
The PR comprises the following changes:
 - make the warning message and the error thrown (when a generated class already exists) more verbose;
 - delete the `bindings.txt` file on every build until incremental parsing of the javascript and dynamic class generation is properly implemented