### PR TITLE
Improve exceptions when incorrectly instantiating interfaces

### DIFF
--- a/test-app/app/src/main/assets/app/tests/extendedClassesTests.js
+++ b/test-app/app/src/main/assets/app/tests/extendedClassesTests.js
@@ -73,4 +73,12 @@ describe("Tests extended classes ", function () {
 		
 		expect(labelgetIMAGE_ID_PROP1).toBe(labelgetIMAGE_ID_PROP2);
 	});
+
+	it("should not crash with no exception when incorrectly calling extended class constructor", function () {
+	    let MyObj = java.lang.Object.extend({
+                        toString: () => { return "It's MyObj" }
+                    });
+
+        expect(() => { myObj() }).toThrow();
+	});
 });

--- a/test-app/app/src/main/assets/app/tests/testInterfaceImplementation.js
+++ b/test-app/app/src/main/assets/app/tests/testInterfaceImplementation.js
@@ -27,4 +27,8 @@ describe("Tests Java interfaces are implemented correctly", function () {
 
 		expect(callClose).toBe(true);
 	});
+
+	it("should not crash with no exception when calling interface incorrectly", function () {
+	    expect(() => { java.lang.Runnable({ run: () => { android.util.Log.d("Log", ""); } }) }).toThrow();
+	});
 });


### PR DESCRIPTION
Addreses the problem described in https://github.com/NativeScript/android-runtime/issues/836