### PR TITLE
fix(sbg): change the sbg to generate classes with shorter class names

### DIFF
--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -31,7 +31,7 @@ def PACKAGE_JSON = "package.json"
 def SBG_JAVA_DEPENDENCIES = "sbg-java-dependencies.txt"
 def SBG_INPUT_FILE = "sbg-input-file.txt"
 def SBG_OUTPUT_FILE = "sbg-output-file.txt"
-def SBG_JS_PARCED_FILES = "sbg-js-parced-files.txt"
+def SBG_JS_PARSED_FILES = "sbg-js-parsed-files.txt"
 def SBG_BINDINGS_NAME = "sbg-bindings.txt"
 def SBG_INTERFACE_NAMES = "sbg-interface-names.txt"
 def INPUT_JS_DIR = "$projectDir/src/main/assets/app"
@@ -248,7 +248,6 @@ tasks.whenTaskAdded({ org.gradle.api.DefaultTask currentTask ->
 
 task runSbg(type: JavaExec) {
     inputs.dir(INPUT_JS_DIR)
-    outputs.dir(OUTPUT_JAVA_DIR)
 
     workingDir "$BUILD_TOOLS_PATH"
     main "-jar"
@@ -468,7 +467,7 @@ task validateAppIdMatch {
 
 //////// custom clean ///////////
 task cleanSbg(type: Delete) {
-    delete "$BUILD_TOOLS_PATH/$SBG_JS_PARCED_FILES",
+    delete "$BUILD_TOOLS_PATH/$SBG_JS_PARSED_FILES",
             "$BUILD_TOOLS_PATH/$SBG_JAVA_DEPENDENCIES",
             "$BUILD_TOOLS_PATH/$SBG_INTERFACE_NAMES",
             "$BUILD_TOOLS_PATH/$SBG_BINDINGS_NAME",

--- a/test-app/build-tools/.gitignore
+++ b/test-app/build-tools/.gitignore
@@ -1,7 +1,7 @@
 static-binding-generator.jar
 sbg-bindings.txt
 sbg-interfaces-names.txt
-sbg-js-parced-files.txt
+sbg-js-parsed-files.txt
 sbg-input-file.txt
 sbg-output-file.txt
 sbg-java-dependencies.txt

--- a/test-app/build-tools/jsparser/js_parser.js
+++ b/test-app/build-tools/jsparser/js_parser.js
@@ -40,13 +40,13 @@ var fs = require("fs"),
 	extendDecoratorName = "JavaProxy",
 	interfacesDecoratorName = "Interfaces",
 	outFile = "out/out_parsed_typescript.txt", // default out file
-	inputDir = "input_parced_typescript", // default input folder
+	inputDir = "input_parsed_typescript", // default input folder
 	SBG_INTERFACE_NAMES = "sbg-interface-names.txt",
 	interfacesNamesFilePath = getRelativeToBuildTools(SBG_INTERFACE_NAMES), //default interace_names file path
 	SBG_INPUT_FILE = "sbg-input-file.txt",
 	SBG_BINDINGS_NAME = "sbg-bindings.txt",
 	SBG_INTERFACE_NAMES = "sbg-interfaces-names.txt",
-	SBG_JS_PARCED_FILES = "sbg-js-parced-files.txt",
+	SBG_JS_PARSED_FILES = "sbg-js-parsed-files.txt",
 	interfaceNames = [],
 	inputFiles = [];
 
@@ -67,7 +67,7 @@ try {
 } catch (e) { }
 outFile = getRelativeToBuildTools(SBG_BINDINGS_NAME)
 interfacesNamesFilePath = getRelativeToBuildTools(SBG_INTERFACE_NAMES)
-inputFilesPath = getRelativeToBuildTools(SBG_JS_PARCED_FILES)
+inputFilesPath = getRelativeToBuildTools(SBG_JS_PARSED_FILES)
 
 function getRelativeToBuildTools(relativePath) {
 	return path.resolve(`${BUILD_TOOLS_DIR}/${relativePath}`)
@@ -82,7 +82,6 @@ var tsHelpersFilePath = path.join(inputDir, "..", "internal", "ts_helpers.js");
 // ENTRY POINT!
 readLinesFromFile(inputFilesPath, inputFiles, tsHelpersFilePath)
 	.then(getFileAst)
-	.then(getExtendsLineColumn) //config
 	.then(readInterfaceNames) //config
 	.then(traverseAndAnalyseFilesDir) //start
 	.catch(exceptionHandler);
@@ -127,33 +126,6 @@ function getFileAst(tsHelpersFilePath) {
 
 			return resolve(ast);
 		});
-	});
-};
-
-/*
-*	Get line and column of the extend function in the tsHelpers.js file
-* 	(Line and column are used as identifiers for the typescript extended classes!)
-*/
-function getExtendsLineColumn(ast) {
-	return new Promise(function (resolve, reject) {
-
-		var tsHelpersInfo = {};
-		traverse.default(ast, {
-			enter: function (path) {
-
-				if (t.isAssignmentExpression(path.parent) &&
-					t.isCallExpression(path) &&
-					path.node.callee.property &&
-					path.node.callee.property.name === "extend" &&
-					path.node.callee.object.name === "parent") {
-					tsHelpersInfo.line = path.node.callee.property.loc.start.line
-					tsHelpersInfo.column = path.node.callee.property.loc.start.column + 1
-				}
-			}
-		})
-
-		es5_visitors.setLineAndColumn(tsHelpersInfo);
-		return resolve(true);
 	});
 };
 

--- a/test-app/build-tools/jsparser/package.json
+++ b/test-app/build-tools/jsparser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ast-parser",
   "version": "1.0.0",
-  "description": "",
+  "description": "javascript static analysis tool",
   "main": "js_parser.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -15,6 +15,5 @@
     "filewalker": "0.1.2",
     "lazy": "1.0.11"
   },
-  "repository": "https://github.com/NativeScript/android-runtime",
-  "description": "javascript static analysis tool"
+  "repository": "https://github.com/NativeScript/android-runtime"
 }

