### PR TITLE
add a warning if no bindings.txt file was found

### DIFF
--- a/android-static-binding-generator/project/build.gradle
+++ b/android-static-binding-generator/project/build.gradle
@@ -274,6 +274,9 @@ task generateBindings() {
 	inputs.dir (bindingsFile)
 
 	doFirst {
+		if(!file(bindingsFileP).exists()) {
+			throw new GradleException("No ${bindingsFileP} was found after runAstParser task was ran! Check to see if there are any .js files inside ${jsCodeDir}")
+		}
 		javaexec {
 			main "-jar"
 


### PR DESCRIPTION
fix for https://github.com/NativeScript/android-runtime/issues/833

_problem_
When gradle can't find `.js` files to parse it doesn't show an ok Error, pointing out the problem

_solution_
Throw an error that describes the issue, in this case, to help the user figure out the problem.
