### PR TITLE
chore: add waffle.io badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-[![Build Status](https://travis-ci.org/NativeScript/android-runtime.svg?branch=master)](https://travis-ci.org/NativeScript/android-runtime)
-
 # Android-Runtime
+[![Build Status](https://travis-ci.org/NativeScript/android-runtime.svg?branch=master)](https://travis-ci.org/NativeScript/android-runtime)
+[![Waffle.io - NativeScript Runtimes and CLI](https://badge.waffle.io/NativeScript/android-runtime.svg?columns=In%20Progress)](https://waffle.io/NativeScript/android-runtime)
+
 Contains the source code for the NativeScript's Android runtime. The android-runtime is a main component used in [NativeScript](https://www.nativescript.org/).
 
 # Main Projects


### PR DESCRIPTION
Add waffle.io badge to waffle board in order to give more visibility to the current issues status.