### PR TITLE
Clear pointers to deallocated memory. Add better marshaling error messages

### DIFF
--- a/runtime/src/main/jni/CallbackHandlers.cpp
+++ b/runtime/src/main/jni/CallbackHandlers.cpp
@@ -317,8 +317,11 @@ void CallbackHandlers::CallJavaMethod(const Local<Object>& caller, const string&
         callerJavaObject = objectManager->GetJavaObjectByJsObject(caller);
         if (callerJavaObject.IsNull()) {
             stringstream ss;
-            ss << "No java object found on which to call \"" << methodName <<
-               "\" method. It is possible your Javascript object is not linked with the corresponding Java class. Try passing context(this) to the constructor function.";
+            if (args.IsConstructCall()) {
+                ss << "No java object found on which to call \"" << methodName << "\" method. It is possible your Javascript object is not linked with the corresponding Java class. Try passing context(this) to the constructor function.";
+            } else {
+                ss << "Failed calling " << methodName << " on a " << className << " instance. The JavaScript instance no longer has available Java instance counterpart.";
+            }
             throw NativeScriptException(ss.str());
         }
     }

--- a/runtime/src/main/jni/JsArgToArrayConverter.cpp
+++ b/runtime/src/main/jni/JsArgToArrayConverter.cpp
@@ -263,7 +263,8 @@ bool JsArgToArrayConverter::ConvertArg(const Local<Value>& arg, int index) {
             if (success) {
                 SetConvertedObject(env, index, obj.Move(), obj.IsGlobal());
             } else {
-                s << "Cannot convert JavaScript object with id " << jsObj->GetIdentityHash() << " at index " << index;
+                String::Utf8Value jsObjStr(jsObj);
+                s << "Cannot marshal JavaScript argument " << (*jsObjStr ? *jsObjStr : "<failed-to-string>") << " at index " << index << " to Java type.";
             }
             break;
 
@@ -274,7 +275,7 @@ bool JsArgToArrayConverter::ConvertArg(const Local<Value>& arg, int index) {
         SetConvertedObject(env, index, nullptr);
         success = true;
     } else {
-        s << "Cannot convert JavaScript object at index " << index;
+        s << "Cannot marshal JavaScript argument at index " << index << " to Java type.";
         success = false;
     }
 

--- a/runtime/src/main/jni/ObjectManager.cpp
+++ b/runtime/src/main/jni/ObjectManager.cpp
@@ -329,6 +329,7 @@ void ObjectManager::ReleaseJSInstance(Persistent<Object>* po, JSInstanceInfo* js
     m_idToObject.erase(it);
     m_released.insert(po, javaObjectID);
     po->Reset();
+
     delete po;
     delete jsInstanceInfo;
 


### PR DESCRIPTION
In case the MarkReachableObjects is perfect regular instances will be reachable from implementation object and won't be released. However sometime ago several issues were reported that tried to find Java object by weird ids (big negative numbers). When working with the MarkReachableObjects suppressed I managed to crash with the same message, it turned out we have deleted the JSInstanceInfo* but the JavaScript instances were still keeping an External ref to the deleted memory. This External will now be cleared with undefined. And the messaging will be somewhat better.

Further the above error surfaced in the wrong place, the error reported was referring Java calling an overridden method that throws, but instead the JavaScript implementation of this method was catching a JavaScript exception, raised due problems with marshalling. This will now print index and toString of the argument that fails conversion and file and line numbers.