### PR TITLE
fix: jar dependency + bump package version

### DIFF
--- a/build-artifacts/project-template-gradle/app/build.gradle
+++ b/build-artifacts/project-template-gradle/app/build.gradle
@@ -254,7 +254,7 @@ task addDependenciesFromNativeScriptPlugins {
 			project.dependencies.add("compile", [name: fileName, ext: "aar"])
 		}
 
-		def jarFiles = fileTree(dir: file("${dep.directory}/platforms/android"), include: ["**/*.jar"])
+		def jarFiles = fileTree(dir: file("$rootDir/${dep.directory}/platforms/android"), include: ["**/*.jar"])
 		jarFiles.each { jarFile ->
 			println "\t + adding jar plugin dependency: " + jarFile.getAbsolutePath()
 		}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tns-android",
   "description": "NativeScript Runtime for Android",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/NativeScript/android-runtime.git"


### PR DESCRIPTION
* bump package version
* fix problem where metadata isn't generated for plugins' jar dependencies in `platforms/android` fodler