### PR TITLE
fix(console): implement a smarter JSON.stringify which doesn't crash on Circular references

### DIFF
--- a/test-app/runtime/src/main/cpp/V8GlobalHelpers.cpp
+++ b/test-app/runtime/src/main/cpp/V8GlobalHelpers.cpp
@@ -9,6 +9,8 @@
 using namespace v8;
 using namespace std;
 
+static std::map<v8::Isolate*, v8::Persistent<v8::Function>*> isolateToPersistentSmartJSONStringify = std::map<v8::Isolate*, v8::Persistent<v8::Function>*>();
+
 string tns::ConvertToString(const Local<v8::String>& s) {
     if (s.IsEmpty()) {
         return string();
@@ -18,6 +20,61 @@ string tns::ConvertToString(const Local<v8::String>& s) {
     }
 }
 
+Local<Function> GetSmartJSONStringifyFunction(Isolate* isolate) {
+    auto it = isolateToPersistentSmartJSONStringify.find(isolate);
+    if (it != isolateToPersistentSmartJSONStringify.end()) {
+        auto smartStringifyPersistentFunction = it->second;
+
+        return smartStringifyPersistentFunction->Get(isolate);
+    }
+
+    string smartStringifyFunctionScript =
+        "(function () {\n"
+        "    function smartStringify(object) {\n"
+        "        seen = [];\n"
+        "        var replacer = function (key, value) {\n"
+        "            if (value != null && typeof value == \"object\") {\n"
+        "                if (seen.indexOf(value) >= 0) {\n"
+        "                    if (key) {\n"
+        "                        return \"[Circular]\";\n"
+        "                    }\n"
+        "                    return;\n"
+        "                }\n"
+        "                seen.push(value);\n"
+        "            }\n"
+        "            return value;\n"
+        "        };\n"
+        "        return JSON.stringify(object, replacer, 2);\n"
+        "    }\n"
+        "    return smartStringify;\n"
+        "})();";
+
+    auto source = tns::ArgConverter::ConvertToV8String(isolate, smartStringifyFunctionScript);
+    auto context = isolate->GetCurrentContext();
+
+    Local<Script> script;
+    auto maybeScript = Script::Compile(context, source).ToLocal(&script);
+
+    if (script.IsEmpty()) {
+        return Local<Function>();
+    }
+
+    Local<Value> result;
+    auto maybeResult = script->Run(context).ToLocal(&result);
+
+    if (result.IsEmpty() && !result->IsFunction()) {
+        return Local<Function>();
+    }
+
+    auto smartStringifyFunction = result.As<Function>();
+
+    auto smartStringifyPersistentFunction = new Persistent<Function>(isolate, smartStringifyFunction);
+
+    isolateToPersistentSmartJSONStringify.insert(std::make_pair(isolate, smartStringifyPersistentFunction));
+
+    return smartStringifyPersistentFunction->Get(isolate);
+}
+
 Local<String> tns::JsonStringifyObject(Isolate* isolate, Handle<v8::Value> value) {
     v8::HandleScope scope(isolate);
 
@@ -25,9 +82,25 @@ Local<String> tns::JsonStringifyObject(Isolate* isolate, Handle<v8::Value> value
         return String::Empty(isolate);
     }
 
+    Local<Function> smartJSONStringifyFunction = GetSmartJSONStringifyFunction(isolate);
+
+    if (!smartJSONStringifyFunction.IsEmpty()) {
+        if (value->IsObject()) {
+            v8::Local<v8::Value> resultValue;
+            v8::TryCatch tc;
+
+            Local<Value> args[] = { value->ToObject() };
+            auto success = smartJSONStringifyFunction->Call(isolate->GetCurrentContext(), Undefined(isolate), 1, args).ToLocal(&resultValue);
+
+            if (success && !tc.HasCaught()) {
+                return resultValue->ToString();
+            }
+        }
+    }
+
     v8::Local<v8::String> resultString;
     v8::TryCatch tc;
-    auto success = v8::JSON::Stringify(isolate->GetCurrentContext(), value->ToObject(isolate)).ToLocal(&resultString);
+    auto success = v8::JSON::Stringify(isolate->GetCurrentContext(), value->ToObject(isolate), ArgConverter::ConvertToV8String(isolate, "2")).ToLocal(&resultString);
 
     if (!success && tc.HasCaught()) {
         auto message = tc.Message()->Get();
@@ -123,4 +196,3 @@ bool tns::V8SetPrivateValue(Isolate* isolate, const Local<Object>& obj, const Lo
 
     return res.FromMaybe(false);
 }
-

--- a/test-app/runtime/src/main/cpp/V8GlobalHelpers.h
+++ b/test-app/runtime/src/main/cpp/V8GlobalHelpers.h
@@ -5,6 +5,7 @@
 #include "v8.h"
 #include "include/v8.h"
 #include <string>
+#include <map>
 
 namespace tns {
 std::string ConvertToString(const v8::Local<v8::String>& s);

--- a/test-app/runtime/src/main/cpp/console/Console.cpp
+++ b/test-app/runtime/src/main/cpp/console/Console.cpp
@@ -12,6 +12,7 @@
 #include <V8GlobalHelpers.h>
 #include <v8_inspector/src/inspector/v8-log-agent-impl.h>
 #include <JsV8InspectorClient.h>
+#include <NativeScriptException.h>
 #include "Console.h"
 
 namespace tns {
@@ -164,114 +165,186 @@ const std::string buildLogString(const v8::FunctionCallbackInfo<v8::Value>& info
 }
 
 void Console::assertCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
-    auto isolate = info.GetIsolate();
+    try {
+        auto isolate = info.GetIsolate();
 
-    auto argLen = info.Length();
-    auto expressionPasses = argLen && info[0]->BooleanValue();
+        auto argLen = info.Length();
+        auto expressionPasses = argLen && info[0]->BooleanValue();
 
-    if (!expressionPasses) {
-        std::stringstream assertionError;
+        if (!expressionPasses) {
+            std::stringstream assertionError;
 
-        assertionError << "Assertion failed: ";
+            assertionError << "Assertion failed: ";
 
-        if (argLen > 1) {
-            assertionError << buildLogString(info, 1);
-        } else {
-            assertionError << "console.assert";
+            if (argLen > 1) {
+                assertionError << buildLogString(info, 1);
+            } else {
+                assertionError << "console.assert";
+            }
+
+            std::string log = assertionError.str();
+            sendToADBLogcat(log, ANDROID_LOG_ERROR);
+            sendToDevToolsFrontEnd(isolate, log, "error");
         }
-
-        std::string log = assertionError.str();
-        sendToADBLogcat(log, ANDROID_LOG_ERROR);
-        sendToDevToolsFrontEnd(isolate, log, "error");
+    } catch (NativeScriptException& e) {
+        e.ReThrowToV8();
+    } catch (std::exception e) {
+        std::stringstream ss;
+        ss << "Error: c++ exception: " << e.what() << std::endl;
+        NativeScriptException nsEx(ss.str());
+        nsEx.ReThrowToV8();
+    } catch (...) {
+        NativeScriptException nsEx(std::string("Error: c++ exception!"));
+        nsEx.ReThrowToV8();
     }
 }
 
 void Console::errorCallback(const v8::FunctionCallbackInfo <v8::Value>& info) {
-    std::string log = buildLogString(info);
+    try {
+        std::string log = buildLogString(info);
 
-    sendToADBLogcat(log, ANDROID_LOG_ERROR);
-    sendToDevToolsFrontEnd(info.GetIsolate(), log, "error");
+        sendToADBLogcat(log, ANDROID_LOG_ERROR);
+        sendToDevToolsFrontEnd(info.GetIsolate(), log, "error");
+    } catch (NativeScriptException& e) {
+        e.ReThrowToV8();
+    } catch (std::exception e) {
+        std::stringstream ss;
+        ss << "Error: c++ exception: " << e.what() << std::endl;
+        NativeScriptException nsEx(ss.str());
+        nsEx.ReThrowToV8();
+    } catch (...) {
+        NativeScriptException nsEx(std::string("Error: c++ exception!"));
+        nsEx.ReThrowToV8();
+    }
 }
 
 void Console::infoCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
-    std::string log = buildLogString(info);
+    try {
+        std::string log = buildLogString(info);
 
-    sendToADBLogcat(log, ANDROID_LOG_INFO);
-    sendToDevToolsFrontEnd(info.GetIsolate(), log, "info");
+        sendToADBLogcat(log, ANDROID_LOG_INFO);
+        sendToDevToolsFrontEnd(info.GetIsolate(), log, "info");
+    } catch (NativeScriptException& e) {
+        e.ReThrowToV8();
+    } catch (std::exception e) {
+        std::stringstream ss;
+        ss << "Error: c++ exception: " << e.what() << std::endl;
+        NativeScriptException nsEx(ss.str());
+        nsEx.ReThrowToV8();
+    } catch (...) {
+        NativeScriptException nsEx(std::string("Error: c++ exception!"));
+        nsEx.ReThrowToV8();
+    }
 }
 
 void Console::logCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
-    std::string log = buildLogString(info);
+    try {
+        std::string log = buildLogString(info);
 
-    sendToADBLogcat(log, ANDROID_LOG_INFO);
-    sendToDevToolsFrontEnd(info.GetIsolate(), log, "info");
+        sendToADBLogcat(log, ANDROID_LOG_INFO);
+        sendToDevToolsFrontEnd(info.GetIsolate(), log, "info");
+    } catch (NativeScriptException& e) {
+        e.ReThrowToV8();
+    } catch (std::exception e) {
+        std::stringstream ss;
+        ss << "Error: c++ exception: " << e.what() << std::endl;
+        NativeScriptException nsEx(ss.str());
+        nsEx.ReThrowToV8();
+    } catch (...) {
+        NativeScriptException nsEx(std::string("Error: c++ exception!"));
+        nsEx.ReThrowToV8();
+    }
 }
 
 void Console::warnCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
-    std::string log = buildLogString(info);
+    try {
+        std::string log = buildLogString(info);
 
-    sendToADBLogcat(log, ANDROID_LOG_WARN);
-    sendToDevToolsFrontEnd(info.GetIsolate(), log, "warning");
+        sendToADBLogcat(log, ANDROID_LOG_WARN);
+        sendToDevToolsFrontEnd(info.GetIsolate(), log, "warning");
+    } catch (NativeScriptException& e) {
+        e.ReThrowToV8();
+    } catch (std::exception e) {
+        std::stringstream ss;
+        ss << "Error: c++ exception: " << e.what() << std::endl;
+        NativeScriptException nsEx(ss.str());
+        nsEx.ReThrowToV8();
+    } catch (...) {
+        NativeScriptException nsEx(std::string("Error: c++ exception!"));
+        nsEx.ReThrowToV8();
+    }
 }
 
 void Console::dirCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
-    auto isolate = info.GetIsolate();
-    auto context = isolate->GetCurrentContext();
+    try {
+        auto isolate = info.GetIsolate();
+        auto context = isolate->GetCurrentContext();
 
-    v8::HandleScope scope(isolate);
+        v8::HandleScope scope(isolate);
 
-    std::stringstream ss;
+        std::stringstream ss;
 
-    auto argLen = info.Length();
-    if (argLen) {
-        if (info[0]->IsObject()) {
-            ss << "==== object dump start ====" << std::endl;
-            v8::Local<v8::Object> argObject = info[0].As<v8::Object>();
+        auto argLen = info.Length();
+        if (argLen) {
+            if (info[0]->IsObject()) {
+                ss << "==== object dump start ====" << std::endl;
+                v8::Local<v8::Object> argObject = info[0].As<v8::Object>();
 
-            v8::Local<v8::Array> propNames;
-            argObject->GetPropertyNames(context).ToLocal(&propNames);
+                v8::Local<v8::Array> propNames;
+                argObject->GetPropertyNames(context).ToLocal(&propNames);
 
-            auto propertiesLen = propNames->Length();
-            for (int i = 0; i < propertiesLen; i++) {
-                auto propertyName = propNames->Get(context, i).ToLocalChecked();
-                auto propertyValue = argObject->Get(context, propertyName).ToLocalChecked();
+                auto propertiesLen = propNames->Length();
+                for (int i = 0; i < propertiesLen; i++) {
+                    auto propertyName = propNames->Get(context, i).ToLocalChecked();
+                    auto propertyValue = argObject->Get(context, propertyName).ToLocalChecked();
 
-                auto propIsFunction = propertyValue->IsFunction();
+                    auto propIsFunction = propertyValue->IsFunction();
 
-                ss << ArgConverter::ConvertToString(propertyName->ToString(isolate));
+                    ss << ArgConverter::ConvertToString(propertyName->ToString(isolate));
 
-                if (propIsFunction) {
-                    ss << "()";
-                } else if (propertyValue->IsObject()) {
-                    auto obj = propertyValue->ToObject(isolate);
-                    auto objString = transformJSObject(isolate, obj);
-                    std::string jsonStringifiedObject = ArgConverter::ConvertToString(objString);
-                    // if object prints out as the error string for circular references, replace with #CR instead for brevity
-                    if (jsonStringifiedObject.find("circular structure") != std::string::npos) {
-                        jsonStringifiedObject = "#CR";
+                    if (propIsFunction) {
+                        ss << "()";
+                    } else if (propertyValue->IsObject()) {
+                        auto obj = propertyValue->ToObject(isolate);
+                        auto objString = transformJSObject(isolate, obj);
+                        std::string jsonStringifiedObject = ArgConverter::ConvertToString(objString);
+                        // if object prints out as the error string for circular references, replace with #CR instead for brevity
+                        if (jsonStringifiedObject.find("circular structure") != std::string::npos) {
+                            jsonStringifiedObject = "#CR";
+                        }
+                        ss << ": " << jsonStringifiedObject;
+                    } else {
+                        ss << ": \"" << ArgConverter::ConvertToString(propertyValue->ToDetailString(isolate)) << "\"";
                     }
-                    ss << ": " << jsonStringifiedObject;
-                } else {
-                    ss << ": \"" << ArgConverter::ConvertToString(propertyValue->ToDetailString(isolate)) << "\"";
+
+                    ss << std::endl;
                 }
 
-                ss << std::endl;
+                ss << "==== object dump end ====" << std::endl;
+            } else {
+                std::string logString = buildLogString(info);
+
+                ss << logString;
             }
-
-            ss << "==== object dump end ====" << std::endl;
         } else {
-            std::string logString = buildLogString(info);
-
-            ss << logString;
+            ss << std::endl;
         }
-    } else {
-        ss << std::endl;
+
+        std::string log = ss.str();
+
+        sendToADBLogcat(log, ANDROID_LOG_INFO);
+        sendToDevToolsFrontEnd(isolate, log, "info");
+    } catch (NativeScriptException& e) {
+        e.ReThrowToV8();
+    } catch (std::exception e) {
+        std::stringstream ss;
+        ss << "Error: c++ exception: " << e.what() << std::endl;
+        NativeScriptException nsEx(ss.str());
+        nsEx.ReThrowToV8();
+    } catch (...) {
+        NativeScriptException nsEx(std::string("Error: c++ exception!"));
+        nsEx.ReThrowToV8();
     }
-
-    std::string log = ss.str();
-
-    sendToADBLogcat(log, ANDROID_LOG_INFO);
-    sendToDevToolsFrontEnd(isolate, log, "info");
 }
 
 const std::string buildStacktraceFrameLocationPart(v8::Local<v8::StackFrame> frame) {
@@ -313,102 +386,138 @@ const std::string buildStacktraceFrameMessage(v8::Local<v8::StackFrame> frame) {
 }
 
 void Console::traceCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
-    auto isolate = info.GetIsolate();
-    std::stringstream ss;
+    try {
+        auto isolate = info.GetIsolate();
+        std::stringstream ss;
 
-    std::string logString = buildLogString(info);
+        std::string logString = buildLogString(info);
 
-    if (logString.compare("\n") == 0) {
-        ss << "Trace";
-    } else {
-        ss << "Trace: " << logString;
+        if (logString.compare("\n") == 0) {
+            ss << "Trace";
+        } else {
+            ss << "Trace: " << logString;
+        }
+
+        ss << std::endl;
+
+        v8::HandleScope scope(isolate);
+
+        auto stack = v8::StackTrace::CurrentStackTrace(isolate, 10, v8::StackTrace::StackTraceOptions::kDetailed);
+
+        auto framesCount = stack->GetFrameCount();
+
+        for (int i = 0; i < framesCount; i++) {
+            auto frame = stack->GetFrame(i);
+
+            ss << buildStacktraceFrameMessage(frame) << std::endl;
+        }
+
+        std::string log = ss.str();
+        __android_log_write(ANDROID_LOG_ERROR, LOG_TAG, log.c_str());
+        sendToDevToolsFrontEnd(isolate, log, "error");
+    } catch (NativeScriptException& e) {
+        e.ReThrowToV8();
+    } catch (std::exception e) {
+        std::stringstream ss;
+        ss << "Error: c++ exception: " << e.what() << std::endl;
+        NativeScriptException nsEx(ss.str());
+        nsEx.ReThrowToV8();
+    } catch (...) {
+        NativeScriptException nsEx(std::string("Error: c++ exception!"));
+        nsEx.ReThrowToV8();
     }
-
-    ss << std::endl;
-
-    v8::HandleScope scope(isolate);
-
-    auto stack = v8::StackTrace::CurrentStackTrace(isolate, 10, v8::StackTrace::StackTraceOptions::kDetailed);
-
-    auto framesCount = stack->GetFrameCount();
-
-    for (int i = 0; i < framesCount; i++) {
-        auto frame = stack->GetFrame(i);
-
-        ss << buildStacktraceFrameMessage(frame) << std::endl;
-    }
-
-    std::string log = ss.str();
-    __android_log_write(ANDROID_LOG_ERROR, LOG_TAG, log.c_str());
-    sendToDevToolsFrontEnd(isolate, log, "error");
 }
 
 void Console::timeCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
-    auto isolate = info.GetIsolate();
+    try {
+        auto isolate = info.GetIsolate();
 
-    v8::HandleScope scope(isolate);
+        v8::HandleScope scope(isolate);
 
-    auto argLen = info.Length();
-    std::string label = "default";
+        auto argLen = info.Length();
+        std::string label = "default";
 
-    v8::Local<v8::String> argString;
-    if (argLen && info[0]->ToString(isolate->GetCurrentContext()).ToLocal(&argString)) {
-        label = ArgConverter::ConvertToString(argString);
+        v8::Local<v8::String> argString;
+        if (argLen && info[0]->ToString(isolate->GetCurrentContext()).ToLocal(&argString)) {
+            label = ArgConverter::ConvertToString(argString);
+        }
+
+        auto it = Console::s_isolateToConsoleTimersMap.find(isolate);
+        if (it == Console::s_isolateToConsoleTimersMap.end()) {
+            // throw?
+        }
+
+        auto nano = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::system_clock::now());
+        double timeStamp = nano.time_since_epoch().count();
+
+        it->second.insert(std::make_pair(label, timeStamp));
+    } catch (NativeScriptException& e) {
+        e.ReThrowToV8();
+    } catch (std::exception e) {
+        std::stringstream ss;
+        ss << "Error: c++ exception: " << e.what() << std::endl;
+        NativeScriptException nsEx(ss.str());
+        nsEx.ReThrowToV8();
+    } catch (...) {
+        NativeScriptException nsEx(std::string("Error: c++ exception!"));
+        nsEx.ReThrowToV8();
     }
-
-    auto it = Console::s_isolateToConsoleTimersMap.find(isolate);
-    if (it == Console::s_isolateToConsoleTimersMap.end()) {
-        // throw?
-    }
-
-    auto nano = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::system_clock::now());
-    double timeStamp = nano.time_since_epoch().count();
-
-    it->second.insert(std::make_pair(label, timeStamp));
 }
 
 void Console::timeEndCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
-    auto isolate = info.GetIsolate();
+    try {
+        auto isolate = info.GetIsolate();
 
-    auto argLen = info.Length();
-    std::string label = "default";
+        auto argLen = info.Length();
+        std::string label = "default";
 
-    v8::Local<v8::String> argString;
-    if (argLen && info[0]->ToString(isolate->GetCurrentContext()).ToLocal(&argString)) {
-        label = ArgConverter::ConvertToString(argString);
+        v8::Local<v8::String> argString;
+        if (argLen && info[0]->ToString(isolate->GetCurrentContext()).ToLocal(&argString)) {
+            label = ArgConverter::ConvertToString(argString);
+        }
+
+        auto it = Console::s_isolateToConsoleTimersMap.find(isolate);
+        if (it == Console::s_isolateToConsoleTimersMap.end()) {
+            // throw?
+        }
+
+        std::map<std::string, double> timersMap = it->second;
+
+        auto itTimersMap = timersMap.find(label);
+        if (itTimersMap == timersMap.end()) {
+            std::string warning = std::string("No such label '" + label + "' for console.timeEnd()");
+
+            __android_log_write(ANDROID_LOG_WARN, LOG_TAG, warning.c_str());
+            sendToDevToolsFrontEnd(isolate, warning, "warning");
+
+            return;
+        }
+
+        auto nano = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::system_clock::now());
+        double endTimeStamp = nano.time_since_epoch().count();
+        double startTimeStamp = itTimersMap->second;
+
+        it->second.erase(label);
+
+        auto diff = endTimeStamp - startTimeStamp;
+
+        std::stringstream ss;
+        ss << label << ": " << std::fixed << std::setprecision(2) << diff << "ms" ;
+        std::string log = ss.str();
+
+        __android_log_write(ANDROID_LOG_INFO, LOG_TAG, log.c_str());
+        sendToDevToolsFrontEnd(isolate, log, "info");
+    } catch (NativeScriptException& e) {
+        e.ReThrowToV8();
+    } catch (std::exception e) {
+        std::stringstream ss;
+        ss << "Error: c++ exception: " << e.what() << std::endl;
+        NativeScriptException nsEx(ss.str());
+        nsEx.ReThrowToV8();
+    } catch (...) {
+        NativeScriptException nsEx(std::string("Error: c++ exception!"));
+        nsEx.ReThrowToV8();
     }
-
-    auto it = Console::s_isolateToConsoleTimersMap.find(isolate);
-    if (it == Console::s_isolateToConsoleTimersMap.end()) {
-        // throw?
-    }
-
-    std::map<std::string, double> timersMap = it->second;
-
-    auto itTimersMap = timersMap.find(label);
-    if (itTimersMap == timersMap.end()) {
-        std::string warning = std::string("No such label '" + label + "' for console.timeEnd()");
-
-        __android_log_write(ANDROID_LOG_WARN, LOG_TAG, warning.c_str());
-        sendToDevToolsFrontEnd(isolate, warning, "warning");
-
-        return;
-    }
-
-    auto nano = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::system_clock::now());
-    double endTimeStamp = nano.time_since_epoch().count();
-    double startTimeStamp = itTimersMap->second;
-
-    it->second.erase(label);
-
-    auto diff = endTimeStamp - startTimeStamp;
-
-    std::stringstream ss;
-    ss << label << ": " << std::fixed << std::setprecision(2) << diff << "ms" ;
-    std::string log = ss.str();
-
-    __android_log_write(ANDROID_LOG_INFO, LOG_TAG, log.c_str());
-    sendToDevToolsFrontEnd(isolate, log, "info");
 }
 
 const char* Console::LOG_TAG = "JS";

--- a/test-app/runtime/src/main/cpp/console/Console.cpp
+++ b/test-app/runtime/src/main/cpp/console/Console.cpp
@@ -304,6 +304,10 @@ void Console::dirCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
 
                     if (propIsFunction) {
                         ss << "()";
+                    } else if (propertyValue->IsArray()) {
+                        auto stringResult = buildStringFromArg(isolate, propertyValue);
+                        std::string jsonStringifiedArray = ArgConverter::ConvertToString(stringResult);
+                        ss << ": " << jsonStringifiedArray;
                     } else if (propertyValue->IsObject()) {
                         auto obj = propertyValue->ToObject(isolate);
                         auto objString = transformJSObject(isolate, obj);


### PR DESCRIPTION
Implement error handling for the `console.` callbacks