### PR TITLE
Marking mode none

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ bin/
 .project
 .DS_Store
 .settings
+
+build-artifacts/

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ bin/
 .svn/
 
 **/.vscode/
+
+.project
+.DS_Store
+.settings

--- a/runtime/src/main/java/com/tns/AppConfig.java
+++ b/runtime/src/main/java/com/tns/AppConfig.java
@@ -18,20 +18,7 @@ class AppConfig {
         MemoryCheckInterval("memoryCheckInterval", 0),
         FreeMemoryRatio("freeMemoryRatio", 0.0),
         Profiling("profiling", ""),
-        MarkingMode("markingMode", "Full");
-
-        public static final KnownKeys[] asArray = {
-            V8FlagsKey,
-            CodeCacheKey,
-            HeapSnapshotScriptKey,
-            SnapshotFile,
-            ProfilerOutputDirKey,
-            GcThrottleTime,
-            MemoryCheckInterval,
-            FreeMemoryRatio,
-            Profiling,
-            MarkingMode
-        };
+        MarkingMode("markingMode", com.tns.MarkingMode.values()[0]);
 
         private final String name;
         private final Object defaultValue;
@@ -44,18 +31,8 @@ class AppConfig {
         public String getName() {
             return name;
         }
-
         public Object getDefaultValue() {
             return defaultValue;
-        }
-
-        int getIndex() {
-            for (int i=0; i<asArray.length; i++) {
-                if (asArray[i] == this) {
-                    return i;
-                }
-            }
-            return -1;
         }
     }
 
@@ -75,21 +52,21 @@ class AppConfig {
         try {
             rootObject = FileSystem.readJSONFile(packageInfo);
             if (rootObject != null) {
-                if (rootObject.has(KnownKeys.Profiling.getName())) {
+                if (rootObject.has(KnownKeys.Profiling.name())) {
                     String profiling = rootObject.getString(KnownKeys.Profiling.getName());
-                    values[KnownKeys.Profiling.getIndex()] = profiling;
+                    values[KnownKeys.Profiling.ordinal()] = profiling;
                 }
                 if (rootObject.has(AndroidKey)) {
                     JSONObject androidObject = rootObject.getJSONObject(AndroidKey);
                     if (androidObject.has(KnownKeys.V8FlagsKey.getName())) {
-                        values[KnownKeys.V8FlagsKey.getIndex()] = androidObject.getString(KnownKeys.V8FlagsKey.getName());
+                        values[KnownKeys.V8FlagsKey.ordinal()] = androidObject.getString(KnownKeys.V8FlagsKey.getName());
                     }
                     if (androidObject.has(KnownKeys.CodeCacheKey.getName())) {
-                        values[KnownKeys.CodeCacheKey.getIndex()] = androidObject.getBoolean(KnownKeys.CodeCacheKey.getName());
+                        values[KnownKeys.CodeCacheKey.ordinal()] = androidObject.getBoolean(KnownKeys.CodeCacheKey.getName());
                     }
                     if (androidObject.has(KnownKeys.HeapSnapshotScriptKey.getName())) {
                         String value = androidObject.getString(KnownKeys.HeapSnapshotScriptKey.getName());
-                        values[KnownKeys.HeapSnapshotScriptKey.getIndex()] = FileSystem.resolveRelativePath(appDir.getPath(), value, appDir + "/app/");
+                        values[KnownKeys.HeapSnapshotScriptKey.ordinal()] = FileSystem.resolveRelativePath(appDir.getPath(), value, appDir + "/app/");
                     }
                     if (androidObject.has(HeapSnapshotBlobKey)) {
                         String value = androidObject.getString(HeapSnapshotBlobKey);
@@ -98,23 +75,27 @@ class AppConfig {
                         if (dir.exists() && dir.isDirectory()) {
                             // this path is expected to be a directory, containing three sub-directories: armeabi-v7a, x86 and arm64-v8a
                             path = path + "/" + Build.CPU_ABI + "/" + KnownKeys.SnapshotFile.getName();
-                            values[KnownKeys.SnapshotFile.getIndex()] = path;
+                            values[KnownKeys.SnapshotFile.ordinal()] = path;
                         }
                     }
                     if (androidObject.has(KnownKeys.ProfilerOutputDirKey.getName())) {
-                        values[KnownKeys.ProfilerOutputDirKey.getIndex()] = androidObject.getString(KnownKeys.ProfilerOutputDirKey.getName());
+                        values[KnownKeys.ProfilerOutputDirKey.ordinal()] = androidObject.getString(KnownKeys.ProfilerOutputDirKey.getName());
                     }
                     if (androidObject.has(KnownKeys.GcThrottleTime.getName())) {
-                        values[KnownKeys.GcThrottleTime.getIndex()] = androidObject.getInt(KnownKeys.GcThrottleTime.getName());
+                        values[KnownKeys.GcThrottleTime.ordinal()] = androidObject.getInt(KnownKeys.GcThrottleTime.getName());
                     }
                     if (androidObject.has(KnownKeys.MemoryCheckInterval.getName())) {
-                        values[KnownKeys.MemoryCheckInterval.getIndex()] = androidObject.getInt(KnownKeys.MemoryCheckInterval.getName());
+                        values[KnownKeys.MemoryCheckInterval.ordinal()] = androidObject.getInt(KnownKeys.MemoryCheckInterval.getName());
                     }
                     if (androidObject.has(KnownKeys.FreeMemoryRatio.getName())) {
-                        values[KnownKeys.FreeMemoryRatio.getIndex()] = androidObject.getDouble(KnownKeys.FreeMemoryRatio.getName());
+                        values[KnownKeys.FreeMemoryRatio.ordinal()] = androidObject.getDouble(KnownKeys.FreeMemoryRatio.getName());
                     }
                     if (androidObject.has(KnownKeys.MarkingMode.getName())) {
-                        values[KnownKeys.MarkingMode.getIndex()] = androidObject.getString(KnownKeys.MarkingMode.getName());
+                        try {
+                            String value = androidObject.getString(KnownKeys.MarkingMode.getName());
+                            values[KnownKeys.MarkingMode.ordinal()] = MarkingMode.valueOf(value);
+                        } catch(Throwable e) {
+                        }
                     }
                 }
             }
@@ -128,28 +109,27 @@ class AppConfig {
     }
 
     private static Object[] makeDefaultOptions() {
-        Object[] result = new Object[KnownKeys.asArray.length];
-        int index = 0;
-        for (KnownKeys key: KnownKeys.asArray) {
-            result[index++] = key.getDefaultValue();
+        Object[] result = new Object[KnownKeys.values().length];
+        for (KnownKeys key: KnownKeys.values()) {
+            result[key.ordinal()] = key.getDefaultValue();
         }
         return result;
     }
 
     public int getGcThrottleTime() {
-        return (int)values[KnownKeys.GcThrottleTime.getIndex()];
+        return (int)values[KnownKeys.GcThrottleTime.ordinal()];
     }
 
     public int getMemoryCheckInterval() {
-        return (int)values[KnownKeys.MemoryCheckInterval.getIndex()];
+        return (int)values[KnownKeys.MemoryCheckInterval.ordinal()];
     }
 
     public double getFreeMemoryRatio() {
-        return (double)values[KnownKeys.FreeMemoryRatio.getIndex()];
+        return (double)values[KnownKeys.FreeMemoryRatio.ordinal()];
     }
 
     public String getProfilingMode() {
-        return (String)values[KnownKeys.Profiling.getIndex()];
+        return (String)values[KnownKeys.Profiling.ordinal()];
     }
-    public String getMarkingMode() { return (String)values[KnownKeys.MarkingMode.getIndex()]; }
+    public MarkingMode getMarkingMode() { return (MarkingMode)values[KnownKeys.MarkingMode.ordinal()]; }
 }

--- a/runtime/src/main/java/com/tns/AppConfig.java
+++ b/runtime/src/main/java/com/tns/AppConfig.java
@@ -1,14 +1,12 @@
 package com.tns;
 
 import java.io.File;
-
 import org.json.JSONObject;
-
 import android.os.Build;
 import android.util.Log;
 
 class AppConfig {
-    private enum KnownKeys {
+    protected enum KnownKeys {
         V8FlagsKey("v8Flags", "--expose_gc"),
         CodeCacheKey("codeCache", false),
         HeapSnapshotScriptKey("heapSnapshotScript", ""),
@@ -18,7 +16,7 @@ class AppConfig {
         MemoryCheckInterval("memoryCheckInterval", 0),
         FreeMemoryRatio("freeMemoryRatio", 0.0),
         Profiling("profiling", ""),
-        MarkingMode("markingMode", com.tns.MarkingMode.values()[0]);
+        MarkingMode("markingMode", com.tns.MarkingMode.full);
 
         private final String name;
         private final Object defaultValue;
@@ -52,7 +50,7 @@ class AppConfig {
         try {
             rootObject = FileSystem.readJSONFile(packageInfo);
             if (rootObject != null) {
-                if (rootObject.has(KnownKeys.Profiling.name())) {
+                if (rootObject.has(KnownKeys.Profiling.getName())) {
                     String profiling = rootObject.getString(KnownKeys.Profiling.getName());
                     values[KnownKeys.Profiling.ordinal()] = profiling;
                 }
@@ -92,9 +90,12 @@ class AppConfig {
                     }
                     if (androidObject.has(KnownKeys.MarkingMode.getName())) {
                         try {
-                            String value = androidObject.getString(KnownKeys.MarkingMode.getName());
-                            values[KnownKeys.MarkingMode.ordinal()] = MarkingMode.valueOf(value);
-                        } catch(Throwable e) {
+                            String markingModeString = androidObject.getString(KnownKeys.MarkingMode.getName());
+                            MarkingMode markingMode = MarkingMode.valueOf(markingModeString);
+                            values[KnownKeys.MarkingMode.ordinal()] = markingMode;
+                        } catch(Exception e) {
+                            e.printStackTrace();
+                            Log.v("JS", "Failed to parse marking mode. The default " + ((MarkingMode)KnownKeys.MarkingMode.getDefaultValue()).name() + " will be used.");
                         }
                     }
                 }
@@ -131,5 +132,6 @@ class AppConfig {
     public String getProfilingMode() {
         return (String)values[KnownKeys.Profiling.ordinal()];
     }
+
     public MarkingMode getMarkingMode() { return (MarkingMode)values[KnownKeys.MarkingMode.ordinal()]; }
 }

--- a/runtime/src/main/java/com/tns/AppConfig.java
+++ b/runtime/src/main/java/com/tns/AppConfig.java
@@ -17,7 +17,8 @@ class AppConfig {
         GcThrottleTime("gcThrottleTime", 0),
         MemoryCheckInterval("memoryCheckInterval", 0),
         FreeMemoryRatio("freeMemoryRatio", 0.0),
-        Profiling("profiling", "");
+        Profiling("profiling", ""),
+        MarkingMode("markingMode", "Full");
 
         public static final KnownKeys[] asArray = {
             V8FlagsKey,
@@ -28,7 +29,8 @@ class AppConfig {
             GcThrottleTime,
             MemoryCheckInterval,
             FreeMemoryRatio,
-            Profiling
+            Profiling,
+            MarkingMode
         };
 
         private final String name;
@@ -111,6 +113,9 @@ class AppConfig {
                     if (androidObject.has(KnownKeys.FreeMemoryRatio.getName())) {
                         values[KnownKeys.FreeMemoryRatio.getIndex()] = androidObject.getDouble(KnownKeys.FreeMemoryRatio.getName());
                     }
+                    if (androidObject.has(KnownKeys.MarkingMode.getName())) {
+                        values[KnownKeys.MarkingMode.getIndex()] = androidObject.getString(KnownKeys.MarkingMode.getName());
+                    }
                 }
             }
         } catch (Exception e) {
@@ -146,4 +151,5 @@ class AppConfig {
     public String getProfilingMode() {
         return (String)values[KnownKeys.Profiling.getIndex()];
     }
+    public String getMarkingMode() { return (String)values[KnownKeys.MarkingMode.getIndex()]; }
 }

--- a/runtime/src/main/java/com/tns/MarkingMode.java
+++ b/runtime/src/main/java/com/tns/MarkingMode.java
@@ -1,0 +1,9 @@
+package com.tns;
+
+/**
+ * Created by cankov on 24/08/2017.
+ */
+enum MarkingMode {
+    full,
+    none
+}

--- a/runtime/src/main/java/com/tns/Runtime.java
+++ b/runtime/src/main/java/com/tns/Runtime.java
@@ -207,7 +207,7 @@ public class Runtime {
         if (staticConfiguration != null && staticConfiguration.appConfig != null) {
             return staticConfiguration.appConfig.getMarkingMode().ordinal();
         } else {
-            return MarkingMode.values()[0].ordinal();
+            return ((MarkingMode)AppConfig.KnownKeys.MarkingMode.getDefaultValue()).ordinal();
         }
     }
 

--- a/runtime/src/main/java/com/tns/Runtime.java
+++ b/runtime/src/main/java/com/tns/Runtime.java
@@ -202,17 +202,17 @@ public class Runtime {
         return dynamicConfig;
     }
 
-    public int getMarkingMode() {
-        String mode = staticConfiguration == null || staticConfiguration.appConfig == null ? "full" : staticConfiguration.appConfig.getMarkingMode();
-        if ("none".equals(mode)) {
-            return 1;
+    @RuntimeCallable
+    public int getMarkingModeOrdinal() {
+        if (staticConfiguration != null && staticConfiguration.appConfig != null) {
+            return staticConfiguration.appConfig.getMarkingMode().ordinal();
+        } else {
+            return MarkingMode.values()[0].ordinal();
         }
-        return 0;
     }
 
     public static boolean isInitialized() {
         Runtime runtime = Runtime.getCurrentRuntime();
-
         return (runtime != null) ? runtime.isInitializedImpl() : false;
     }
 

--- a/runtime/src/main/jni/ObjectManager.cpp
+++ b/runtime/src/main/jni/ObjectManager.cpp
@@ -299,7 +299,7 @@ void ObjectManager::JSObjectFinalizer(Isolate* isolate, ObjectWeakCallbackState*
     Persistent<Object>* po = callbackState->target;
     auto jsInstanceInfo = GetJSInstanceInfoFromRuntimeObject(po->Get(m_isolate));
 
-    if (!jsInstanceInfo) {
+    if (jsInstanceInfo == nullptr) {
         po->Reset();
         return;
     }

--- a/runtime/src/main/jni/ObjectManager.h
+++ b/runtime/src/main/jni/ObjectManager.h
@@ -57,6 +57,18 @@ class ObjectManager {
             END
         };
 
+        enum class JavaScriptMarkingMode {
+            /**
+             * For JavaScript instances with implementation objects that were marked for collection,
+             * MarkReachableObjects will scann the whole graph of reachable objects and keep strong reference to
+             * the Java instances of implementation objects.
+             */
+            Full,
+            /**
+             * Fully suppress the MarkReachableObjects.
+             */
+            None
+        };
 
     private:
 
@@ -142,7 +154,11 @@ class ObjectManager {
 
         static void JSObjectWeakCallbackStatic(const v8::WeakCallbackInfo<ObjectWeakCallbackState>& data);
 
+        static void JSObjectFinalizerStatic(const v8::WeakCallbackInfo<ObjectWeakCallbackState>& data);
+
         void JSObjectWeakCallback(v8::Isolate* isolate, ObjectWeakCallbackState* callbackState);
+
+        void JSObjectFinalizer(v8::Isolate* isolate, ObjectWeakCallbackState* callbackState);
 
         bool HasImplObject(v8::Isolate* isolate, const v8::Local<v8::Object>& obj);
 
@@ -196,6 +212,8 @@ class ObjectManager {
 
         bool m_useGlobalRefs;
 
+        JavaScriptMarkingMode m_markingMode;
+
         jclass JAVA_LANG_CLASS;
 
         jmethodID GET_NAME_METHOD_ID;
@@ -205,6 +223,8 @@ class ObjectManager {
         jmethodID GET_OR_CREATE_JAVA_OBJECT_ID_METHOD_ID;
 
         jmethodID MAKE_INSTANCE_WEAK_BATCH_METHOD_ID;
+
+        jmethodID MAKE_INSTANCE_WEAK_AND_CHECK_IF_ALIVE_METHOD_ID;
 
         jmethodID CHECK_WEAK_OBJECTS_ARE_ALIVE_METHOD_ID;
 

--- a/runtime/src/main/jni/ObjectManager.h
+++ b/runtime/src/main/jni/ObjectManager.h
@@ -57,10 +57,13 @@ class ObjectManager {
             END
         };
 
-        enum class JavaScriptMarkingMode {
+        /**
+         * Memory management modes. Keep the members in sync with the java/com/tns/MarkingMode.
+         */
+        enum JavaScriptMarkingMode {
             /**
              * For JavaScript instances with implementation objects that were marked for collection,
-             * MarkReachableObjects will scann the whole graph of reachable objects and keep strong reference to
+             * MarkReachableObjects will scan the whole graph of reachable objects and keep strong reference to
              * the Java instances of implementation objects.
              */
             Full,
@@ -139,6 +142,8 @@ class ObjectManager {
         bool IsJsRuntimeObject(const v8::Local<v8::Object>& object);
 
         JSInstanceInfo* GetJSInstanceInfo(const v8::Local<v8::Object>& object);
+
+        JSInstanceInfo* GetJSInstanceInfoFromRuntimeObject(const v8::Local<v8::Object>& object);
 
         void ReleaseJSInstance(v8::Persistent<v8::Object>* po, JSInstanceInfo* jsInstanceInfo);
 

--- a/test-app/app/src/main/assets/app/package.json
+++ b/test-app/app/src/main/assets/app/package.json
@@ -5,6 +5,7 @@
 		"profilerOutputDir": "",
 		"gcThrottleTime": 500,
 		"memoryCheckInterval": 10,
-		"freeMemoryRatio": 0.50
+		"freeMemoryRatio": 0.50,
+		"markingMode": "full"
 	}
 }


### PR DESCRIPTION
Allows the MarkReachableObjects to be suppressed.
Setting:
```
{
  "android": {
    "markingMode": "none"
  }
}
```
Will completely disable the JavaScript heap traversal in MarkReachableObjects. This saves about 500ms. block on the main thread (we've seen it go up to 1350ms during navigation)

The memory management model changes drastically:

 - When a Java instance marshalled to a JavaScript type, the Java and JavaScript instances are bound,
    - Add finaliser to the JavaScript instance
    - Add a strong reference to the Java instance (this will not let it be garbage collected)

 - When the JavaScript instance's finaliser is called (the JavaScript instance is not reachable)
    - Make the reference to the Java instance weak (this will let it be garbage collected by Java GC)
    - Check the weak reference to the Java instance, if the Java instance is still alive, don't let the JavaScript instance be collected

This approach can lead to instances being prematurely collected, but doesn't involve long blocks on the main thread.

We want to run excessive testing on our apps so we can get a better understanding of the implications following from suppression MarkReachableObjects.