### PR TITLE
fix(sbg): webpack excludes webpack chunks

### DIFF
--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/Main.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/Main.java
@@ -1,6 +1,7 @@
 package org.nativescript.staticbindinggenerator;
 
 import org.apache.commons.io.FileUtils;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -25,6 +26,7 @@ public class Main {
     private static File outputDir;
     private static File inputDir;
     private static String dependenciesFile;
+    private static String webpackWorkersExcludePath;
 
     static {
         inputJsFiles = new ArrayList<>();
@@ -73,6 +75,8 @@ public class Main {
 
         List<DataRow> inputFile = Generator.getRows(SBG_INPUT_FILE);
         inputDir = new File(inputFile.get(0).getRow());
+        webpackWorkersExcludePath = Paths.get(inputDir.getAbsolutePath(), "__worker-chunks.json").toString();
+
         if (!inputDir.exists() || !inputDir.isDirectory()) {
             throw new IllegalArgumentException(String.format("Couldn't find the output dir %s or it wasn't a directory", inputDir.getAbsolutePath()));
         }
@@ -159,7 +163,6 @@ public class Main {
         }
     }
 
-    private static String webpackWorkersExcludePath = System.getProperty("user.dir") + "/app/src/main/assets/app/__worker-chunks.json";
     private static List<String> webpackWorkersExcludesList;
 
     /*
@@ -172,7 +175,11 @@ public class Main {
         if (workersExcludeFile.exists()) {
             try {
                 String workersExcludeFileContent = FileUtils.readFileToString(workersExcludeFile, Charset.defaultCharset());
-                webpackWorkersExcludesList = (List<String>) new JSONObject(workersExcludeFileContent);
+                JSONArray jsonarray = new JSONArray(workersExcludeFileContent);
+                for (int i = 0; i < jsonarray.length(); i++) {
+                    String excludeFile = (String) jsonarray.get(i);
+                    webpackWorkersExcludesList.add(excludeFile);
+                }
             } catch (Exception e) {
                 e.printStackTrace();
                 System.out.println("Malformed workers exclude file at ${webpackWorkersExcludePath}");


### PR DESCRIPTION
Fix for: https://github.com/NativeScript/android-runtime/issues/898
Webpack generates file `__worker-chunks.json` containing files to ignore while jsparser is doing it's work. That file was not parsed correctly which lead to the crash in the issue.

Don't merge before: https://github.com/NativeScript/android-runtime/pull/901 as this branch build on top of it.