### PR TITLE
[SBG] Escape spaces in file names

### DIFF
--- a/test-app/build-tools/jsparser/visitors/es5-visitors.js
+++ b/test-app/build-tools/jsparser/visitors/es5-visitors.js
@@ -734,7 +734,7 @@ var es5_visitors = (function () {
     }
 
     function _generateLineToWrite(classNameFromDecorator, extendClass, overriddenMethodNames, extendInfo, filePath, implementedInterfaces = "") {
-        const extendInfoFile = extendInfo.file ? extendInfo.file.replace(/[-\\/\\.]/g, "_") : "";
+        const extendInfoFile = extendInfo.file ? extendInfo.file.replace(/[-\\/\\. ]/g, "_") : "";
         const extendInfoLine = extendInfo.line ? extendInfo.line : "";
         const extendInfoColumn = extendInfo.column ? extendInfo.column : "";
         const extendInfoNewClassName = extendInfo.className ? extendInfo.className : "";


### PR DESCRIPTION
Ad addendum to my last PR https://github.com/NativeScript/android-runtime/pull/942

The addition in this PR fixes a bug with java classes extended in javascript files that contain spaces in the name.