### PR TITLE
change app.gradle to only be applied before plugin configurations

### DIFF
--- a/build-artifacts/project-template-gradle/build.gradle
+++ b/build-artifacts/project-template-gradle/build.gradle
@@ -232,8 +232,6 @@ android {
 	def dimensions = applyPluginsIncludeGradleConfigurations()
 	
 	flavorDimensions(*dimensions)
-
-	applyAppGradleConfiguration()
 }
 
 repositories {


### PR DESCRIPTION
Change the build configuration phase to only apply `app.gradle` once, before applying `include.gradle`s from plugins - keep old pre-3.3.0 behavior. 

What this means is that settings defined in `app.gradle` can be overridden by other gradle scripts applied afterwards.

cc @dtopuzov 