### PR TITLE
fix: Enable multidex support for versions older than API 21

### DIFF
--- a/build-artifacts/project-template-gradle/app/src/main/java/com/tns/NativeScriptApplication.java
+++ b/build-artifacts/project-template-gradle/app/src/main/java/com/tns/NativeScriptApplication.java
@@ -1,6 +1,8 @@
 package com.tns;
 
 import android.app.Application;
+import android.os.Build;
+import android.support.multidex.MultiDex;
 
 public class NativeScriptApplication extends Application {
 
@@ -20,6 +22,14 @@ public class NativeScriptApplication extends Application {
             }
         } finally {
             frame.close();
+        }
+    }
+
+    public void attachBaseContext(android.content.Context base) {
+        super.attachBaseContext(base);
+        if (Build.VERSION.SDK_INT < 21) {
+            // As the new gradle plugin automatically uses multidex if necessary we need to call this for older android API versions
+            MultiDex.install(this);
         }
     }
 

--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -198,6 +198,8 @@ dependencies {
     if (project.hasProperty("supportVersion")) {
         supportVer = supportVersion
     }
+
+    compile "com.android.support:multidex:1.0.2"
     compile "com.android.support:support-v4:$supportVer"
     compile "com.android.support:appcompat-v7:$supportVer"
     debugCompile "com.android.support:design:$supportVer"
@@ -272,7 +274,7 @@ task addDependenciesFromAppResourcesLibraries {
             println "\t + adding jar plugin dependency: $jarFileAbsolutePath"
             pluginsJarLibraries.add(jarFile.getAbsolutePath())
         }
-        
+
         project.dependencies.add("compile", jarFiles)
     }
 }


### PR DESCRIPTION
As with the latest version of the graddle we've enabled multidex by default we need to handle multidex processing in API levels older than api 21.
Fixes https://github.com/NativeScript/android-runtime/issues/999