### PR TITLE
Fix v8 GC Crash caused by incorrect usage of the internal V8 API

### DIFF
--- a/runtime/src/main/jni/ObjectManager.cpp
+++ b/runtime/src/main/jni/ObjectManager.cpp
@@ -109,7 +109,7 @@ ObjectManager::JSInstanceInfo* ObjectManager::GetJSInstanceInfo(const Local<Obje
 }
 
 bool ObjectManager::IsJsRuntimeObject(const v8::Local<v8::Object>& object) {
-    int internalFieldCount = NativeScriptExtension::GetInternalFieldCount(object);
+    int internalFieldCount = object->InternalFieldCount();
     const int count = static_cast<int>(MetadataNodeKeys::END);
     return internalFieldCount == count;
 }

--- a/runtime/src/main/jni/include/V8NativeScriptExtension.h
+++ b/runtime/src/main/jni/include/V8NativeScriptExtension.h
@@ -14,6 +14,10 @@ namespace v8 {
 
 		static v8::Local<v8::Array> GetPropertyKeys(v8::Isolate *isolate, const v8::Local<v8::Context>& context, const v8::Local<v8::Object>& object, bool& success);
 
+		/*
+		 * Deprecated. Use V8 Object.InternalFieldCount() instead.
+		 * TODO: Pete: remove in following 6.x update
+		 */
 		static int GetInternalFieldCount(const v8::Local<v8::Object>& object);
 
         static void CpuFeaturesProbe(bool cross_compile);


### PR DESCRIPTION
PR comprises of:
- deprecate V8Extension GetInternalFieldCount and use V8 Object's InternalFieldCount API

- fix crash after V8 GC was finished when incorrectly using the GetInternalFieldCount failed to resolve the JS Object

Should address crashes as found and described in https://github.com/rigor789/nativescript-vue/issues/32