### PR TITLE
Respect libraries in App_Resources/Android

### DIFF
--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -17,6 +17,7 @@
 */
 
 import groovy.json.JsonSlurper
+import java.nio.file.Paths
 
 apply plugin: "com.android.application"
 
@@ -67,8 +68,25 @@ project.ext.selectedBuildType = project.hasProperty("release") ? "release" : "de
 ///////////////////////////// CONFIGURATIONS ///////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////
 
+def getAppResourcesDirectory = { ->
+    def defaultPathToAppResources = "$USER_PROJECT_ROOT/app/App_Resources"
+    def pathToAppResources
+    def nsConfigFile = file("$USER_PROJECT_ROOT/nsconfig.json")
+
+    if (nsConfigFile.exists()) {
+        def nsConfigJsonContent = new JsonSlurper().parseText(nsConfigFile.getText("UTF-8"))
+
+        if (nsConfigJsonContent.app_resources != null) {
+            pathToAppResources = java.nio.file.Paths.get(USER_PROJECT_ROOT).resolve(nsConfigJsonContent.app_resources).toAbsolutePath()
+        }
+    }
+
+    return pathToAppResources != null ? pathToAppResources : defaultPathToAppResources
+}
+
 def applyAppGradleConfiguration = { ->
-    def pathToAppGradle = "$USER_PROJECT_ROOT/app/App_Resources/Android/app.gradle"
+    def appResourcesDir = getAppResourcesDirectory()
+    def pathToAppGradle = "$appResourcesDir/Android/app.gradle"
     def appGradle = file(pathToAppGradle)
     if (appGradle.exists()) {
         println "\t + applying user-defined configuration from ${appGradle}"

--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -154,6 +154,12 @@ repositories {
     def pluginDependencies = nativescriptDependencies.collect {
         "$rootDir/${it.directory}/$PLATFORMS_ANDROID"
     }
+
+    // some plugins may have their android dependencies in a /libs subdirectory
+    pluginDependencies.addAll(nativescriptDependencies.collect {
+        "$rootDir/${it.directory}/$PLATFORMS_ANDROID/libs"
+    })
+
     if (!externalRuntimeExists) {
         pluginDependencies.add("libs/runtime-libs")
     }

--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -245,6 +245,8 @@ task addDependenciesFromAppResourcesLibraries {
         jarFiles.each { jarFile ->
             println "\t + adding jar library dependency: " + jarFile.getAbsolutePath()
         }
+        
+        project.dependencies.add("compile", jarFiles)
     }
 }
 

--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -150,7 +150,6 @@ android {
 def externalRuntimeExists = !findProject(':runtime').is(null)
 
 repositories {
-
     // used for local *.AAR files
     def pluginDependencies = nativescriptDependencies.collect {
         "$rootDir/${it.directory}/$PLATFORMS_ANDROID"
@@ -158,6 +157,11 @@ repositories {
     if (!externalRuntimeExists) {
         pluginDependencies.add("libs/runtime-libs")
     }
+
+    def localAppResources = getAppResourcesDirectory()
+    def localAppResourcesLibraries = "$localAppResources/Android/libs"
+
+    pluginDependencies.add(localAppResourcesLibraries)
 
     if (pluginDependencies.size() > 0) {
         flatDir {
@@ -222,6 +226,25 @@ task addDependenciesFromNativeScriptPlugins {
         }
 
         project.dependencies.add("compile", jarFiles)
+    }
+}
+
+task addDependenciesFromAppResourcesLibraries {
+    def appResources = getAppResourcesDirectory()
+    def appResourcesLibraries = file("$appResources/Android/libs")
+    if (appResourcesLibraries.exists()) {
+        def aarFiles = fileTree(dir: appResourcesLibraries, include: ["**/*.aar"])
+        aarFiles.each { aarFile ->
+            def length = aarFile.name.length() - 4
+            def fileName = aarFile.name[0..<length]
+            println "\t + adding aar library dependency: " + aarFile.getAbsolutePath()
+            project.dependencies.add("compile", [name: fileName, ext: "aar"])
+        }
+
+        def jarFiles = fileTree(dir: appResourcesLibraries, include: ["**/*.jar"])
+        jarFiles.each { jarFile ->
+            println "\t + adding jar library dependency: " + jarFile.getAbsolutePath()
+        }
     }
 }
 


### PR DESCRIPTION
Modified the build.gradle script to read the `App_Resources` location from the `nsconfig.json` file, and if one isn't present - default to `app/App_Resources`

Implements https://github.com/NativeScript/android-runtime/issues/899 by collecting all jars and aars as local dependencies to the project.

This PR is based on [this](https://github.com/NativeScript/android-runtime/tree/plamen5kov/revert) branch.