### PR TITLE
Revert "fix(sbg): generate unique class names for ts-extended classes #923

### DIFF
--- a/test-app/app/src/main/assets/internal/ts_helpers.js
+++ b/test-app/app/src/main/assets/internal/ts_helpers.js
@@ -55,7 +55,7 @@
 			function extend(child, parent) {
 				__log("TS extend called");
 				if (!child.__extended) {
-		        	child.__extended = parent.extend(child.name, child.prototype, true);
+		        	child.__extended = parent.extend(child.name, child.prototype);
 		        }
 		 
 		        return child.__extended;

--- a/test-app/runtime/src/main/cpp/MetadataNode.cpp
+++ b/test-app/runtime/src/main/cpp/MetadataNode.cpp
@@ -825,6 +825,7 @@ void MetadataNode::ExtendedClassConstructorCallback(const v8::FunctionCallbackIn
         v8::HandleScope handleScope(isolate);
 
         auto implementationObject = Local<Object>::New(isolate, *extData->implementationObject);
+
         const auto& extendName = extData->extendedName;
 
         SetInstanceMetadata(isolate, thiz, extData->node);
@@ -1185,7 +1186,8 @@ void MetadataNode::PackageGetterCallback(Local<Name> property, const PropertyCal
     }
 }
 
-bool MetadataNode::ValidateExtendArguments(const FunctionCallbackInfo<Value>& info, bool extendLocationFound, string& extendLocation, v8::Local<v8::String>& extendName, Local<Object>& implementationObject, bool isTypeScriptExtend) {
+bool MetadataNode::ValidateExtendArguments(const FunctionCallbackInfo<Value>& info, string& extendLocation, v8::Local<v8::String>& extendName, Local<Object>& implementationObject) {
+    bool extendLocationFound = GetExtendLocation(extendLocation);
 
     if (info.Length() == 1) {
         if (!extendLocationFound) {
@@ -1205,7 +1207,7 @@ bool MetadataNode::ValidateExtendArguments(const FunctionCallbackInfo<Value>& in
         }
 
         implementationObject = info[0]->ToObject();
-    } else if (info.Length() == 2 || isTypeScriptExtend) {
+    } else if (info.Length() == 2) {
         if (!info[0]->IsString()) {
             stringstream ss;
             ss << "Invalid extend() call. No name for extend specified at location: " << extendLocation.c_str();
@@ -1280,7 +1282,6 @@ void MetadataNode::ExtendMethodCallback(const v8::FunctionCallbackInfo<v8::Value
         string extendLocation;
 
         auto hasDot = false;
-        auto isTypeScriptExtend = false;
         if (info.Length() == 2) {
             if (info[0].IsEmpty() || !info[0]->IsString()) {
                 stringstream ss;
@@ -1298,19 +1299,13 @@ void MetadataNode::ExtendMethodCallback(const v8::FunctionCallbackInfo<v8::Value
             }
             string strName = ArgConverter::ConvertToString(info[0].As<String>());
             hasDot = strName.find('.') != string::npos;
-        } else if (info.Length() == 3) {
-            if (info[2]->IsBoolean() && info[2]->BooleanValue()) {
-                isTypeScriptExtend = true;
-            }
         }
 
         if (hasDot) {
             extendName = info[0].As<String>();
             implementationObject = info[1].As<Object>();
         } else {
-            std::string getExtendLocation;
-            auto isValidExtendLocation = GetExtendLocation(extendLocation, isTypeScriptExtend);
-            auto validArgs = ValidateExtendArguments(info, isValidExtendLocation, extendLocation, extendName, implementationObject, isTypeScriptExtend);
+            auto validArgs = ValidateExtendArguments(info, extendLocation, extendName, implementationObject);
 
             if (!validArgs) {
                 return;
@@ -1417,17 +1412,11 @@ bool MetadataNode::IsValidExtendName(const Local<String>& name) {
     return true;
 }
 
-bool MetadataNode::GetExtendLocation(string& extendLocation, bool isTypeScriptExtend) {
+bool MetadataNode::GetExtendLocation(string& extendLocation) {
     stringstream extendLocationStream;
-    auto stackTrace = StackTrace::CurrentStackTrace(Isolate::GetCurrent(), 3, StackTrace::kOverview);
+    auto stackTrace = StackTrace::CurrentStackTrace(Isolate::GetCurrent(), 1, StackTrace::kOverview);
     if (!stackTrace.IsEmpty()) {
-        Local<StackFrame> frame;
-        if (isTypeScriptExtend) {
-            frame = stackTrace->GetFrame(2); // the _super.apply call to ts_helpers will always be the third call frame
-        }  else {
-            frame = stackTrace->GetFrame(0);
-        }
-
+        auto frame = stackTrace->GetFrame(0);
         if (!frame.IsEmpty()) {
             auto scriptName = frame->GetScriptName();
             if (scriptName.IsEmpty()) {

--- a/test-app/runtime/src/main/cpp/MetadataNode.h
+++ b/test-app/runtime/src/main/cpp/MetadataNode.h
@@ -107,7 +107,7 @@ class MetadataNode {
         static void InterfaceConstructorCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
         static void ClassConstructorCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
         static void ExtendMethodCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
-        static bool ValidateExtendArguments(const v8::FunctionCallbackInfo<v8::Value>& info, bool extendLocationFound, std::string& extendLocation, v8::Local<v8::String>& extendName, v8::Local<v8::Object>& implementationObject, bool isTypeScriptExtend);
+        static bool ValidateExtendArguments(const v8::FunctionCallbackInfo<v8::Value>& info, std::string& extendLocation, v8::Local<v8::String>& extendName, v8::Local<v8::Object>& implementationObject);
         static void ExtendedClassConstructorCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
 
         static void NullObjectAccessorGetterCallback(v8::Local<v8::String> property, const v8::PropertyCallbackInfo<v8::Value>& info);
@@ -126,7 +126,7 @@ class MetadataNode {
         static void ArrayIndexedPropertySetterCallback(uint32_t index, v8::Local<v8::Value> value, const v8::PropertyCallbackInfo<v8::Value>& info);
 
         static bool IsValidExtendName(const v8::Local<v8::String>& name);
-        static bool GetExtendLocation(std::string& extendLocation, bool isTypeScriptExtend);
+        static bool GetExtendLocation(std::string& extendLocation);
         static ExtendedClassCacheData GetCachedExtendedClassData(v8::Isolate* isolate, const std::string& proxyClassName);
 
         v8::Local<v8::Function> Wrap(v8::Isolate* isolate, const v8::Local<v8::Function>& function, const std::string& name, const std::string& origin, bool isCtorFunc);


### PR DESCRIPTION

This reverts commit 4e89392df4ce0cb68885375b91df35d7575c12f5.

The reasoning behind this is the file length limitation on Windows OS

