### PR TITLE
Add warning for difference of application identifier.

### DIFF
--- a/build-artifacts/project-template-gradle/build.gradle
+++ b/build-artifacts/project-template-gradle/build.gradle
@@ -721,6 +721,26 @@ copyTypings.onlyIf({
 	generateTypescriptDefinitions.didWork;
 })
 
+task validateAppIdMatch {
+	doLast {
+		def packageJsonFile = new File("$projectDir/../../package.json");
+		def lineSeparator = System.getProperty("line.separator");
+
+		if (packageJsonFile.exists()) {
+			String content = packageJsonFile.getText("UTF-8")
+			def jsonSlurper = new JsonSlurper()
+			def packageJsonMap = jsonSlurper.parseText(content)
+
+			if (packageJsonMap.nativescript.id != android.defaultConfig.applicationId) {
+				def errorMessage = "${lineSeparator}WARNING: The Application identifier is different from the one inside 'package.json' file.$lineSeparator" +
+					"NativeScript CLI might not work properly.$lineSeparator" +
+					"Update the application identifier in package.json and app.gradle so that they match.";
+				logger.error(errorMessage);
+			}
+		}
+	}
+}
+
 ////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////// OPTIONAL TASKS //////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////
@@ -801,6 +821,7 @@ task deleteGeneratedBindings(type: Delete) {
 	delete "$projectDir/src/main/java/com/tns/gen"
 }
 
+buildapk.finalizedBy("validateAppIdMatch");
 deleteMetadata.dependsOn(":asbg:clean")
 deleteFlavors.dependsOn(deleteMetadata)
 deleteConfigurations.dependsOn(deleteFlavors)

--- a/build-artifacts/project-template-gradle/build.gradle
+++ b/build-artifacts/project-template-gradle/build.gradle
@@ -726,7 +726,7 @@ task validateAppIdMatch {
 		def packageJsonFile = new File("$projectDir/../../package.json");
 		def lineSeparator = System.getProperty("line.separator");
 
-		if (packageJsonFile.exists()) {
+		if (packageJsonFile.exists() && !project.hasProperty("release")) {
 			String content = packageJsonFile.getText("UTF-8")
 			def jsonSlurper = new JsonSlurper()
 			def packageJsonMap = jsonSlurper.parseText(content)


### PR DESCRIPTION
### Description
User can change the application identifier inside his app.gradle file, but NativeScript LiveSync works with the one inside package.json. This causes the NativeScript CLI to not work as expected.

### Does your commit message include the wording below to reference a specific issue in this repo?
<!--Fixes/Implements #[Issue Number]. -->
Fixes https://github.com/NativeScript/nativescript-cli/issues/2825

### Related Pull Requests
<!-- List links related to this Pull Request from other repos/branches: -->
https://github.com/NativeScript/nativescript-cli/pull/3033

### Does your pull request have [unit tests](https://github.com/NativeScript/NativeScript/blob/master/running-tests.md)?
<!--If not, why?
If not, please tell us why tests are not included, and list all steps needed to test your pull request manually. -->
Steps to tests.

1. tns create testApp
2. tns platform add android
3. Edit applicationId iniside app/AppResources/Android/app.gradle.
4. tns build android


