### PR TITLE
fix(devtools): if Elements tab is empty, try to repopulate on consecutive opening

### DIFF
--- a/test-app/runtime/src/main/cpp/v8_inspector/src/inspector/v8-dom-agent-impl.cpp
+++ b/test-app/runtime/src/main/cpp/v8_inspector/src/inspector/v8-dom-agent-impl.cpp
@@ -92,6 +92,12 @@ void V8DOMAgentImpl::getDocument(ErrorString* errorString, std::unique_ptr<proto
                     auto errorMessage = "Error while parsing debug `DOM Node` object. ";
                     DEBUG_WRITE_FORCE("JS Error: %s", errorMessage, errorSupportString.c_str());
                     *errorString = errorSupportString.c_str();
+
+                    return;
+                } else if (domNode->getChildren(protocol::Array<protocol::DOM::Node>::create().get())->length() == 0) {
+                    *errorString = "Root view empty.";
+
+                    return;
                 } else {
                     *out_root = std::move(domNode);
 
@@ -99,6 +105,8 @@ void V8DOMAgentImpl::getDocument(ErrorString* errorString, std::unique_ptr<proto
                 }
             } else {
                 *errorString = "Didn't get a proper result from __getDocument call. Returning empty visual tree.";
+
+                return;
             }
         }
     }

--- a/test-app/runtime/src/main/cpp/v8_inspector/src/inspector/v8-dom-agent-impl.cpp
+++ b/test-app/runtime/src/main/cpp/v8_inspector/src/inspector/v8-dom-agent-impl.cpp
@@ -50,14 +50,6 @@ void V8DOMAgentImpl::disable(ErrorString*) {
 }
 
 void V8DOMAgentImpl::getDocument(ErrorString* errorString, std::unique_ptr<protocol::DOM::Node>* out_root) {
-    std::unique_ptr<protocol::DOM::Node> defaultNode = protocol::DOM::Node::create()
-            .setNodeId(0)
-            .setNodeType(9)
-            .setNodeName("Frame")
-            .setLocalName("Frame")
-            .setNodeValue("")
-            .build();
-
     std::string getDocumentFunctionString = "getDocument";
     // TODO: Pete: Find a better way to get a hold of the isolate
     auto isolate = v8::Isolate::GetCurrent();
@@ -79,7 +71,6 @@ void V8DOMAgentImpl::getDocument(ErrorString* errorString, std::unique_ptr<proto
             if (tc.HasCaught()) {
                 *errorString = utils::Common::getJSCallErrorMessage(getDocumentFunctionString, tc.Message()->Get()).c_str();
 
-                *out_root = std::move(defaultNode);
                 return;
             }
 
@@ -100,6 +91,7 @@ void V8DOMAgentImpl::getDocument(ErrorString* errorString, std::unique_ptr<proto
                 if (!errorSupportString.empty()) {
                     auto errorMessage = "Error while parsing debug `DOM Node` object. ";
                     DEBUG_WRITE_FORCE("JS Error: %s", errorMessage, errorSupportString.c_str());
+                    *errorString = errorSupportString.c_str();
                 } else {
                     *out_root = std::move(domNode);
 
@@ -111,7 +103,7 @@ void V8DOMAgentImpl::getDocument(ErrorString* errorString, std::unique_ptr<proto
         }
     }
 
-    *out_root = std::move(defaultNode);
+    *errorString = "getDocument function not available on the global object.";
 }
 
 void V8DOMAgentImpl::removeNode(ErrorString* errorString, int in_nodeId) {


### PR DESCRIPTION
Originally, the empty DOM node result would be cached, which the DevTools frontend would consider as a valid tree, and would not make another request to DOM.getDocument until the page was invalidated. 

The proposed changes solve that problem by not assigning an empty DOM node, and instead returning an error message.

Addresses https://github.com/NativeScript/android-runtime/issues/966