### PR TITLE
Rewrite livesync implementation

### DIFF
--- a/test-app/app/src/debug/java/com/tns/NativeScriptSyncService.java
+++ b/test-app/app/src/debug/java/com/tns/NativeScriptSyncService.java
@@ -30,6 +30,7 @@ public class NativeScriptSyncService {
     }
 
     private class LocalServerSocketThread implements Runnable {
+
         private volatile boolean running;
         private final String name;
 
@@ -62,6 +63,11 @@ public class NativeScriptSyncService {
             } catch (IOException e) {
                 e.printStackTrace();
             }
+        }
+
+        @Override
+        protected void finalize() throws Throwable {
+            this.serverSocket.close();
         }
     }
 
@@ -148,12 +154,6 @@ public class NativeScriptSyncService {
                 logger.write(String.format("Error while LiveSyncing: %s", e.toString()));
                 e.printStackTrace();
                 exceptionWhileLivesyncing = true;
-            } finally {
-                try {
-                    socket.close();
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
             }
 
             if (!exceptionWhileLivesyncing) {
@@ -306,6 +306,11 @@ public class NativeScriptSyncService {
             } while (size > 0);
 
             return buffer;
+        }
+
+        @Override
+        protected void finalize() throws Throwable {
+            this.socket.close();
         }
 
     }