--- a/test-app/build-tools/jsparser/visitors/es5-visitors.js
+++ b/test-app/build-tools/jsparser/visitors/es5-visitors.js
@@ -4,11 +4,7 @@ var es5_visitors = (function () {
 
         defaultExtendDecoratorName = "JavaProxy",
         columnOffset = 1,
-        FILE_SEPARATOR = "_f",
-        LINE_SEPARATOR = "_l",
-        COLUMN_SEPARATOR = "_c",
-        DECLARED_CLASS_SEPARATOR = "__",
-        TYPESCRIPT_EXTEND_STRING = FILE_SEPARATOR + "rnal_ts_helpers_l47_c38",
+        ASTERISK_SEPARATOR = "*",
         customExtendsArr = [],
         normalExtendsArr = [],
         interfacesArr = [],
@@ -72,9 +68,9 @@ var es5_visitors = (function () {
         return res;
     }
 
-	/*
-	*	Returns the common extends array generated from visitor
-	*/
+    /*
+   *       Returns the common extends array generated from visitor
+   */
     es5Visitor.getCommonExtendInfo = function () {
         var res = [];
         for (var index in normalExtendsArr) {
@@ -168,7 +164,7 @@ var es5_visitors = (function () {
         } else {
             var lineToWrite;
 
-            lineToWrite = _generateLineToWrite("", extendClass, overriddenMethodNames, `${FILE_SEPARATOR}${config.filePath}${LINE_SEPARATOR}${typescriptClassExtendSuperCallLocation.line}${COLUMN_SEPARATOR}${typescriptClassExtendSuperCallLocation.column}` + DECLARED_CLASS_SEPARATOR + declaredClassName, "", implementedInterfaces);
+            lineToWrite = _generateLineToWrite("", extendClass, overriddenMethodNames, { file: config.filePath, line: typescriptClassExtendSuperCallLocation.line, column: typescriptClassExtendSuperCallLocation.column, className: declaredClassName }, "", implementedInterfaces);
 
             if (config.logger) {
                 config.logger.info(lineToWrite)
@@ -382,7 +378,12 @@ var es5_visitors = (function () {
 
             var isCorrectInterfaceName = _testClassName(arg0.value);
             var overriddenInterfaceMethods = _getOverriddenMethods(arg1, config);
-            var extendInfo = FILE_SEPARATOR + config.filePath + LINE_SEPARATOR + path.node.loc.start.line + COLUMN_SEPARATOR + (path.node.loc.start.column + columnOffset) + DECLARED_CLASS_SEPARATOR + (isCorrectInterfaceName ? arg0.value : "");
+            var extendInfo = {
+                file: config.filePath,
+                line: path.node.loc.start.line,
+                column: path.node.loc.start.column + columnOffset,
+                className: (isCorrectInterfaceName ? arg0.value : "")
+            }
             var lineToWrite = _generateLineToWrite("", currentInterface, overriddenInterfaceMethods.join(","), extendInfo, "");
             if (config.logger) {
                 config.logger.info(lineToWrite)
@@ -496,7 +497,12 @@ var es5_visitors = (function () {
             if (config.logger) {
                 config.logger.info(lineToWrite)
             }
-            var extendInfo = FILE_SEPARATOR + config.filePath + LINE_SEPARATOR + path.node.property.loc.start.line + COLUMN_SEPARATOR + (path.node.property.loc.start.column + columnOffset) + DECLARED_CLASS_SEPARATOR + className;
+            var extendInfo = {
+                file: config.filePath,
+                line: path.node.property.loc.start.line,
+                column: path.node.property.loc.start.column + columnOffset,
+                className: className
+            };
             lineToWrite = _generateLineToWrite(isCorrectExtendClassName ? className : "", extendClass.reverse().join("."), overriddenMethodNames, extendInfo, "", implementedInterfaces);
             normalExtendsArr.push(lineToWrite)
         }
@@ -727,9 +733,22 @@ var es5_visitors = (function () {
         return false;
     }
 
-    function _generateLineToWrite(classNameFromDecorator, extendClass, overriddenMethodNames, extendInfo, filePath, implementedInterfaces) {
-        var sanitizedExtendInfo = extendInfo.replace(/[-\\/\\.]/g, "_");
-        var lineToWrite = extendClass + "*" + sanitizedExtendInfo + "*" + overriddenMethodNames + "*" + classNameFromDecorator + "*" + filePath + "*" + (implementedInterfaces ? implementedInterfaces : "");
+    function _generateLineToWrite(classNameFromDecorator, extendClass, overriddenMethodNames, extendInfo, filePath, implementedInterfaces = "") {
+        const extendInfoFile = extendInfo.file ? extendInfo.file.replace(/[-\\/\\.]/g, "_") : "";
+        const extendInfoLine = extendInfo.line ? extendInfo.line : "";
+        const extendInfoColumn = extendInfo.column ? extendInfo.column : "";
+        const extendInfoNewClassName = extendInfo.className ? extendInfo.className : "";
+
+        var lineToWrite = `${extendClass}${ASTERISK_SEPARATOR}`
+            + `${extendInfoFile}${ASTERISK_SEPARATOR}`
+            + `${extendInfoLine}${ASTERISK_SEPARATOR}`
+            + `${extendInfoColumn}${ASTERISK_SEPARATOR}`
+            + `${extendInfoNewClassName}${ASTERISK_SEPARATOR}`
+            + `${overriddenMethodNames}${ASTERISK_SEPARATOR}`
+            + `${classNameFromDecorator}${ASTERISK_SEPARATOR}`
+            + `${filePath}${ASTERISK_SEPARATOR}`
+            + `${implementedInterfaces}`
+
         return lineToWrite;
     }
 
@@ -737,8 +756,7 @@ var es5_visitors = (function () {
         if (customExtendsArrGlobal.indexOf(param) === -1) {
             customExtendsArr.push(lineToWrite)
             customExtendsArrGlobal.push(param)
-        }
-        else {
+        } else {
             console.log("Warning: there already is an extend called " + param + ".")
             if (extendPath.indexOf("tns_modules") === -1) {
                 // app folder will take precedence over tns_modules
@@ -749,13 +767,8 @@ var es5_visitors = (function () {
         }
     }
 
-    function setLineAndColumn(data) {
-        TYPESCRIPT_EXTEND_STRING = FILE_SEPARATOR + "rnal_ts_helpers_l" + data.line + "_c" + data.column;
-    }
-
     return {
-        es5Visitor: es5Visitor,
-        setLineAndColumn: setLineAndColumn
+        es5Visitor: es5Visitor
     }
 })();
 

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/DataRow.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/DataRow.java
@@ -2,10 +2,14 @@ package org.nativescript.staticbindinggenerator;
 
 public class DataRow {
     private final String DELIMITER = "\\*";
-    private final int ELEMENT_NUMBER = 6;
+    private final int ELEMENT_NUMBER = 9;
     private final String row;
     private String baseClassname;
     private String suffix;
+    private String file;
+    private String line;
+    private String column;
+    private String newClassName;
     private String[] methods;
     private String filename;
     private String jsFilename;
@@ -24,8 +28,25 @@ public class DataRow {
         return baseClassname;
     }
 
+
     public String getSuffix() {
         return suffix;
+    }
+
+    public String getFile() {
+        return file;
+    }
+
+    public String getLine() {
+        return line;
+    }
+
+    public String getColumn() {
+        return column;
+    }
+
+    public String getNewClassName() {
+        return newClassName;
     }
 
     public String[] getMethods() {
@@ -52,10 +73,17 @@ public class DataRow {
         }
 
         baseClassname = data[0];
-        suffix = data[1];
-        methods = data[2].split(",");
-        filename = data[3];
-        jsFilename = data[4];
-        interfaces = data[5].split(",");
+        file = data[1];
+        line = data[2];
+        column = data[3];
+
+        int newClassNameIndex = 4;
+
+        newClassName = data[newClassNameIndex];
+
+        methods = data[newClassNameIndex + 1].split(",");
+        filename = data[newClassNameIndex + 2];
+        jsFilename = data[newClassNameIndex + 3];
+        interfaces = data[newClassNameIndex + 4].split(",");
     }
 }

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/Generator.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/Generator.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
@@ -84,19 +85,21 @@ public class Generator {
 
         File baseDir = new File(outputDir, baseDirPath);
         if (!baseDir.exists()) {
-            boolean success = baseDir.mkdirs();
+            baseDir.mkdirs();
         }
 
-        String name;
+        String name = "";
         Boolean isInterface = clazz.isInterface();
 
         if (hasSpecifiedName) {
             name = getSimpleClassname(dataRow.getFilename());
         } else {
-            name = getSimpleClassname(clazz.getClassName());
-
-            if (!isInterface) {
-                name += dataRow.getSuffix();
+            if (isInterface) {
+                name = getSimpleClassname(clazz.getClassName());
+            } else {
+                // name of the class: last portion of the full file name + line + column + variable name
+                String[] lastFilePathPart = dataRow.getFile().split("_");
+                name += lastFilePathPart[lastFilePathPart.length - 1] + "_" + dataRow.getLine() + "_" + dataRow.getColumn() + "_" + dataRow.getNewClassName();
             }
         }
 
@@ -149,9 +152,6 @@ public class Generator {
             String classname = dataRow.getBaseClassname();
             boolean isJavaExtend = classes.containsKey(classname);
             if (isJavaExtend) {
-
-//                System.out.println("SBG: DataRow: baseClassName: " + classname + ", suffix: " + dataRow.getSuffix() + ", interfaces: " + String.join(", ", Arrays.asList(dataRow.getInterfaces())) + ", jsFileName: " + dataRow.getJsFilename());
-
                 Binding binding = generateBinding(dataRow, interfaceNames);
 
                 if (binding != null) {

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/Main.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/Main.java
@@ -18,7 +18,7 @@ public class Main {
     public static final String SBG_INPUT_FILE = "sbg-input-file.txt";
     public static final String SBG_OUTPUT_FILE = "sbg-output-file.txt";
     public static final String SBG_BINDINGS_NAME = "sbg-bindings.txt";
-    public static final String SBG_JS_PARCED_FILES = "sbg-js-parced-files.txt";
+    public static final String SBG_JS_PARSED_FILES = "sbg-js-parsed-files.txt";
     public static final String SBG_INTERFACE_NAMES = "sbg-interfaces-names.txt";
 
     private static String jsCodeAbsolutePath;
@@ -57,7 +57,7 @@ public class Main {
         } catch (JSONException e) {
             e.printStackTrace();
         }
-        String pathToJsFileParams = SBG_JS_PARCED_FILES;
+        String pathToJsFileParams = SBG_JS_PARSED_FILES;
         PrintWriter pw = GetInterfaceNames.ensureOutputFile(pathToJsFileParams);
         for (String f : inputJsFiles) {
             pw.write(f);

--- a/test-app/runtime/src/main/cpp/Util.cpp
+++ b/test-app/runtime/src/main/cpp/Util.cpp
@@ -110,3 +110,20 @@ u16string Util::ConvertFromUtf8ToUtf16(const string& str) {
 
     return utf16String;
 }
+
+void Util::JoinString(const std::vector<std::string>& list, const std::string& delimiter,
+                      std::string& out) {
+    out.clear();
+
+    stringstream ss;
+
+    for (vector<string>::const_iterator it = list.begin(); it != list.end(); ++it) {
+        ss << *it;
+
+        if (it != list.end() - 1) {
+            ss << delimiter;
+        }
+    }
+
+    out = ss.str();
+}

--- a/test-app/runtime/src/main/cpp/Util.h
+++ b/test-app/runtime/src/main/cpp/Util.h
@@ -12,6 +12,8 @@ class Util {
 
         static void SplitString(const std::string& str, const std::string& delimiters, std::vector<std::string>& tokens);
 
+        static void JoinString(const std::vector<std::string>& list, const std::string& delimiter, std::string& out);
+
         static bool EndsWith(const std::string& str, const std::string& suffix);
 
         static std::string ConvertFromJniToCanonicalName(const std::string& name);

--- a/test-app/runtime/src/main/java/com/tns/ClassResolver.java
+++ b/test-app/runtime/src/main/java/com/tns/ClassResolver.java
@@ -14,16 +14,10 @@ class ClassResolver {
         String name = null;
         String className = cannonicalClassName;
 
-        int classExtendSeparatorIndex = cannonicalClassName.indexOf("_f");
-        if (classExtendSeparatorIndex != -1) {
-            className = cannonicalClassName.substring(0, classExtendSeparatorIndex);
-            name = cannonicalClassName.substring(classExtendSeparatorIndex + 1);
-        } else {
-            classExtendSeparatorIndex = cannonicalClassName.indexOf("_unknown_location");
-            if (classExtendSeparatorIndex != -1) {
-                className = cannonicalClassName.substring(0, classExtendSeparatorIndex);
-                name = cannonicalClassName.substring(classExtendSeparatorIndex + 1);
-            }
+        int locationSeparatorIndex = cannonicalClassName.indexOf("_unknown_location");
+        if (locationSeparatorIndex != -1) {
+            className = cannonicalClassName.substring(0, locationSeparatorIndex);
+            name = cannonicalClassName.substring(locationSeparatorIndex + 1);
         }
 
         Class<?> clazz = null;

--- a/test-app/runtime/src/main/java/com/tns/DexFactory.java
+++ b/test-app/runtime/src/main/java/com/tns/DexFactory.java
@@ -64,10 +64,6 @@ public class DexFactory {
     public Class<?> resolveClass(String name, String className, String[] methodOverrides, String[] implementedInterfaces, boolean isInterface) throws ClassNotFoundException, IOException {
         String fullClassName = className.replace("$", "_");
 
-        if (!isInterface) {
-            fullClassName += CLASS_NAME_LOCATION_SEPARATOR + name;
-        }
-
         // try to get pre-generated binding classes
         try {
             if (logger.isEnabled()) {
@@ -82,6 +78,9 @@ public class DexFactory {
 
             return pregeneratedClass;
         } catch (Exception e) {
+            if (logger.isEnabled()) {
+                logger.write("Pre-generated class not found:  " + fullClassName.replace("-", "_"));
+            }
         }
         //
 


### PR DESCRIPTION
The change is required to mitigate and prevent the long-path windows error
from crashing builds on windows when there are classes extended in a
deeper directory structure such as:
`GestureDetector_SimpleOnGestureListener_ftns_modules_tns_core_modules_ui_gestures_gestures_l16_c32__TapAndDoubleTapGestureListenerImpl`

The changes make it so the same class would be reduced to:
`gestures_16_32_TapAndDoubleTapGestureListenerImpl`. This is achieved by not
including the base class in the name, stripping the path name to just the
last fragment of the path, as well as removing redundant underscores, and
line/column separators

Interface names are preserved - package name + class name for the java class stubs preserve the original package name + class name and prepend `com.tns.gen`.

The PR is based on the [plamen5kov/revert](https://github.com/NativeScript/android-runtime/tree/plamen5kov/revert) branch.