### PR TITLE
runtime doesn't try to delete /data/local/tmp/ folder anymore

### DIFF
--- a/build-artifacts/project-template-gradle/build.gradle
+++ b/build-artifacts/project-template-gradle/build.gradle
@@ -208,8 +208,6 @@ dependencies {
 	if(project.hasProperty("supportVersion")) {
 		supportVer = supportVersion
 	}
-	
-        debugCompile group: 'commons-io', name: 'commons-io', version: '2.0.1'
 
 	compile "com.android.support:support-v4:$supportVer"
 	compile "com.android.support:appcompat-v7:$supportVer"

--- a/build-artifacts/project-template-gradle/src/debug/java/com/tns/NativeScriptSyncService.java
+++ b/build-artifacts/project-template-gradle/src/debug/java/com/tns/NativeScriptSyncService.java
@@ -61,18 +61,15 @@ public class NativeScriptSyncService {
 
         if (fullSyncDir.exists()) {
             executeFullSync(context, fullSyncDir);
-            deleteRecursive(fullSyncDir);
             return;
         }
 
         if (syncDir.exists()) {
             executePartialSync(context, syncDir);
-            deleteRecursive(syncDir);
         }
 
         if (removedSyncDir.exists()) {
             executeRemovedSync(context, removedSyncDir);
-            deleteRecursive(removedSyncDir);
         }
     }
 
@@ -128,11 +125,7 @@ public class NativeScriptSyncService {
                 int length = input.readInt();
                 input.readFully(new byte[length]); // ignore the payload
                 executePartialSync(context, syncDir);
-                // delete temporary /sync dir after syncing .xml/.css resources
-                deleteRecursive(syncDir);
                 executeRemovedSync(context, removedSyncDir);
-                // delete temporary /removedsync dir after removing files from the project
-                deleteRecursive(removedSyncDir);
 
                 runtime.runScript(new File(NativeScriptSyncService.this.context.getFilesDir(), "internal/livesync.js"));
                 try {
@@ -151,14 +144,6 @@ public class NativeScriptSyncService {
         localServerThread = new LocalServerSocketThread(context.getPackageName() + "-livesync");
         localServerJavaThread = new Thread(localServerThread);
         localServerJavaThread.start();
-    }
-
-    private void deleteRecursive(File fileOrDirectory) {
-        try {
-            org.apache.commons.io.FileUtils.deleteDirectory(fileOrDirectory);
-        } catch (IOException e) {
-            android.util.Log.d("Sync", e.toString());
-        }
     }
 
     public static boolean isSyncEnabled(Context context) {

--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -399,10 +399,6 @@ model {
     }
 }
 
-dependencies {
-    compile group: 'commons-io', name: 'commons-io', version: '2.0.1'
-}
-
 if (project.hasProperty("embedBindingGenerator")) {
     dependencies {
         compile fileTree(dir: (project(':binding-generator').buildDir.toString() + "/libs"), include: ['*.jar'])

--- a/test-app/app/src/main/java/com/tns/NativeScriptSyncService.java
+++ b/test-app/app/src/main/java/com/tns/NativeScriptSyncService.java
@@ -61,18 +61,15 @@ public class NativeScriptSyncService {
 
         if (fullSyncDir.exists()) {
             executeFullSync(context, fullSyncDir);
-            deleteRecursive(fullSyncDir);
             return;
         }
 
         if (syncDir.exists()) {
             executePartialSync(context, syncDir);
-            deleteRecursive(syncDir);
         }
 
         if (removedSyncDir.exists()) {
             executeRemovedSync(context, removedSyncDir);
-            deleteRecursive(removedSyncDir);
         }
     }
 
@@ -128,11 +125,7 @@ public class NativeScriptSyncService {
                 int length = input.readInt();
                 input.readFully(new byte[length]); // ignore the payload
                 executePartialSync(context, syncDir);
-                // delete temporary /sync dir after syncing .xml/.css resources
-                deleteRecursive(syncDir);
                 executeRemovedSync(context, removedSyncDir);
-                // delete temporary /removedsync dir after removing files from the project
-                deleteRecursive(removedSyncDir);
 
                 runtime.runScript(new File(NativeScriptSyncService.this.context.getFilesDir(), "internal/livesync.js"));
                 try {
@@ -151,14 +144,6 @@ public class NativeScriptSyncService {
         localServerThread = new LocalServerSocketThread(context.getPackageName() + "-livesync");
         localServerJavaThread = new Thread(localServerThread);
         localServerJavaThread.start();
-    }
-
-    private void deleteRecursive(File fileOrDirectory) {
-        try {
-            org.apache.commons.io.FileUtils.deleteDirectory(fileOrDirectory);
-        } catch (IOException e) {
-            android.util.Log.d("Sync", e.toString());
-        }
     }
 
     public static boolean isSyncEnabled(Context context) {


### PR DESCRIPTION
_problem_
The app doesn't have permissions to delete anything from `/data/local/tmp` folder.

_solution_
The actual solution is in [this PR](https://github.com/NativeScript/nativescript-cli/pull/3027) and we need to remove the attempt to delete files from the runtime as a consequence.

Don't merge before: https://github.com/NativeScript/nativescript-cli/pull/3027