### PR TITLE
Update ASBG parser and ASBG generated classes tests to run on travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,10 @@ script:
   - echo no | android create avd --force -n $EMULATOR_NAME-$EMULATOR_API_LEVEL -t android-$EMULATOR_API_LEVEL --abi $ANDROID_ABI -c 12M
   - emulator -avd $EMULATOR_NAME-$EMULATOR_API_LEVEL -no-skin -no-audio -no-window &
   - android-wait-for-emulator
-  - "node android-static-binding-generator/run-tests"
+  - cd android-static-binding-generator
+  - "npm install"
+  - "node run-tests"
+  - cd ..
   - "android-static-binding-generator/project/staticbindinggenerator/gradlew clean test --project-dir android-static-binding-generator/project/staticbindinggenerator/"
   - "cd test-app && ./gradlew runtest --stacktrace"
   - adb -e logcat -d 300

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,8 @@ script:
   - echo no | android create avd --force -n $EMULATOR_NAME-$EMULATOR_API_LEVEL -t android-$EMULATOR_API_LEVEL --abi $ANDROID_ABI -c 12M
   - emulator -avd $EMULATOR_NAME-$EMULATOR_API_LEVEL -no-skin -no-audio -no-window &
   - android-wait-for-emulator
+  - "node android-static-binding-generator/run-tests"
+  - "android-static-binding-generator/project/staticbindinggenerator/gradlew clean test --project-dir android-static-binding-generator/project/staticbindinggenerator/"
   - "cd test-app && ./gradlew runtest --stacktrace"
   - adb -e logcat -d 300
   - cd ..

--- a/android-static-binding-generator/package.json
+++ b/android-static-binding-generator/package.json
@@ -2,10 +2,11 @@
   "name": "static_analysis",
   "version": "1.0.0",
   "description": "",
-  "main": "project/parse.js",
+  "main": "project/parser",
   "scripts": {
-    "test": "jasmine JASMINE_CONFIG_PATH=jasmine.json"
+    "test": "node run-tests.js"
   },
+  "repository": "https://github.com/NativeScript/android-runtime/",
   "author": "",
   "license": "ISC",
   "dependencies": {
@@ -15,6 +16,7 @@
     "lazy": "^1.0.11"
   },
   "devDependencies": {
+    "jasmine": "^2.8.0",
     "jasmine-node": "^1.14.5"
   }
 }

--- a/android-static-binding-generator/package.json
+++ b/android-static-binding-generator/package.json
@@ -16,7 +16,7 @@
     "lazy": "^1.0.11"
   },
   "devDependencies": {
-    "jasmine": "^2.8.0",
-    "jasmine-node": "^1.14.5"
+    "jasmine": "2.8.0",
+    "jasmine-node": "1.14.5"
   }
 }

--- a/android-static-binding-generator/run-tests.js
+++ b/android-static-binding-generator/run-tests.js
@@ -1,0 +1,34 @@
+(function () {
+    let { spawnSync, execSync } = require('child_process');
+
+    console.log("Installing JavaScript parser test dependencies.");
+
+    execSync('npm install');
+
+    console.log("Executing JavaScript parser tests using Jasmine.");
+
+    const subprocess = spawnSync('node', ['./node_modules/jasmine/bin/jasmine.js', 'JASMINE_CONFIG_PATH=jasmine.json'], { cwd: __dirname });
+
+    let stdout = subprocess.stdout.toString();
+    let stderr = subprocess.stderr.toString();
+    let code = subprocess.status;
+    let err = subprocess.error;
+
+    if (code !== 0) {
+        console.log("Tests runner exited with a non-zero code.");
+
+        let errorString = stdout;
+
+        if (err) {
+            errorString = err;
+        }
+
+        if (stderr) {
+            errorString = stderr;
+        }
+
+        throw new Error(errorString);
+    }
+
+    console.log(stdout);
+}());

--- a/android-static-binding-generator/run-tests.js
+++ b/android-static-binding-generator/run-tests.js
@@ -3,7 +3,9 @@
 
     console.log("Installing JavaScript parser test dependencies.");
 
