### PR TITLE
feat(nsconfig): read app resources path from nsconfig or default

### DIFF
--- a/build-artifacts/project-template-gradle/app/build.gradle
+++ b/build-artifacts/project-template-gradle/app/build.gradle
@@ -76,6 +76,27 @@ def renameResultApks = { variant ->
 ///////////////////////////// CONFIGURATIONS ///////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////
 
+def getAppResourcesDirectory = { ->
+	def USER_PROJECT_ROOT = "$rootDir/../.."
+    def defaultPathToAppResources = "$USER_PROJECT_ROOT/app/App_Resources"
+    def pathToAppResources
+    def nsConfigFile = file("$USER_PROJECT_ROOT/nsconfig.json")
+
+    if (nsConfigFile.exists()) {
+        def nsConfigJsonContent = new JsonSlurper().parseText(nsConfigFile.getText("UTF-8"))
+
+        if (nsConfigJsonContent.appResourcesPath != null) {
+            pathToAppResources = java.nio.file.Paths.get(USER_PROJECT_ROOT).resolve(nsConfigJsonContent.appResourcesPath).toAbsolutePath()
+        } else if (nsConfigJsonContent.appPath != null) {
+			def pathToApp = java.nio.file.Paths.get(USER_PROJECT_ROOT).resolve(nsConfigJsonContent.appPath).toAbsolutePath();
+			pathToAppResources = "$pathToApp/App_Resources"
+		}
+    }
+
+    return pathToAppResources != null ? pathToAppResources : defaultPathToAppResources
+}
+
+
 def applyPluginsIncludeGradleConfigurations =  { ->
 	def taskNames = project.getGradle().startParameter.taskNames
 
@@ -139,7 +160,8 @@ def applyPluginsIncludeGradleConfigurations =  { ->
 }
 
 def applyAppGradleConfiguration = { ->
-	def pathToAppGradle = "$rootDir/../../app/App_Resources/Android/app.gradle"
+	def appResourcesDir = getAppResourcesDirectory()
+	def pathToAppGradle = "$appResourcesDir/Android/app.gradle"
 	def appGradle = file(pathToAppGradle)
 	if (appGradle.exists()) {
 		println "\t + applying user-defined configuration from ${appGradle}"


### PR DESCRIPTION
<!--Dear friend, we, the rest of the NativeScript community thank you for your
contribution! Because we want to present a really nice, readable changelog with each
release, please provide the following information: -->

### Create a meaningful title
<!-- Please, ensure your title is less than 50 characters and starts with a capital letter. We strive to follow the guidelines in the
[How to Write a Git Commit Message] (http://chris.beams.io/posts/git-commit/) article for PR titles. -->
Read App Resources path from nsconfig.

### Description
Part of implementation for https://github.com/NativeScript/nativescript-cli/issues/3257

### Related Pull Requests
<!-- List links related to this Pull Request from other repos/branches: -->
https://github.com/NativeScript/nativescript-cli/pull/3329
https://github.com/NativeScript/nativescript-cli/pull/3356