--- a/test-app/app/src/debug/java/com/tns/NativeScriptSyncService.java
+++ b/test-app/app/src/debug/java/com/tns/NativeScriptSyncService.java
@@ -138,8 +138,9 @@ public class NativeScriptSyncService {
                     } else if (operation == CREATE_FILE_OPERATION) {
 
                         String fileName = getFileName();
-                        byte[] content = getFileContent();
+                        byte[] content = getFileContent(fileName);
                         createOrOverrideFile(fileName, content);
+
 
                     } else if (operation == DEFAULT_OPERATION) {
                         logger.write("LiveSync: input stream is empty!");
@@ -222,18 +223,18 @@ public class NativeScriptSyncService {
             return fileName.trim();
         }
 
-        private byte[] getFileContent() throws IOException {
+        private byte[] getFileContent(String fileName) throws IllegalStateException {
             byte[] contentBuff;
             int contentL = -1;
             byte[] contentLength;
             try {
                 contentLength = readNextBytes(CONTENT_LENGTH_BYTE_SIZE);
             } catch (Exception e) {
-                throw new IllegalStateException(String.format("\nLiveSync: failed to parse %s. %s\noriginal exception: %s", FILE_CONTENT_LENGTH, LIVESYNC_ERROR_SUGGESTION, e.toString()));
+                throw new IllegalStateException(String.format("\nLiveSync: failed to parse %s %s. %s\noriginal exception: %s", fileName, FILE_CONTENT_LENGTH, LIVESYNC_ERROR_SUGGESTION, e.toString()));
             }
 
             if (contentLength == null) {
-                throw new IllegalStateException(String.format("\nLiveSync: Missing %s bytes. %s", FILE_CONTENT_LENGTH, LIVESYNC_ERROR_SUGGESTION));
+                throw new IllegalStateException(String.format("\nLiveSync: Missing %s bytes. Did you send %s %s? %s", FILE_CONTENT_LENGTH, fileName, FILE_CONTENT_LENGTH, LIVESYNC_ERROR_SUGGESTION));
             }
 
             try {
@@ -241,13 +242,13 @@ public class NativeScriptSyncService {
                 contentBuff = readNextBytes(contentL);
 
             } catch (NumberFormatException e) {
-                throw new IllegalStateException(String.format("\nLiveSync: failed to parse %s. %s\noriginal exception: %s", FILE_CONTENT_LENGTH, LIVESYNC_ERROR_SUGGESTION, e.toString()));
+                throw new IllegalStateException(String.format("\nLiveSync: failed to parse %s %s. %s\noriginal exception: %s", fileName, FILE_CONTENT_LENGTH, LIVESYNC_ERROR_SUGGESTION, e.toString()));
             } catch (Exception e) {
-                throw new IllegalStateException(String.format("\nLiveSync: failed to parse %s. %s\noriginal exception: %s", FILE_CONTENT, LIVESYNC_ERROR_SUGGESTION, e.toString()));
+                throw new IllegalStateException(String.format("\nLiveSync: failed to parse %s %s. %s\noriginal exception: %s", fileName, FILE_CONTENT, LIVESYNC_ERROR_SUGGESTION, e.toString()));
             }
 
             if (contentBuff == null) {
-                throw new IllegalStateException(String.format("\nLiveSync: Missing %s bytes. %s", FILE_CONTENT, LIVESYNC_ERROR_SUGGESTION));
+                throw new IllegalStateException(String.format("\nLiveSync: Missing %s bytes. Did you send %s %s? %s", FILE_CONTENT, fileName, FILE_CONTENT, LIVESYNC_ERROR_SUGGESTION));
             }
 
             return contentBuff;

--- a/test-app/app/src/debug/java/com/tns/NativeScriptSyncService.java
+++ b/test-app/app/src/debug/java/com/tns/NativeScriptSyncService.java
@@ -113,6 +113,15 @@ public class NativeScriptSyncService {
         public void run() {
             boolean exceptionWhileLivesyncing = false;
             try {
+
+                output.write(context.getPackageName().getBytes());
+
+            } catch (IOException e) {
+                logger.write(String.format("Error while LiveSyncing: Client socket might be closed!", e.toString()));
+                exceptionWhileLivesyncing = true;
+                e.printStackTrace();
+            }
+            try {
                 do {
                     int operation = getOperation();
                     if (operation == DELETE_FILE_OPERATION) {

--- a/test-app/app/src/debug/java/com/tns/NativeScriptSyncService.java
+++ b/test-app/app/src/debug/java/com/tns/NativeScriptSyncService.java
@@ -97,6 +97,7 @@ public class NativeScriptSyncService {
         public static final int CONTENT_LENGTH_BYTE_SIZE = 10;
         public static final int DELETE_FILE_OPERATION = 7;
         public static final int CREATE_FILE_OPERATION = 8;
+        public static final int DO_SYNC_OPERATION = 9;
         public static final String FILE_NAME = "fileName";
         public static final String FILE_NAME_LENGTH = FILE_NAME + "Length";
         public static final String OPERATION = "operation";
@@ -143,7 +144,6 @@ public class NativeScriptSyncService {
                 do {
                     int operation = getOperation();
 
-                    System.out.println("Operation: " + input.available());
                     if (operation == DELETE_FILE_OPERATION) {
 
                         String fileName = getFileName();
@@ -155,6 +155,10 @@ public class NativeScriptSyncService {
                         byte[] content = getFileContent(fileName);
                         createOrOverrideFile(fileName, content);
 
+                    } else if (operation == DO_SYNC_OPERATION) {
+
+                        runtime.runScript(new File(NativeScriptSyncService.this.context.getFilesDir(), "internal/livesync.js"));
+
                     } else if (operation == DEFAULT_OPERATION) {
                         logger.write("LiveSync: input stream is empty!");
                         break;
@@ -162,8 +166,6 @@ public class NativeScriptSyncService {
                         throw new IllegalArgumentException(String.format("\nLiveSync: Operation not recognised. %s", LIVESYNC_ERROR_SUGGESTION));
                     }
 
-                    //TODO: do debouncing
-                    runtime.runScript(new File(NativeScriptSyncService.this.context.getFilesDir(), "internal/livesync.js"));
                 } while (true);
 
             } catch (Exception e) {

--- a/test-app/app/src/main/java/com/tns/LogcatLogger.java
+++ b/test-app/app/src/main/java/com/tns/LogcatLogger.java
@@ -21,11 +21,15 @@ public final class LogcatLogger implements Logger {
     }
 
     public final void write(String msg) {
-        Log.d(DEFAULT_LOG_TAG, msg);
+        if (this.enabled) {
+            Log.d(DEFAULT_LOG_TAG, msg);
+        }
     }
 
     public final void write(String tag, String msg) {
-        Log.d(tag, msg);
+        if (this.enabled) {
+            Log.d(tag, msg);
+        }
     }
 
     private void initLogging(Context context) {

--- a/test-app/app/src/main/java/com/tns/RuntimeHelper.java
+++ b/test-app/app/src/main/java/com/tns/RuntimeHelper.java
@@ -190,8 +190,6 @@ public final class RuntimeHelper {
                         Constructor cons = NativeScriptSyncService.getConstructor(new Class[] {Runtime.class, Logger.class, Context.class});
                         Object syncService = cons.newInstance(runtime, logger, app);
 
-                        Method syncMethod = NativeScriptSyncService.getMethod("sync");
-                        syncMethod.invoke(syncService);
                         Method startServerMethod = NativeScriptSyncService.getMethod("startServer");
                         startServerMethod.invoke(syncService);
                     } catch (ClassNotFoundException e) {


### PR DESCRIPTION
[Related Issue](https://github.com/NativeScript/android-runtime/issues/932)

_problem_
livesync doesn't work the same way on all devices because of permission changes in upper API levels

_solution_
make livesync work with file content passing through unix sockets

_expected behavior_
files that are pushed to socket are created or deleted, depending on operation

Protocol:
create: (operation)(fileNameLength)(fileName)(fileContentLength)(fileContent)
Example of message sent through socket: `800007./a.txt0000000011fileContent`

delete: (operation)(fileNameLength)(fileName)
Example of message sent through socket: `700003./a`

Create example explained:
_operation_: 8 - create, 7 - delete (8)
_fileNamelength_: exactly 5 bytes (00007)
_fileName_: relative to app folder (./a.txt)
_fileContentLength_: exactly 10 bytes (0000000011)
_fileContent_: byte buffer (fileContent)

> This PR is based on [this](https://github.com/NativeScript/android-runtime/tree/plamen5kov/revert) branch.