### PR TITLE
replace chrono::steady_clock usage with chrono::system_clock

### DIFF
--- a/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
@@ -634,8 +634,8 @@ void CallbackHandlers::LogMethodCallback(const v8::FunctionCallbackInfo<v8::Valu
 }
 
 void CallbackHandlers::TimeCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
-    auto nano = std::chrono::time_point_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now());
-    double duration = nano.time_since_epoch().count() / 1000000.0;
+    auto nano = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::system_clock::now());
+    double duration = nano.time_since_epoch().count();
     args.GetReturnValue().Set(duration);
 }
 

--- a/test-app/runtime/src/main/cpp/ManualInstrumentation.cpp
+++ b/test-app/runtime/src/main/cpp/ManualInstrumentation.cpp
@@ -5,4 +5,4 @@
 #include "ManualInstrumentation.h"
 
 bool tns::instrumentation::Frame::disabled = true;
-const std::chrono::steady_clock::time_point tns::instrumentation::Frame::disabled_time = std::chrono::steady_clock::time_point();
+const std::chrono::system_clock::time_point tns::instrumentation::Frame::disabled_time = std::chrono::system_clock::time_point();

--- a/test-app/runtime/src/main/cpp/ManualInstrumentation.h
+++ b/test-app/runtime/src/main/cpp/ManualInstrumentation.h
@@ -15,7 +15,7 @@ namespace instrumentation {
 class Frame {
     public:
         inline Frame() : Frame("") { }
-        inline Frame(std::string name) : name(name), start(disabled ? disabled_time : std::chrono::steady_clock::now()) {}
+        inline Frame(std::string name) : name(name), start(disabled ? disabled_time : std::chrono::system_clock::now()) {}
 
         inline ~Frame() {
             if (!name.empty() && check()) {
@@ -27,7 +27,7 @@ class Frame {
             if (disabled) {
                 return false;
             }
-            std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+            std::chrono::system_clock::time_point end = std::chrono::system_clock::now();
             auto duration = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::operator-(end, start)).count();
             return duration >= 16000;
         }
@@ -36,7 +36,7 @@ class Frame {
             if (disabled) {
                 return;
             }
-            std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
+            std::chrono::system_clock::time_point end = std::chrono::system_clock::now();
             auto duration = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::operator-(end, start)).count();
             auto startMilis = std::chrono::time_point_cast<std::chrono::microseconds>(start).time_since_epoch().count() / 1000.0;
             auto endMilis = std::chrono::time_point_cast<std::chrono::microseconds>(end).time_since_epoch().count() / 1000.0;
@@ -56,9 +56,9 @@ class Frame {
 
     private:
         static bool disabled;
-        static const std::chrono::steady_clock::time_point disabled_time; // Couldn't find reasonable constant
+        static const std::chrono::system_clock::time_point disabled_time; // Couldn't find reasonable constant
 
-        const std::chrono::steady_clock::time_point start;
+        const std::chrono::system_clock::time_point start;
         const std::string name;
 
         Frame(const Frame&) = delete;


### PR DESCRIPTION
The changes in the PR replace all occurrences of `chrono::steady_clock` in favor of `chrono::system_clock`. That's done due to the fact that when compiled with NDK 15, the calls to `chrono::steady_clock` return a `stopwatch` time, that may *not* be the same as the `watch` time returned by `system_clock`. 

The runtime-exposed `__time` javascript callback needs to return time since 1970 so as to properly visualize a timeline of time taken to execute certain large chunks of NativeScript code since the start of the Android process.