### PR TITLE
don't make flavors when only aar files are present

### DIFF
--- a/build-artifacts/project-template-gradle/app/build.gradle
+++ b/build-artifacts/project-template-gradle/app/build.gradle
@@ -96,6 +96,12 @@ def applyPluginsIncludeGradleConfigurations =  { ->
 		if (!androidDir.exists()) {
 			return
 		}
+
+		FileTree allFilesExeptForAar = fileTree(dir: androidDir, exclude: "**/*.aar");
+		if(allFilesExeptForAar.size() <= 0) {
+			return;
+		}
+
 		def includeGradleFile = new File(androidDir, "include.gradle")
 
 		def packageJsonPath = file("$rootDir/${dep.directory}/package.json")

--- a/build-artifacts/project-template-gradle/app/build.gradle
+++ b/build-artifacts/project-template-gradle/app/build.gradle
@@ -97,8 +97,8 @@ def applyPluginsIncludeGradleConfigurations =  { ->
 			return
 		}
 
-		FileTree allFilesExeptForAar = fileTree(dir: androidDir, exclude: "**/*.aar");
-		if(allFilesExeptForAar.size() <= 0) {
+		FileTree allFilesExceptForAars = fileTree(dir: androidDir, exclude: "**/*.aar");
+		if(allFilesExceptForAars.size() <= 0) {
 			return;
 		}
 


### PR DESCRIPTION
_problem_
we create flavors, when there's no need: example: when in a native plugin `tns-core-modules-widgets` we create a flavor when there's only an `.aar` file in the `<plugin>platforms/android` folder.

_solution_
if only aar files inside nativeDependencies, don't create a flavor

> This is a temporary solution to make - debugging the runtime easier.