### PR TITLE
fix(user template): problem with jar files in nativescript plugins

### DIFF
--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -217,7 +217,7 @@ task addDependenciesFromNativeScriptPlugins {
             project.dependencies.add("compile", [name: fileName, ext: "aar"])
         }
 
-        def jarFiles = fileTree(dir: file("${dep.directory}/$PLATFORMS_ANDROID"), include: ["**/*.jar"])
+        def jarFiles = fileTree(dir: file("$rootDir/${dep.directory}/$PLATFORMS_ANDROID"), include: ["**/*.jar"])
         jarFiles.each { jarFile ->
             println "\t + adding jar plugin dependency: " + jarFile.getAbsolutePath()
         }


### PR DESCRIPTION
This fixes a number of currently broken nativescript plugins on android.  Basically any nativescript plugin that shipped with it's own jar file for native code is broken until this is made live.  In the interim i execute this command before building/running android (but after it is prepared and there is a `platforms/android` directory):

```
sed -Ei '' 's/"\$\{dep.directory\}\/platforms\/android"/"\$rootDir\/\${dep.directory}\/platforms\/android"/' platforms/android/app/build.gradle
```

