### PR TITLE
always wait for debugger to connect before continuing debugger backend

### DIFF
--- a/build-artifacts/project-template-gradle/build.gradle
+++ b/build-artifacts/project-template-gradle/build.gradle
@@ -153,6 +153,9 @@ android {
         release {
             signingConfig signingConfigs.release
         }
+	debug {
+		buildConfigField "boolean", "WAIT_FOR_DEBUG", "true"
+	}
     }
 	
 	applicationVariants.all { variant ->

--- a/build-artifacts/project-template-gradle/build.gradle
+++ b/build-artifacts/project-template-gradle/build.gradle
@@ -4,6 +4,8 @@
 *			gradle buildapk -Prelease (release mode)
 *			gradle buildapk (debug mode -> default)
 * 	Options:
+*			-PwaitForDebugger //in case property is passed debugger will wait for "Debugger.enable" from frontend for 30 seconds
+*
 *			-Prelease  //this flag will run build in release mode
 *			-PksPath=[path_to_keystore_file]
 *			-PksPassword=[password_for_keystore_file]
@@ -14,7 +16,7 @@
 *			-PbuildToolsVersion=[build_tools_version]
 *			-PsupportVersion=[support_version]
 *			-PcompileSdk=[compile_sdk_version]
-
+*
 *			-PdontRunSbg=[true/false]
 */
 
@@ -154,7 +156,11 @@ android {
             signingConfig signingConfigs.release
         }
 	debug {
-		buildConfigField "boolean", "WAIT_FOR_DEBUG", "true"
+		def waitForDebbug = "false";
+		if(project.hasProperty("waitForDebugger")) {
+			waitForDebbug = "true";
+		}
+		buildConfigField "boolean", "WAIT_FOR_DEBUG", waitForDebbug
 	}
     }
 	

--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -40,6 +40,15 @@ model {
             minifyEnabled = false
             proguardFiles.add(file('proguard-rules.txt'))
         }
+		debug {
+			buildConfigFields {
+				create() {
+					type "boolean"
+					name "WAIT_FOR_DEBUG"
+					value "false"
+				}
+			}
+		}
     }
 }
 

--- a/test-app/app/src/main/java/com/tns/RuntimeHelper.java
+++ b/test-app/app/src/main/java/com/tns/RuntimeHelper.java
@@ -152,7 +152,7 @@ public final class RuntimeHelper {
                 runtime = Runtime.initializeRuntimeWithConfiguration(config);
                 if (isDebuggable) {
                     try {
-                        v8Inspector = new AndroidJsV8Inspector(app.getFilesDir().getAbsolutePath(), app.getPackageName());
+                        v8Inspector = new AndroidJsV8Inspector(app.getFilesDir().getAbsolutePath(), app.getPackageName(), logger);
                         v8Inspector.start();
 
                         // the following snippet is used as means to notify the VSCode extension


### PR DESCRIPTION
_in short_
We didn't wait for debugger frontend to notofy backend before continuing execution.
See [original issue](https://github.com/NativeScript/nativescript-vscode-extension/issues/143#issuecomment-325528677)

_problem_
When we start `chrome dev tools` or `vscode extension` we wait for the `Debugger.enable` but we don't make the debugger backend wait too. This causes the backend to just continue parsing files and ignoring recognized breakpoints because the frontend is not ready to handle them and is ready to do so after it sends `Debugger.enable`.

_solution_
Make backend wait until frontend is ready to handle breakpoints.