### PR TITLE
Add google maven repository to project build script

### DIFF
--- a/build-artifacts/project-template-gradle/build.gradle
+++ b/build-artifacts/project-template-gradle/build.gradle
@@ -197,6 +197,8 @@ android {
 
 repositories {
     jcenter()
+    maven { url 'https://maven.google.com' }
+
     // used for local *.AAR files
     flatDir {
     	dirs 'libs/aar'


### PR DESCRIPTION
Google started distributing their `Google Play Services` android plugins in a maven repository that, unless included in the gradle build script will limit users from using the latest versions of google-play-services plugins.

By implicitly referencing the google maven repository, we relieve developers from having to manually include it.

Ref: https://developer.android.com/studio/build/dependencies.html#google-maven