### PR TITLE
Metadata generator is more tolerable now

### DIFF
--- a/android-metadata-generator/src/src/com/telerik/metadata/Builder.java
+++ b/android-metadata-generator/src/src/com/telerik/metadata/Builder.java
@@ -60,7 +60,11 @@ public class Builder {
                 // our class path API 17
                 // Class<?> clazz = Class.forName(className, false, loader);
                 ClassDescriptor clazz = ClassRepo.findClass(className);
-                generate(clazz, root);
+                if (clazz == null) {
+                    throw new ClassNotFoundException("Class " + className + " not found in the input android libraries.");
+                } else {
+                    generate(clazz, root);
+                }
             } catch (Throwable e) {
                 System.out.println("Skip " + className);
                 System.out.println("\tError: " + e.toString());
@@ -248,6 +252,12 @@ public class Builder {
         } else {
             String name = ClassUtil.getCanonicalName(type.getSignature());
             ClassDescriptor clazz = ClassRepo.findClass(name);
+
+            // if clazz is not found in the ClassRepo, the method/field being analyzed will be skipped
+            if (clazz == null) {
+                return null;
+            }
+
             node = getOrCreateNode(root, clazz, null);
         }
 

--- a/android-metadata-generator/src/src/com/telerik/metadata/ClassRepo.java
+++ b/android-metadata-generator/src/src/com/telerik/metadata/ClassRepo.java
@@ -12,16 +12,6 @@ public class ClassRepo {
     private static ArrayList<ClassMapProvider> cachedProviders = new ArrayList<ClassMapProvider>();
 
     public static void addToCache(ClassMapProvider classMapProvider) {
-        for (String className : classMapProvider.getClassMap().keySet()) {
-            for (ClassMapProvider cachedProvider : cachedProviders) {
-                ClassDescriptor clazz = cachedProvider.getClassMap().get(className);
-                if (clazz != null) {
-                    String errMsg = "Class " + className + " conflict: "
-                                    + classMapProvider.getPath() + " and " + cachedProvider.getPath();
-                    throw new IllegalArgumentException(errMsg);
-                }
-            }
-        }
         cachedProviders.add(classMapProvider);
     }
 
@@ -33,6 +23,7 @@ public class ClassRepo {
                 break;
             }
         }
+
         return clazz;
     }
 

--- a/android-metadata-generator/src/src/com/telerik/metadata/Generator.java
+++ b/android-metadata-generator/src/src/com/telerik/metadata/Generator.java
@@ -29,7 +29,7 @@ public class Generator {
                 "You need to pass an output directory!");
         }
 
-        if (args != null && args.length > 1) {
+        if (args.length > 1) {
             params = new String[args.length - 1];
             for (int i = 1; i < args.length; i++) {
                 params[i - 1] = args[i];


### PR DESCRIPTION
Addresses issue https://github.com/NativeScript/android-runtime/issues/832 by making the following small changes:

- when collecting classes from input jars, do not crash on clashing classes (classes that are already brought in from another library). The assumption here is that the build will crash at earlier point during the java compilation step, and it should not concern the metadata generator.
(e.g. An android library depends on appache http library, but if imported in gradle as a dependency, the class collection logic in the metadata generation would fail, complaining that 3 classes coincide in name - some of the appache http classes are left inside the android sdk packages for whatever legacy reasons they have)

- when traversing a class's methods/fields, do not skip class if the parameter of a single method is not found in the ClassLoader. Instead continue, and try to generate as much metadata as possible for the class being analyzed.