### PR TITLE
Plamen5kov/improve interface generator

### DIFF
--- a/android-metadata-generator/.gitignore
+++ b/android-metadata-generator/.gitignore
@@ -1,2 +1,10 @@
 /src/jars/
 /src/com/
+/build
+*.iml
+.gradle
+/local.properties
+/.idea
+!/.idea/misc.xml
+/a
+!.gitignore

--- a/android-static-binding-generator/project/interface-name-generator/src/main/java/com/ig/GetInterfaceNames.java
+++ b/android-static-binding-generator/project/interface-name-generator/src/main/java/com/ig/GetInterfaceNames.java
@@ -62,8 +62,9 @@ public class GetInterfaceNames
                 try {
                     c = cl.loadClass(className);
                 }
-                catch (NoClassDefFoundError localNoClassDefFoundError)
-                {
+                catch (IllegalAccessError e) {
+                }
+                catch (NoClassDefFoundError localNoClassDefFoundError) {
                 }
                 if ((c != null) && (c.isInterface() == true)) {
                     String res = c.getName().replace('$', '.');


### PR DESCRIPTION
_problem_
In Java, you can't load a private class when loaded in different class loader. The thrown exception is: `IllegalAccessError`.

_solution_
Because we use it only for generating metadata, we can work around the problem by skipping it, like we do with `NoClassDefFoundError`. This will allow users to continue their work with the problem plugins.
>This is only a temporary work around so the users can continue their work ... we should figure out what's with the plugins requesting specific Android jars from the gradle cache.

_related issue_
https://github.com/NativeScript/android-runtime/issues/755
