### PR TITLE
fix(sbg): generate unique class names for ts-extended classes

### DIFF
--- a/test-app/app/src/main/assets/internal/ts_helpers.js
+++ b/test-app/app/src/main/assets/internal/ts_helpers.js
@@ -55,7 +55,7 @@
 			function extend(child, parent) {
 				__log("TS extend called");
 				if (!child.__extended) {
-		        	child.__extended = parent.extend(child.name, child.prototype);
+		        	child.__extended = parent.extend(child.name, child.prototype, true);
 		        }
 		 
 		        return child.__extended;

--- a/test-app/runtime/src/main/cpp/MetadataNode.h
+++ b/test-app/runtime/src/main/cpp/MetadataNode.h
@@ -107,7 +107,7 @@ class MetadataNode {
         static void InterfaceConstructorCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
         static void ClassConstructorCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
         static void ExtendMethodCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
-        static bool ValidateExtendArguments(const v8::FunctionCallbackInfo<v8::Value>& info, std::string& extendLocation, v8::Local<v8::String>& extendName, v8::Local<v8::Object>& implementationObject);
+        static bool ValidateExtendArguments(const v8::FunctionCallbackInfo<v8::Value>& info, bool extendLocationFound, std::string& extendLocation, v8::Local<v8::String>& extendName, v8::Local<v8::Object>& implementationObject, bool isTypeScriptExtend);
         static void ExtendedClassConstructorCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
 
         static void NullObjectAccessorGetterCallback(v8::Local<v8::String> property, const v8::PropertyCallbackInfo<v8::Value>& info);
@@ -126,7 +126,7 @@ class MetadataNode {
         static void ArrayIndexedPropertySetterCallback(uint32_t index, v8::Local<v8::Value> value, const v8::PropertyCallbackInfo<v8::Value>& info);
 
         static bool IsValidExtendName(const v8::Local<v8::String>& name);
-        static bool GetExtendLocation(std::string& extendLocation);
+        static bool GetExtendLocation(std::string& extendLocation, bool isTypeScriptExtend);
         static ExtendedClassCacheData GetCachedExtendedClassData(v8::Isolate* isolate, const std::string& proxyClassName);
 
         v8::Local<v8::Function> Wrap(v8::Isolate* isolate, const v8::Local<v8::Function>& function, const std::string& name, const std::string& origin, bool isCtorFunc);


### PR DESCRIPTION
The changes in the PR aim to allow the runtime to create and process class names for Android classes extended in TypeScript code in a fashion similar to how Android classes are extended in JavaScript - the resulting class names contain the _Extendee_ (base class), the file name, line and column of the constructor function definition, as well as the name of the new class (if anonymous).

This is necessary so that Java classes are more easily debugged, and also allows TypeScript-extended Android classes to function properly in an _uglified_ _webpack_ build.

Addresses https://github.com/NativeScript/android-runtime/issues/898, #692, and a couple other issues across the NativeScript organization.
 
