### PR TITLE
apply user configuration before plugins' configuration to provide external properties

### DIFF
--- a/build-artifacts/project-template-gradle/build.gradle
+++ b/build-artifacts/project-template-gradle/build.gradle
@@ -145,6 +145,8 @@ def applyAppGradleConfiguration = { ->
 	if (appGradle.exists()) {
 		println "\t + applying user-defined configuration from ${appGradle}"
 		apply from: pathToAppGradle
+	} else {
+		println "\t + couldn't load user-defined configuration from ${appGradle}. File doesn't exist."
 	}
 }
 
@@ -224,6 +226,8 @@ android {
 			compileTask.dependsOn("asbg:generateBindings")
 		}
 	}
+
+	applyAppGradleConfiguration()
 
 	def dimensions = applyPluginsIncludeGradleConfigurations()
 	

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tns-android",
   "description": "NativeScript Runtime for Android",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "files": [
     "**/*"
   ]


### PR DESCRIPTION
Apply the user-defined configuration of `app.gradle` before any other plugin-defined configs, during a Gradle build. 

Doing that will ensure that project-external properties defined as `project.ext` will be available throughout the configuration step for plugin gradle scripts.

Finally the user configuration will be reapplied, in order to apply settings the plugin scripts might have overridden.