### PR TITLE
move google-services.json to app folder if present

### DIFF
--- a/build-artifacts/project-template-gradle/settings.gradle
+++ b/build-artifacts/project-template-gradle/settings.gradle
@@ -3,3 +3,5 @@ include ':app', ':asbg' //,  ':runtime', ":runtime-binding-generator"
 project(':asbg').projectDir = new File('build-tools/android-static-binding-generator')
 //project(':runtime').projectDir = new File('path/to/runtime')
 //project(':runtime-binding-generator').projectDir = new File('path/to/runtime-binding-generator')
+
+file("google-services.json").renameTo(file("./app/google-services.json"))


### PR DESCRIPTION
_problem_
when a plugin has `google-services.json` file, some scripts move it to `platforms/android` folder, but this file should be moved to `platforms/android/app` with the AndroidStudio compatible project.

_solution_
move `google-services.json` to the right place, before the gradle configuration has started.

_expected behavior_
if the file exists, it's moved to `./app` folder, when the CLI calls gradle build