### PR TITLE
fix(project-build-script): change compile -> implementation 

### DIFF
--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -63,7 +63,7 @@ def nativescriptDependencies = new JsonSlurper().parseText(dependenciesJson.text
 def computeCompileSdkVersion = { -> project.hasProperty("compileSdk") ? compileSdk : 26 }
 def computeTargetSdkVersion = { -> project.hasProperty("targetSdk") ? targetSdk : 26 }
 def computeBuildToolsVersion = { ->
-    "25.2.5"
+    project.hasProperty("buildToolsVersion") ? buildToolsVersion : "27.0.1"
 }
 
 project.ext.selectedBuildType = project.hasProperty("release") ? "release" : "debug"
@@ -224,8 +224,7 @@ dependencies {
         println "\t + adding nativescript runtime package dependency: $runtime"
         project.dependencies.add("implementation", [name: runtime, ext: "aar"])
     } else {
-        implementation project(':runtime')
-
+        implementation project(path: ':runtime', configuration: 'default')
     }
 }
 

--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -206,15 +206,15 @@ dependencies {
 
     def sbgProjectExists = !findProject(':static-binding-generator').is(null)
     if (sbgProjectExists) {
-        provided project(':static-binding-generator')
+        compileOnly project(':static-binding-generator')
     }
     def mdgProjectExists = !findProject(':android-metadata-generator').is(null)
     if (mdgProjectExists) {
-        provided project(':android-metadata-generator')
+        compileOnly project(':android-metadata-generator')
     }
     def dtsgProjectExists = !findProject(':dts-generator').is(null)
     if (dtsgProjectExists) {
-        provided project(':dts-generator')
+        compileOnly project(':dts-generator')
     }
 
     def useV8Symbols = nativescriptDependencies.any {

--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -63,7 +63,7 @@ def nativescriptDependencies = new JsonSlurper().parseText(dependenciesJson.text
 def computeCompileSdkVersion = { -> project.hasProperty("compileSdk") ? compileSdk : 26 }
 def computeTargetSdkVersion = { -> project.hasProperty("targetSdk") ? targetSdk : 26 }
 def computeBuildToolsVersion = { ->
-    project.hasProperty("buildToolsVersion") ? buildToolsVersion : "27.0.1"
+    "25.2.5"
 }
 
 project.ext.selectedBuildType = project.hasProperty("release") ? "release" : "debug"
@@ -198,9 +198,9 @@ dependencies {
     if (project.hasProperty("supportVersion")) {
         supportVer = supportVersion
     }
-    compile "com.android.support:support-v4:$supportVer"
-    compile "com.android.support:appcompat-v7:$supportVer"
-    debugCompile "com.android.support:design:$supportVer"
+    implementation "com.android.support:support-v4:$supportVer"
+    implementation "com.android.support:appcompat-v7:$supportVer"
+    debugImplementation "com.android.support:design:$supportVer"
     def sbgProjectExists = !findProject(':static-binding-generator').is(null)
     if (sbgProjectExists) {
         provided project(':static-binding-generator')
@@ -222,7 +222,7 @@ dependencies {
     if (!externalRuntimeExists) {
         def runtime = useV8Symbols ? "nativescript-regular" : "nativescript-optimized"
         println "\t + adding nativescript runtime package dependency: $runtime"
-        project.dependencies.add("compile", [name: runtime, ext: "aar"])
+        project.dependencies.add("implementation", [name: runtime, ext: "aar"])
     } else {
         implementation project(':runtime')
 
@@ -240,7 +240,7 @@ task addDependenciesFromNativeScriptPlugins {
             def length = aarFile.name.length() - 4
             def fileName = aarFile.name[0..<length]
             println "\t + adding aar plugin dependency: " + aarFile.getAbsolutePath()
-            project.dependencies.add("compile", [name: fileName, ext: "aar"])
+            project.dependencies.add("implementation", [name: fileName, ext: "aar"])
         }
 
         def jarFiles = fileTree(dir: file("$rootDir/${dep.directory}/$PLATFORMS_ANDROID"), include: ["**/*.jar"])
@@ -263,7 +263,7 @@ task addDependenciesFromAppResourcesLibraries {
             def length = aarFile.name.length() - 4
             def fileName = aarFile.name[0..<length]
             println "\t + adding aar library dependency: " + aarFile.getAbsolutePath()
-            project.dependencies.add("compile", [name: fileName, ext: "aar"])
+            project.dependencies.add("implementation", [name: fileName, ext: "aar"])
         }
 
         def jarFiles = fileTree(dir: appResourcesLibraries, include: ["**/*.jar"])
@@ -273,7 +273,7 @@ task addDependenciesFromAppResourcesLibraries {
             pluginsJarLibraries.add(jarFile.getAbsolutePath())
         }
         
-        project.dependencies.add("compile", jarFiles)
+        project.dependencies.add("implementation", jarFiles)
     }
 }
 
@@ -346,18 +346,20 @@ def explodeAar(File compileDependency, String outputDir) {
 }
 
 task extractAllJars {
-
     outputs.dir extractedDependenciesDir
 
     doLast {
-        def iter = configurations.compile.resolvedConfiguration.resolvedArtifacts.iterator()
+        def iter;
+        if (project.selectedBuildType == "release") {
+            iter = configurations.releaseCompileClasspath.resolve()
+        } else {
+            iter = configurations.debugCompileClasspath.resolve()
+        }
         def dependencyCounter = 0
-        while (iter.hasNext()) {
-            //declaring variable as specific class for getting code completion in Android Studio
-            org.gradle.api.internal.artifacts.DefaultResolvedArtifact nextDependency = iter.next()
-
+        iter.each {
+            def nextDependency = it
             def outputDir = java.nio.file.Paths.get(extractedDependenciesDir, "" + dependencyCounter).normalize().toString()
-            explodeAar(nextDependency.file, outputDir)
+            explodeAar(nextDependency, outputDir)
             dependencyCounter++
         }
     }

--- a/test-app/build-tools/android-metadata-generator/build.gradle
+++ b/test-app/build-tools/android-metadata-generator/build.gradle
@@ -1,4 +1,4 @@
-/* 
+/*
 *	Packs metadata generator in a .tgz file in ~/dist folder
 *	To build .tgz
 *			gradlew packmg
@@ -32,8 +32,8 @@ sourceSets {
 compileJava.outputs.dir("$rootDir/dist/classes")
 
 dependencies {
-    compile files("./src/libs/bcel-5.2.jar")
-    compile files("./src/libs/dx.jar")
+    implementation files("./src/libs/bcel-5.2.jar")
+    implementation files("./src/libs/dx.jar")
 }
 
 task copyNecessaryFiles {
@@ -42,11 +42,11 @@ task copyNecessaryFiles {
 			from "$rootDir/helpers"
 			into "$rootDir/dist/bin"
 		}
-		
+
 		copy {
 			from "$rootDir/package.json"
 			into "$rootDir/dist"
-		}	
+		}
 	}
 }
 
@@ -55,7 +55,7 @@ jar {
         attributes("Manifest-Version": "1.0",
                    "Main-Class": "com.telerik.metadata.Generator")
     }
-	
+
     from {
 
         configurations.runtime.collect {

--- a/test-app/build-tools/android-metadata-generator/build.gradle
+++ b/test-app/build-tools/android-metadata-generator/build.gradle
@@ -32,8 +32,8 @@ sourceSets {
 compileJava.outputs.dir("$rootDir/dist/classes")
 
 dependencies {
-    implementation files("./src/libs/bcel-5.2.jar")
-    implementation files("./src/libs/dx.jar")
+    compile files("./src/libs/bcel-5.2.jar")
+    compile files("./src/libs/dx.jar")
 }
 
 task copyNecessaryFiles {

--- a/test-app/runtime/build.gradle
+++ b/test-app/runtime/build.gradle
@@ -20,7 +20,6 @@ android {
     compileSdkVersion 26
     buildToolsVersion project.ext._buildToolsVersion
 
-    publishNonDefault true
     defaultConfig {
         minSdkVersion 17
         targetSdkVersion 26
@@ -65,7 +64,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
 }
 
 tasks.whenTaskAdded { task ->


### PR DESCRIPTION
Fixes https://github.com/NativeScript/android-runtime/issues/993 by removing the use of the deprecated `compile` methods when declaring project dependencies, and slightly altering the dependency artifacts traversal logic.

Update: the fix works when tested locally on my Windows workstation with Android Build-Tools 28.0.0-rc1, however it fails on both the Jenkins and Travis CI