### PR TITLE
Plamen5kov/improve gradle logging

### DIFF
--- a/android-static-binding-generator/project/build.gradle
+++ b/android-static-binding-generator/project/build.gradle
@@ -238,6 +238,9 @@ class RunAstParserTask extends DefaultTask {
 		list.add(interfaceNamesFilePath)
 		list.add(jsFilesParametersPath)
 
+		if(project.gradle.startParameter.logLevel.equals(LogLevel.DEBUG)) {
+			list.add("enableVerboseLogging")
+		}
 		logger.info("Task: RunAstParserTask: running node with arguments: " + list.toString().replaceAll(',', ''))
 		runCommand(list)
 

--- a/android-static-binding-generator/project/build.gradle
+++ b/android-static-binding-generator/project/build.gradle
@@ -67,6 +67,8 @@ task generateInterfaceNamesList() {
 					str.add("interfacenamegenerator.jar")
 					str.addAll(jarsArr)
 
+					logger.info("Task: generateInterfaceNamesList: Call interfacenamegenerator.jar with arguments: " + str.toString().replaceAll(',', ''))
+
 					args str.toArray()
 				}
 				java.nio.file.Files.write(java.nio.file.Paths.get(cachedJarsFilePath), [current.toString()], utf8)
@@ -99,7 +101,7 @@ traverseDirectory = { dir, traverseExplicitly ->
 				return;
 			} else {
 				if (pjson.nativescript['recursive-static-bindings']) {
-					// println "Folder will be traversed completely: " + dir
+					logger.info("Task: traverseDirectory: Folder will be traversed completely: " + dir)
 					traverseExplicitly = true;
 				}
 			}
@@ -113,7 +115,7 @@ traverseDirectory = { dir, traverseExplicitly ->
 	currentDir.eachFile(FileType.FILES) { File f ->
 		def file = f.getAbsolutePath();
 		if (file.substring(file.length() - 3, file.length()).equals(".js")) {
-			// println "Visiting JavaScript file: " + f.getName()
+			logger.info("Task: traverseDirectory: Visiting JavaScript file: " + f.getName())
 			inputJsFiles.add(f.getAbsolutePath())
 		}
 	}
@@ -140,6 +142,7 @@ task traverseJsFilesArgs << { //(jsCodeDir, bindingsFilePath, interfaceNamesFile
 	list.add(interfaceNamesFilePath)
 	list.add(jsFilesParameter)
 
+	logger.info("Task: traverseJsFilesArgs: executed with arguments: " + list.toString().replaceAll(',', ''))
 	def proc = list.execute()
 	proc.in.eachLine { line -> println line }
 	proc.out.close()
@@ -235,6 +238,7 @@ class RunAstParserTask extends DefaultTask {
 		list.add(interfaceNamesFilePath)
 		list.add(jsFilesParametersPath)
 
+		logger.info("Task: RunAstParserTask: running node with arguments: " + list.toString().replaceAll(',', ''))
 		runCommand(list)
 
 		// inputs.removed { change ->
@@ -263,6 +267,7 @@ task generateBindings() {
 			def jarsArr = jarsAsStr.replaceAll(/[\[\]]/, "").split(", ")
 			str.addAll(jarsArr)
 
+			logger.info("Task generateBindings: Call staticbindinggenerator.jar with arguments: " + str.toString().replaceAll(',', ''))
 			args str.toArray()
 		}
 	}

--- a/android-static-binding-generator/project/parser/js_parser.js
+++ b/android-static-binding-generator/project/parser/js_parser.js
@@ -10,6 +10,12 @@ if (process.env.AST_PARSER_DISABLE_LOGGING && process.env.AST_PARSER_DISABLE_LOG
 	disableLogger = false;
 }
 
+var 	arguments = process.argv;
+if (arguments && arguments.length) {
+	if(arguments[arguments.length - 1] == "enableVerboseLogging") {
+		disableLogger = false
+	}
+}
 loggingSettings = {
 	"logPath": require("path").dirname(require.main.filename) + "/logs/i.txt",
 	"strategy": "console",
@@ -29,7 +35,6 @@ var fs = require("fs"),
 	lazy = require("lazy"),
 	eol = require('os').EOL,
 
-	arguments = process.argv,
 	appDir = path.dirname(require.main.filename),
 	extendDecoratorName = "JavaProxy",
 	interfacesDecoratorName = "Interfaces",

--- a/android-static-binding-generator/project/parser/js_parser.js
+++ b/android-static-binding-generator/project/parser/js_parser.js
@@ -222,7 +222,6 @@ var readFile = function (filePath, err) {
 				return reject(err);
 			}
 
-			logger.info("+got content of file!");
 			var fileInfo = {
 				filePath: filePath,
 				data: data.toString()
@@ -241,8 +240,6 @@ var astFromFileContent = function (data, err) {
 			logger.warn("+DIDN'T parse ast from file!");
 			return reject(err);
 		}
-
-		logger.info("+parsing ast from file!");
 
 		var ast = babelParser.parse(data.data, {
 			minify: false,

--- a/build-artifacts/project-template-gradle/build.gradle
+++ b/build-artifacts/project-template-gradle/build.gradle
@@ -593,7 +593,7 @@ task collectAllJars {
 	
 	doFirst {
 		configurations.compile.each { File dependencyFile ->
-			// println "\t+" + dependencyFile.getAbsolutePath()
+			logger.info("Task: collectAllJars: dependency file: " + dependencyFile.getAbsolutePath())
 			allJarPaths.add(dependencyFile.getAbsolutePath())
 		}
 		
@@ -651,6 +651,8 @@ task buildMetadata (type: JavaExec) {
 
 		workingDir "build-tools"
 		main "-jar"
+
+		logger.info("Task buildMetadata: Call metadata-generator.jar with arguments: " + metadataParams.toString().replaceAll(',', ''))
 		args metadataParams.toArray()
 	}
 	
@@ -686,6 +688,7 @@ task generateTypescriptDefinitions (type: JavaExec) {
 		paramz.add("-output");
 		paramz.add("typings");
 
+		logger.info("Task generateTypescriptDefinitions: Call dts-generator.jar with arguments: " + paramz.toString().replaceAll(',', ''))
 		args paramz.toArray();
 	}
 }
@@ -762,7 +765,7 @@ task buildapk {
 	// problem is compile dependencies need to be changed before configuration stage
 	// and this is the only way so far
 	tasks.copyAarDependencies.execute()
-    tasks.addAarDependencies.execute()
+	tasks.addAarDependencies.execute()
 
 	//done to build only necessary apk
 	if(project.hasProperty("release")) {


### PR DESCRIPTION
_problem_
Ofter there's not enough build information although user runs command `tns run/build/ android --log trace`

_solution_
Add more logs when --debug flag is passed with cli.
The `--debug` flag that's passed to gradle propagates through the projects and enables verbose of the custom projects like `static binding generator` and `js parser`.