### PR TITLE
Filter out webpacked workers before parsing the scripts in the ASBG

### DIFF
--- a/android-static-binding-generator/project/build.gradle
+++ b/android-static-binding-generator/project/build.gradle
@@ -15,17 +15,17 @@ def jsParserP = "$projectDir/parser/js_parser.js"
 def jsFilesParametersP = "$projectDir/jsFilesParameters.txt"
 
 def webpackWorkersExcludePath = "$projectDir/../../src/main/assets/app/__worker-chunks.json"
-def webpackWorkersExcludesList;
+def webpackWorkersExcludesList = [];
 
 def workersExcludeFile = file(webpackWorkersExcludePath);
-def filterWorkerFiles = false;
 if (workersExcludeFile.exists()) {
-	filterWorkerFiles = true;
-	webpackWorkersExcludesList = new JsonSlurper().parseText(workersExcludeFile.text)
+	// in case the file exists but is malformed
+	try {
+		webpackWorkersExcludesList = new JsonSlurper().parseText(workersExcludeFile.text)
+	} catch (all) {
+		println "Malformed workers exclude file at ${webpackWorkersExcludePath}"
+	}
 }
-
-
-//def absoluteOutDir = new File("./outDir")//project.outDir
 
 def absoluteOutDir;
 if (project.hasProperty("outDir")) {
@@ -123,15 +123,7 @@ traverseDirectory = { dir, traverseExplicitly ->
 
 	currentDir.eachFile(FileType.FILES) { File f ->
 		def currFile = f.getAbsolutePath();
-		if (currFile.substring(currFile.length() - 3, currFile.length()).equals(".js")) {
-			// Read __worker-chunks.json file containing a list of webpacked workers
-			// ignore worker scripts, so as to not attempt to generate bindings for them
-			if (filterWorkerFiles) {
-				if (webpackWorkersExcludesList.any{element -> file(element).getAbsolutePath() == currFile}) {
-					return
-				}
-			}
-
+		if (isJsFile(currFile) && !isWorkerScript(currFile)) {
 			inputJsFiles.add(currFile)
 		}
 	}
@@ -139,6 +131,15 @@ traverseDirectory = { dir, traverseExplicitly ->
 	currentDir.eachFile FileType.DIRECTORIES, { d ->
 		traverseDirectory(d.getAbsolutePath(), traverseExplicitly)
 	}
+}
+
+def isJsFile = { fileName ->  return fileName.substring(fileName.length() - 3, fileName.length()).equals(".js") 
+}
+
+def isWorkerScript = { fileName -> 
+	// Read __worker-chunks.json file containing a list of webpacked workers
+	// ignore worker scripts, so as to not attempt to generate bindings for them
+	return webpackWorkersExcludesList.any{element -> file(element).getAbsolutePath() == fileName}
 }
 
 task traverseJsFilesArgs << { //(jsCodeDir, bindingsFilePath, interfaceNamesFilePath, jsParserPath, jsFilesParameter) {

--- a/android-static-binding-generator/project/build.gradle
+++ b/android-static-binding-generator/project/build.gradle
@@ -14,6 +14,15 @@ def cachedJarsFilePath = "$projectDir/cached.txt"
 def jsParserP = "$projectDir/parser/js_parser.js"
 def jsFilesParametersP = "$projectDir/jsFilesParameters.txt"
 
+def webpackWorkersExcludePath = "$projectDir/../../src/main/assets/app/__worker-chunks.json"
+def webpackWorkersExcludesList;
+
+def workersExcludeFile = file(webpackWorkersExcludePath);
+def filterWorkerFiles = false;
+if (workersExcludeFile.exists()) {
+	filterWorkerFiles = true;
+	webpackWorkersExcludesList = new JsonSlurper().parseText(workersExcludeFile.text)
+}
 
 
 //def absoluteOutDir = new File("./outDir")//project.outDir
@@ -113,10 +122,17 @@ traverseDirectory = { dir, traverseExplicitly ->
 	}
 
 	currentDir.eachFile(FileType.FILES) { File f ->
-		def file = f.getAbsolutePath();
-		if (file.substring(file.length() - 3, file.length()).equals(".js")) {
-			logger.info("Task: traverseDirectory: Visiting JavaScript file: " + f.getName())
-			inputJsFiles.add(f.getAbsolutePath())
+		def currFile = f.getAbsolutePath();
+		if (currFile.substring(currFile.length() - 3, currFile.length()).equals(".js")) {
+			// Read __worker-chunks.json file containing a list of webpacked workers
+			// ignore worker scripts, so as to not attempt to generate bindings for them
+			if (filterWorkerFiles) {
+				if (webpackWorkersExcludesList.any{element -> file(element).getAbsolutePath() == currFile}) {
+					return
+				}
+			}
+
+			inputJsFiles.add(currFile)
 		}
 	}
 


### PR DESCRIPTION
**Problem:**
As explained in https://github.com/NativeScript/android-runtime/issues/778 - webpack will bundle essential code inside the worker chunks, and that will cause the static binding generator's parser to traverse and generate the same classes as many times as there are workers. The logic in the ASBG prevents a class with the same name from being generated more than once to guarantee predictable runtime behavior, and will crash build-time. 

**Proposed Solution:**
Read a list of the worker scripts output by the webpack worker loader, and exclude the script chunks from being javascript-parsed. Should there be extending of classes the runtime binding generator will take care of handling it the first time per app installation.

**Depends on** a custom implementation of the worker-loader, and existing webpack user configurations importing the custom plugin.

**Addresses**: #778