-    execSync('npm install');
+    let npmInstallResult = execSync('npm install');
+
+    console.log(npmInstallResult.toString());
 
     console.log("Executing JavaScript parser tests using Jasmine.");
 

--- a/android-static-binding-generator/tests/specs/ast-parser-tests.spec.js
+++ b/android-static-binding-generator/tests/specs/ast-parser-tests.spec.js
@@ -1,16 +1,15 @@
-'use strict';
-
-var exec = require("child_process").exec,
+const exec = require("child_process").exec,
     path = require("path"),
     fs = require("fs"),
     prefix = path.resolve(__dirname, "../cases/"),
     interfaceNames = path.resolve(__dirname, "../interfaces-names.txt"),
     gradleTraverse = path.resolve(__dirname, "../../project"),
     gradleTaskName = "traverseJsFilesArgs",
-    parser = path.resolve(__dirname, "../../project/parser/js_parser.js");
+    parser = path.resolve(__dirname, "../../project/parser/js_parser.js"),
+    gradleExecutable = path.resolve(__dirname, "../../project/staticbindinggenerator/gradlew");
 
 function execGradle(inputPath, bindingsOutput, jsFilesInput, callback) {
-    exec("gradle -p " + gradleTraverse + " " + gradleTaskName + " -Ptest -PjsCodeDir=\"" + inputPath + "\" -PbindingsFilePath=\"" + bindingsOutput + "\" -PinterfaceNamesFilePath=\"" + interfaceNames + "\" -PjsParserPath=\"" + parser + "\" -PjsFilesParameter=\"" + jsFilesInput + "\"", callback);
+    exec(`${gradleExecutable} -p ${gradleTraverse} ${gradleTaskName} -Ptest -PjsCodeDir="${inputPath}" -PbindingsFilePath="${bindingsOutput}" -PinterfaceNamesFilePath="${interfaceNames}" -PjsParserPath="${parser}" -PjsFilesParameter="${jsFilesInput}"`, callback);
 }
 
 function logExecResult(stdout, stderr) {
@@ -35,9 +34,11 @@ function clearOutput(bindingsOutput, jsFilesInput) {
 }
 
 describe("parser/js_parser tests", function () {
+    beforeAll(() => {
+        jasmine.DEFAULT_TIMEOUT_INTERVAL = 20 * 1000; // give enough time to start the gradle daemon
+    });
 
-    describe("js_parser tests", function () {
-
+    describe("Traversal tests", function () {
         it("Analyse files only in the correct folder structure", function (done) {
 
             let input = path.normalize(prefix + "/mini_app/app"),
@@ -213,7 +214,6 @@ describe("parser/js_parser tests", function () {
                     console.error(`exec error: ${error}`);
                     return;
                 }
-
                 logExecResult(stdout, stderr)
 
                 let bindingsContent = fs.readFileSync(output, "utf-8").toString().trim().split('\n');

--- a/build.gradle
+++ b/build.gradle
@@ -219,11 +219,16 @@ task generateStaticBindingGeneratorJar(type: Exec) {
     doFirst {
         workingDir "$rootDir/android-static-binding-generator/project/staticbindinggenerator"
 
+        
+        def commandArgs = ["assemble"]
+
         if (isWinOs) {
-            commandLine "cmd", "/c", "gradlew", "assemble"
+            commandLine "cmd", "/c", "gradlew"
         } else {
-            commandLine "./gradlew", "assemble"
+            commandLine "./gradlew"
         }
+
+        args commandArgs
     }
 
 }


### PR DESCRIPTION
We have some tests for the Android Static Binding Generator's JavaScript parser - testing whether the correct directories are traversed; tests for the generated bindings data - whether parsing a javascript file with `extends` outputs a string in the expected format; and tests for the generated java classes - whether they compile properly.

Previously these tests were only ran manually. The changes in this PR update the tests to be callable from travis CI.
