### PR TITLE
update js parser with corner case

### DIFF
--- a/android-static-binding-generator/project/parser/visitors/es5-visitors.js
+++ b/android-static-binding-generator/project/parser/visitors/es5-visitors.js
@@ -599,7 +599,7 @@ var es5_visitors = (function () {
     }
 
     function _generateLineToWrite(classNameFromDecorator, extendClass, overriddenMethodNames, extendInfo, filePath, implementedInterfaces) {
-        var lineToWrite = extendClass + "*" + extendInfo.replace(/[\\/\\-]/g, "_") + "*" + overriddenMethodNames + "*" + classNameFromDecorator + "*" + filePath + "*" + (implementedInterfaces ? implementedInterfaces : "");
+        var lineToWrite = extendClass + "*" + extendInfo.replace(/[\\/\\-\\.]/g, "_") + "*" + overriddenMethodNames + "*" + classNameFromDecorator + "*" + filePath + "*" + (implementedInterfaces ? implementedInterfaces : "");
         return lineToWrite;
     }
 

--- a/android-static-binding-generator/tests/cases/file_names_with_dots/app/file.with.dots.js
+++ b/android-static-binding-generator/tests/cases/file_names_with_dots/app/file.with.dots.js
@@ -1,0 +1,1 @@
+android.telephony.PhoneStateListener.extend({});

--- a/android-static-binding-generator/tests/cases/file_names_with_dots/internal/ts_helpers.js
+++ b/android-static-binding-generator/tests/cases/file_names_with_dots/internal/ts_helpers.js
@@ -1,0 +1,124 @@
+(function() {
+	var __extends_ts = function (d, b) {
+	    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+	    function __() { this.constructor = d; }
+	    __.prototype = b.prototype;
+	    d.prototype = new __();
+	};
+	
+	var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+        var c = arguments.length;
+        var r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+
+        if (typeof global.Reflect === "object" && typeof global.Reflect.decorate === "function") {
+            r = global.Reflect.decorate(decorators, target, key, desc);
+        }
+        else {
+            for (var i = decorators.length - 1; i >= 0; i--) {
+                if (d = decorators[i]) {
+                    r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+                }
+            }
+        }
+        return c > 3 && r && Object.defineProperty(target, key, r), r;
+    };
+	
+	var __native = function(thiz) {
+		var result = thiz.__proto__;
+	
+		for (var prop in thiz) 
+		{
+			if (thiz.hasOwnProperty(prop))
+			{
+				thiz.__proto__[prop] = thiz[prop];
+				delete thiz[prop];
+			}
+		}
+		
+		thiz.constructor = undefined;
+		thiz.__proto__ = undefined;
+		Object.freeze(thiz);
+		Object.preventExtensions(thiz)
+		return result;
+	};
+	
+	var __extends = function(Child, Parent) {
+		
+		if (Parent.extend)	{
+			if	(Parent.__isPrototypeImplementationObject) {
+				throw new Error("Can not extend an already extended native object.");
+			}
+			
+			function extend(child, parent) {
+				__log("TS extend called");
+				if (!child.__extended) {
+		        	child.__extended = parent.extend(child.name, child.prototype);
+		        }
+		 
+		        return child.__extended;
+		    };
+		    
+		    Parent.__activityExtend = function(parent, name, implementationObject) {
+		    	__log("__activityExtend called");
+		    	return parent.extend(name, implementationObject);
+		    };
+		    
+		    Parent.call = function(thiz) {
+				var Extended = extend(thiz.__proto__.__child, thiz.__proto__.__parent);
+				if (arguments.length > 1)
+				{
+					thiz.__proto__ = new (Function.prototype.bind.apply(Extended, [null].concat(Array.prototype.slice.call(arguments, 1))));
+				}
+				else
+				{
+					thiz.__proto__ = new Extended();
+				}
+			};
+			
+			Parent.apply = function(thiz, args) {
+				var Extended = extend(thiz.__proto__.__child, thiz.__proto__.__parent);
+				if (args && args.length > 0)
+				{
+					thiz.__proto__ = new (Function.prototype.bind.apply(Extended, [null].concat(args)));
+				}
+				else
+				{
+					thiz.__proto__ = new Extended();
+				}
+			};
+		}
+		
+		__extends_ts(Child, Parent);
+		
+		
+		if (Parent.extend)	{
+			Child.__isPrototypeImplementationObject = true;
+			Child.__proto__ = Parent;
+			Child.prototype.__parent = Parent;
+			Child.prototype.__child = Child;
+		}
+	}
+	
+	function JavaProxy(className) {
+	    return function (target) {
+	    	var extended = target.extend(className, target.prototype)
+	    	extended.name = className;
+	    	return extended;
+	    };
+	}
+
+	function Interfaces(interfacesArr) {
+	    return function (target) {
+            if(interfacesArr instanceof Array) {
+                // attach interfaces: [] to the object
+                target.prototype.interfaces = interfacesArr;
+            }
+	    }
+	}
+	
+	global.__native = __native;
+	global.__extends = __extends;
+	global.__decorate = __decorate;
+	global.JavaProxy = JavaProxy;
+	global.Interfaces = Interfaces;
+})()

--- a/android-static-binding-generator/tests/interfaces-names.txt
+++ b/android-static-binding-generator/tests/interfaces-names.txt
@@ -1,3 +1,4 @@
+android.telephony.PhoneStateListener
 android.support.annotation.WorkerThread
 android.support.annotation.ColorRes
 android.support.annotation.LayoutRes

--- a/android-static-binding-generator/tests/specs/ast-parser-tests.spec.js
+++ b/android-static-binding-generator/tests/specs/ast-parser-tests.spec.js
@@ -42,7 +42,7 @@ describe("parser/js_parser tests", function () {
         it("Analyse files only in the correct folder structure", function (done) {
 
             let input = path.normalize(prefix + "/mini_app/app"),
-                jsFilesParameter = path.normalize(prefix + "/mini_app/jsfiles.txt"),
+                jsFilesParameter = path.normalize(prefix + "/mini_app/jsFiles.txt"),
                 output = path.normalize(prefix + "/mini_app/bindings.txt");
 
             clearOutput(output, jsFilesParameter);
@@ -122,6 +122,31 @@ describe("parser/js_parser tests", function () {
                 });
 
                 expect(allLines.length).toBe(0);
+                done();
+            });
+        });
+
+        it("Files with dots in their names won't reflect in resulting java class names", function (done) {
+            let input = path.normalize(prefix + "/file_names_with_dots/app"),
+                jsFilesParameter = path.normalize(prefix + "/file_names_with_dots/jsFiles.txt"),
+                output = prefix + "/file_names_with_dots/bindings.txt";
+
+            clearOutput(output, jsFilesParameter);
+
+            execGradle(input, output, jsFilesParameter, function (error, stdout, stderr) {
+                if (error) {
+                    console.error(`exec error: ${error}`);
+                    return;
+                }
+
+                logExecResult(stdout, stderr)
+
+                let bindingsContent = fs.readFileSync(output, "utf-8").toString().trim().split('\n');
+
+                let expectedPartialContent = "file_with_dots";
+                let foundExpected = bindingsContent[0].indexOf(expectedPartialContent)
+
+                expect(foundExpected).toBeGreaterThan(0);
                 done();
             });
         });


### PR DESCRIPTION
Update js_parser to cover naming with a dot

While we are statically analyzing the application javascript code, we use the file_name as part of the name for the class, but if the file name contains a dot ".", the java class name becomes invalid. Replacing dot and other characters with a "_".

Fixes issue: https://github.com/NativeScript/android-runtime/issues/761

