### PR TITLE
Configure Build Stages for travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,10 @@ matrix:
       git:
         submodules: false
       script:
-        - "./gradlew -PpreReleaseVersion=$PACKAGE_VERSION -PgitCommitVersion=$TRAVIS_COMMIT --stacktrace"
+        # (PR) build the runtime only once, with the c++ code optimizations 
+        - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then bash ./gradlew -PskipUnoptimized -PpreReleaseVersion=$PACKAGE_VERSION -PgitCommitVersion=$TRAVIS_COMMIT --stacktrace; fi'
+        # (master branch) build the runtime twice - optimized, and regular packages
+        - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash ./gradlew -PpreReleaseVersion=$PACKAGE_VERSION -PgitCommitVersion=$TRAVIS_COMMIT --stacktrace; fi'
         - echo no | android create avd --force -n $EMULATOR_NAME-$EMULATOR_API_LEVEL -t android-$EMULATOR_API_LEVEL --abi $ANDROID_ABI -c 12M
         - emulator -avd $EMULATOR_NAME-$EMULATOR_API_LEVEL -no-skin -no-audio -no-window &
         - android-wait-for-emulator

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,18 @@ matrix:
       sudo: true
       language: android
       jdk: oraclejdk8
+      android:
+        components:
+          - android-$EMULATOR_API_LEVEL
+          - extra-android-support
+          - extra-android-m2repository
+          - cmake
+          - sys-img-$ANDROID_ABI-android-$EMULATOR_API_LEVEL
       git:
         submodules: false
       script:
-        # (PR) build the runtime only once, with the c++ code optimizations 
-        - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then bash ./gradlew -PskipUnoptimized -PpreReleaseVersion=$PACKAGE_VERSION -PgitCommitVersion=$TRAVIS_COMMIT --stacktrace; fi'
-        # (master branch) build the runtime twice - optimized, and regular packages
+        # (master branch) build the runtime twice - optimized, and regular packages, skip on PRs
+        # test-app/gradlew runtest will take care of building the runtime for its testing needs
         - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash ./gradlew -PpreReleaseVersion=$PACKAGE_VERSION -PgitCommitVersion=$TRAVIS_COMMIT --stacktrace; fi'
         - echo no | android create avd --force -n $EMULATOR_NAME-$EMULATOR_API_LEVEL -t android-$EMULATOR_API_LEVEL --abi $ANDROID_ABI -c 12M
         - emulator -avd $EMULATOR_NAME-$EMULATOR_API_LEVEL -no-skin -no-audio -no-window &
@@ -61,11 +67,6 @@ android:
     - tools
     - build-tools-26.0.1
     - android-26
-    - android-$EMULATOR_API_LEVEL
-    - extra-android-support
-    - extra-android-m2repository
-    - cmake
-    - sys-img-$ANDROID_ABI-android-$EMULATOR_API_LEVEL
   licenses:
     - 'android-sdk-preview-license-52d11cd2'
     - 'android-sdk-license-.+'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,51 @@ env:
   - EMULATOR_API_LEVEL=21
   - ANDROID_ABI=armeabi-v7a
   - EMULATOR_NAME=runtime-emu
