### PR TITLE
on livesync delete empty folders on exit

### DIFF
--- a/build-artifacts/project-template-gradle/src/debug/java/com/tns/NativeScriptSyncService.java
+++ b/build-artifacts/project-template-gradle/src/debug/java/com/tns/NativeScriptSyncService.java
@@ -278,6 +278,8 @@ public class NativeScriptSyncService {
                     targetFile.delete();
                 } else {
                     deleteRemovedFiles(file, sourceRootAbsolutePath, targetRootAbsolutePath);
+
+                    // this is done so empty folders, if any, are deleted after we're don deleting files.
                     if (targetFile.listFiles().length == 0) {
                         targetFile.delete();
                     }

--- a/build-artifacts/project-template-gradle/src/debug/java/com/tns/NativeScriptSyncService.java
+++ b/build-artifacts/project-template-gradle/src/debug/java/com/tns/NativeScriptSyncService.java
@@ -268,16 +268,19 @@ public class NativeScriptSyncService {
         if (files != null) {
             for (int i = 0; i < files.length; i++) {
                 File file = files[i];
+                String targetFilePath = file.getAbsolutePath().replace(sourceRootAbsolutePath, targetRootAbsolutePath);
+                File targetFile = new File(targetFilePath);
                 if (file.isFile()) {
                     if (logger.isEnabled()) {
                         logger.write("Syncing removed file: " + file.getAbsolutePath().toString());
                     }
 
-                    String targetFilePath = file.getAbsolutePath().replace(sourceRootAbsolutePath, targetRootAbsolutePath);
-                    File targetFile = new File(targetFilePath);
                     targetFile.delete();
                 } else {
                     deleteRemovedFiles(file, sourceRootAbsolutePath, targetRootAbsolutePath);
+                    if (targetFile.listFiles().length == 0) {
+                        targetFile.delete();
+                    }
                 }
             }
         }

--- a/test-app/app/src/main/java/com/tns/NativeScriptSyncService.java
+++ b/test-app/app/src/main/java/com/tns/NativeScriptSyncService.java
@@ -278,6 +278,8 @@ public class NativeScriptSyncService {
                     targetFile.delete();
                 } else {
                     deleteRemovedFiles(file, sourceRootAbsolutePath, targetRootAbsolutePath);
+
+                    // this is done so empty folders, if any, are deleted after we're don deleting files.
                     if (targetFile.listFiles().length == 0) {
                         targetFile.delete();
                     }

--- a/test-app/app/src/main/java/com/tns/NativeScriptSyncService.java
+++ b/test-app/app/src/main/java/com/tns/NativeScriptSyncService.java
@@ -268,16 +268,19 @@ public class NativeScriptSyncService {
         if (files != null) {
             for (int i = 0; i < files.length; i++) {
                 File file = files[i];
+                String targetFilePath = file.getAbsolutePath().replace(sourceRootAbsolutePath, targetRootAbsolutePath);
+                File targetFile = new File(targetFilePath);
                 if (file.isFile()) {
                     if (logger.isEnabled()) {
                         logger.write("Syncing removed file: " + file.getAbsolutePath().toString());
                     }
 
-                    String targetFilePath = file.getAbsolutePath().replace(sourceRootAbsolutePath, targetRootAbsolutePath);
-                    File targetFile = new File(targetFilePath);
                     targetFile.delete();
                 } else {
                     deleteRemovedFiles(file, sourceRootAbsolutePath, targetRootAbsolutePath);
+                    if (targetFile.listFiles().length == 0) {
+                        targetFile.delete();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Runtime deletes unnecessary folders on livesync

_problem_
When CLI livesyncs,  android runtime needs to remove old files and it does, but it leaves empty folders

_solution_
check if folders are empty on exit and delete if so