-sudo: true
-language: android
-jdk:
-  - oraclejdk8
-git:
-  submodules: false
+
+matrix:
+  include:
+    - stage: "Static Binding Generator Parser Tests"
+      language: node_js 
+      node_js: "6"
+      git:
+        submodules: false
+      script:
+        - cd android-static-binding-generator
+        - npm install && node run-tests
+        - cd ..
+    - stage: "Static Binding Generator Class Generator Tests"
+      language: android
+      jdk: oraclejdk8
+      git:
+        submodules: false
+      script:
+        - "android-static-binding-generator/project/staticbindinggenerator/gradlew test --project-dir android-static-binding-generator/project/staticbindinggenerator/"    
+    - stage: "Build and Tests"
+      sudo: true
+      language: android
+      jdk: oraclejdk8
+      git:
+        submodules: false
+      script:
+        - "./gradlew -PpreReleaseVersion=$PACKAGE_VERSION -PgitCommitVersion=$TRAVIS_COMMIT --stacktrace"
+        - echo no | android create avd --force -n $EMULATOR_NAME-$EMULATOR_API_LEVEL -t android-$EMULATOR_API_LEVEL --abi $ANDROID_ABI -c 12M
+        - emulator -avd $EMULATOR_NAME-$EMULATOR_API_LEVEL -no-skin -no-audio -no-window &
+        - android-wait-for-emulator
+        - cd test-app 
+        - "./gradlew runtest --stacktrace"
+        - adb -e logcat -d 300
+        - cd ..
+      before_install:
+        - echo "y" | sdkmanager "cmake;3.6.4111459"
+        - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
+        - git submodule update --init --recursive
+        - wget https://dl.google.com/android/repository/android-ndk-$NDK_VERSION-linux-x86_64.zip
+        - chmod +x android-ndk-$NDK_VERSION-linux-x86_64.zip
+        - "unzip -q android-ndk-$NDK_VERSION-linux-x86_64.zip"
+        - "rm -rf android-ndk-$NDK_VERSION-linux-x86_64.zip"
+        - export ANDROID_NDK_HOME=`pwd`/android-ndk-$NDK_VERSION
+        - export PATH=${PATH}:${ANDROID_NDK_HOME}
+
 android:
   components:
     - platform-tools
@@ -34,28 +73,7 @@ cache:
   directories:
   - "$HOME/.gradle/caches/"
   - "$HOME/.gradle/wrapper/"
-before_install:
-  - echo "y" | sdkmanager "cmake;3.6.4111459"
-  - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
-  - git submodule update --init --recursive
-  - wget https://dl.google.com/android/repository/android-ndk-$NDK_VERSION-linux-x86_64.zip
-  - chmod +x android-ndk-$NDK_VERSION-linux-x86_64.zip
-  - "unzip -q android-ndk-$NDK_VERSION-linux-x86_64.zip"
-  - "rm -rf android-ndk-$NDK_VERSION-linux-x86_64.zip"
-  - export ANDROID_NDK_HOME=`pwd`/android-ndk-$NDK_VERSION
-  - export PATH=${PATH}:${ANDROID_NDK_HOME}
+
 install:
   - nvm install $NODE_VERSION
-script:
-  - "./gradlew -PpreReleaseVersion=$PACKAGE_VERSION -PgitCommitVersion=$TRAVIS_COMMIT --stacktrace"
-  - echo no | android create avd --force -n $EMULATOR_NAME-$EMULATOR_API_LEVEL -t android-$EMULATOR_API_LEVEL --abi $ANDROID_ABI -c 12M
-  - emulator -avd $EMULATOR_NAME-$EMULATOR_API_LEVEL -no-skin -no-audio -no-window &
-  - android-wait-for-emulator
-  - cd android-static-binding-generator
-  - "npm install"
-  - "node run-tests"
-  - cd ..
-  - "android-static-binding-generator/project/staticbindinggenerator/gradlew clean test --project-dir android-static-binding-generator/project/staticbindinggenerator/"
-  - "cd test-app && ./gradlew runtest --stacktrace"
-  - adb -e logcat -d 300
-  - cd ..
+  

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ def localMetadataGen = "../android-metadata-generator/dist/tns-android-metadata-
 def distDir = "$projectDir/dist"
 def pVersion = "no package version was provided by build.gradle build"
 def arVersion = "no commit sha was provided by build.gradle build"
+def generateRegularRuntimePackage = !project.hasProperty("skipUnoptimized");
 
 task checkEnvironmentVariables {
     if ("$System.env.JAVA_HOME" == "" || "$System.env.JAVA_HOME" == "null") {
@@ -130,7 +131,10 @@ task getCommitVersion {
 task generateRuntime {
     doFirst {
         tasks.generateOptimizedRuntimeAar.execute();
-        tasks.generateRuntimeAar.execute();
+
+        if (generateRegularRuntimePackage) {
+            tasks.generateRuntimeAar.execute();
+        }
     }
 }
 


### PR DESCRIPTION
Split the travis configuration into separate jobs in order to receive feedback from PRs a bit quicker on ASBG generator tests, with the package build and runtime tests executing at the end.

The runtime build on PRs should be faster this time around because the runtime android library will be built just once, as opposed to twice (optimized, and regular).