### PR TITLE
Remove inspector source from release builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,6 +137,8 @@ task generateRuntime {
     doFirst {
         tasks.generateOptimizedRuntimeAar.execute();
 
+        tasks.generateOptimizedWithInspectorRuntimeAar.execute();
+
         if (generateRegularRuntimePackage) {
             tasks.generateRuntimeAar.execute();
         }
@@ -157,7 +159,7 @@ task cleanRuntime (type: Exec) {
 task generateOptimizedRuntimeAar (type: Exec) {
     doFirst {
         workingDir "$TEST_APP_PATH"
-        if(onlyX86) {
+        if (onlyX86) {
             if (isWinOs) {
                 commandLine "cmd", "/c", "gradlew", ":runtime:assembleRelease", "-PpackageVersion=${pVersion}", "-PgitCommitVersion=${arVersion}", "-Poptimized", "-PonlyX86"
             } else {
@@ -168,6 +170,25 @@ task generateOptimizedRuntimeAar (type: Exec) {
                 commandLine "cmd", "/c", "gradlew", ":runtime:assembleRelease", "-PpackageVersion=${pVersion}", "-PgitCommitVersion=${arVersion}", "-Poptimized"
             } else {
                 commandLine "./gradlew", ":runtime:assembleRelease", "-PpackageVersion=${pVersion}", "-PgitCommitVersion=${arVersion}", "-Poptimized"
+            }
+        }
+    }
+}
+
+task generateOptimizedWithInspectorRuntimeAar (type: Exec) {
+    doFirst {
+        workingDir "$TEST_APP_PATH"
+        if (onlyX86) {
+            if (isWinOs) {
+                commandLine "cmd", "/c", "gradlew", ":runtime:assembleRelease", "-PpackageVersion=${pVersion}", "-PgitCommitVersion=${arVersion}", "-PoptimizedWithInspector", "-PonlyX86"
+            } else {
+                commandLine "./gradlew", ":runtime:assembleRelease", "-PpackageVersion=${pVersion}", "-PgitCommitVersion=${arVersion}", "-PoptimizedWithInspector", "-PonlyX86"
+            }
+        } else {
+            if (isWinOs) {
+                commandLine "cmd", "/c", "gradlew", ":runtime:assembleRelease", "-PpackageVersion=${pVersion}", "-PgitCommitVersion=${arVersion}", "-PoptimizedWithInspector"
+            } else {
+                commandLine "./gradlew", ":runtime:assembleRelease", "-PpackageVersion=${pVersion}", "-PgitCommitVersion=${arVersion}", "-PoptimizedWithInspector"
             }
         }
     }
@@ -231,6 +252,11 @@ task copyFilesToProjectTemeplate {
             from "$TEST_APP_PATH/runtime/build/outputs/aar/runtime-optimized-release.aar"
             into "$DIST_FRAMEWORK_PATH/app/libs/runtime-libs"
             rename "runtime-optimized-release.aar", "nativescript-optimized.aar"
+        }
+        copy {
+            from "$TEST_APP_PATH/runtime/build/outputs/aar/runtime-optimized-with-inspector-release.aar"
+            into "$DIST_FRAMEWORK_PATH/app/libs/runtime-libs"
+            rename "runtime-optimized-with-inspector-release.aar", "nativescript-optimized-with-inspector.aar"
         }
         copy {
             from "$TEST_APP_PATH/app/build.gradle"

--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -232,7 +232,16 @@ dependencies {
         return packageJson.nativescript.useV8Symbols
     }
     if (!externalRuntimeExists) {
-        def runtime = useV8Symbols ? "nativescript-regular" : "nativescript-optimized"
+        def runtime = "nativescript-optimized-with-inspector"
+
+        if (project.gradle.startParameter.taskNames.any { it.toLowerCase().contains('release') }) {
+            runtime = "nativescript-optimized"
+        }
+
+        if (useV8Symbols) {
+            runtime = "nativescript-regular"
+        }
+
         println "\t + adding nativescript runtime package dependency: $runtime"
         project.dependencies.add("implementation", [name: runtime, ext: "aar"])
     } else {

--- a/test-app/runtime/CMakeLists.txt
+++ b/test-app/runtime/CMakeLists.txt
@@ -24,66 +24,24 @@ include_directories( src/main/cpp
                     # hack to find some libraries from the ndk
                     ${ANDROID_NDK_ROOT}/sysroot/usr/include/${ARCH_INCLUDE_DIR}/
                     )
-if ( OPTIMIZED_BUILD )
+if ( OPTIMIZED_BUILD OR OPTIMIZED_WITH_INSPECTOR_BUILD )
     set(CMAKE_CXX_FLAGS "${COMMON_CMAKE_ARGUMENTS} -O3 -fvisibility=hidden -ffunction-sections -fno-data-sections")
 else()
     set(CMAKE_CXX_FLAGS "${COMMON_CMAKE_ARGUMENTS} -g")
 endif()
 
-# Command info: https://cmake.org/cmake/help/v3.4/command/add_library.html
-# Creates(shared static) and names a library given relative sources
-# Gradle automatically packages shared libraries with your APK.
-add_library( # Sets the name of the library. When it's built you can find it with lib prefix libNativeScript.so
-        NativeScript
+if ( NOT OPTIMIZED_BUILD OR OPTIMIZED_WITH_INSPECTOR_BUILD )
+    # When building in Release mode we do not include the V8 inspector sources
+    add_definitions(-DINCLUDE_INSPECTOR)
 
-        # Sets the library as a shared library.
-        SHARED
+    set(
+        INSPECTOR_SOURCES
 
-        # Runtime source
-        src/main/cpp/ArgConverter.cpp
-        src/main/cpp/ArrayBufferHelper.cpp
-        src/main/cpp/ArrayElementAccessor.cpp
-        src/main/cpp/ArrayHelper.cpp
-        src/main/cpp/AssetExtractor.cpp
-        src/main/cpp/CallbackHandlers.cpp
-        src/main/cpp/Constants.cpp
-        src/main/cpp/DOMDomainCallbackHandlers.cpp
-        src/main/cpp/DirectBuffer.cpp
-        src/main/cpp/FieldAccessor.cpp
-        src/main/cpp/File.cpp
-        src/main/cpp/JEnv.cpp
-        src/main/cpp/JType.cpp
-        src/main/cpp/JniSignatureParser.cpp
-        src/main/cpp/JsArgConverter.cpp
-        src/main/cpp/JsArgToArrayConverter.cpp
-        src/main/cpp/JsV8InspectorClient.cpp
-        src/main/cpp/Logger.cpp
-        src/main/cpp/ManualInstrumentation.cpp
-        src/main/cpp/MetadataMethodInfo.cpp
-        src/main/cpp/MetadataNode.cpp
-        src/main/cpp/MetadataReader.cpp
-        src/main/cpp/MetadataTreeNode.cpp
-        src/main/cpp/MethodCache.cpp
-        src/main/cpp/ModuleInternal.cpp
-        src/main/cpp/NativeScriptException.cpp
-        src/main/cpp/NetworkDomainCallbackHandlers.cpp
-        src/main/cpp/NumericCasts.cpp
-        src/main/cpp/ObjectManager.cpp
-        src/main/cpp/Profiler.cpp
-        src/main/cpp/ReadWriteLock.cpp
-        src/main/cpp/Runtime.cpp
-        src/main/cpp/SimpleAllocator.cpp
-        src/main/cpp/SimpleProfiler.cpp
-        src/main/cpp/Util.cpp
-        src/main/cpp/V8GlobalHelpers.cpp
-        src/main/cpp/V8StringConstants.cpp
-        src/main/cpp/WeakRef.cpp
         src/main/cpp/com_tns_AndroidJsV8Inspector.cpp
-        src/main/cpp/com_tns_AssetExtractor.cpp
-        src/main/cpp/com_tns_Runtime.cpp
-        src/main/cpp/console/Console.cpp
+        src/main/cpp/JsV8InspectorClient.cpp
+        src/main/cpp/DOMDomainCallbackHandlers.cpp
+        src/main/cpp/NetworkDomainCallbackHandlers.cpp
 
-        # Inspector source
         src/main/cpp/v8_inspector/src/inspector/protocol/CSS.cpp
         src/main/cpp/v8_inspector/src/inspector/protocol/Console.cpp
         src/main/cpp/v8_inspector/src/inspector/protocol/DOM.cpp
@@ -135,13 +93,66 @@ add_library( # Sets the name of the library. When it's built you can find it wit
         src/main/cpp/v8_inspector/src/inspector/v8-stack-trace-impl.cc
         src/main/cpp/v8_inspector/src/inspector/v8-value-utils.cc
         src/main/cpp/v8_inspector/src/inspector/wasm-translation.cc
-)
-
-if ( OPTIMIZED_BUILD )
-    set_target_properties(NativeScript PROPERTIES LINK_FLAGS -Wl,--allow-multiple-definition -Wl,--exclude-libs=ALL -Wl,--gc-sections)
+    )
 else()
-    set_target_properties(NativeScript PROPERTIES LINK_FLAGS -Wl,--allow-multiple-definition)
+    # Debug builds will include the V8 inspector sources
+    set(INSPECTOR_SOURCES)
 endif()
+
+# Command info: https://cmake.org/cmake/help/v3.4/command/add_library.html
+# Creates(shared static) and names a library given relative sources
+# Gradle automatically packages shared libraries with your APK.
+add_library( # Sets the name of the library. When it's built you can find it with lib prefix libNativeScript.so
+            NativeScript
+
+            # Sets the library as a shared library.
+            SHARED
+
+            # Runtime source
+            src/main/cpp/ArgConverter.cpp
+            src/main/cpp/ArrayBufferHelper.cpp
+            src/main/cpp/ArrayElementAccessor.cpp
+            src/main/cpp/ArrayHelper.cpp
+            src/main/cpp/AssetExtractor.cpp
+            src/main/cpp/CallbackHandlers.cpp
+            src/main/cpp/Constants.cpp
+            src/main/cpp/DirectBuffer.cpp
+            src/main/cpp/FieldAccessor.cpp
+            src/main/cpp/File.cpp
+            src/main/cpp/JEnv.cpp
+            src/main/cpp/JType.cpp
+            src/main/cpp/JniSignatureParser.cpp
+            src/main/cpp/JsArgConverter.cpp
+            src/main/cpp/JsArgToArrayConverter.cpp
+            src/main/cpp/Logger.cpp
+            src/main/cpp/ManualInstrumentation.cpp
+            src/main/cpp/MetadataMethodInfo.cpp
+            src/main/cpp/MetadataNode.cpp
+            src/main/cpp/MetadataReader.cpp
+            src/main/cpp/MetadataTreeNode.cpp
+            src/main/cpp/MethodCache.cpp
+            src/main/cpp/ModuleInternal.cpp
+            src/main/cpp/NativeScriptException.cpp
+            src/main/cpp/NumericCasts.cpp
+            src/main/cpp/ObjectManager.cpp
+            src/main/cpp/Profiler.cpp
+            src/main/cpp/ReadWriteLock.cpp
+            src/main/cpp/Runtime.cpp
+            src/main/cpp/SimpleAllocator.cpp
+            src/main/cpp/SimpleProfiler.cpp
+            src/main/cpp/Util.cpp
+            src/main/cpp/V8GlobalHelpers.cpp
+            src/main/cpp/V8StringConstants.cpp
+            src/main/cpp/WeakRef.cpp
+            src/main/cpp/com_tns_AssetExtractor.cpp
+            src/main/cpp/com_tns_Runtime.cpp
+            src/main/cpp/console/Console.cpp
+
+            # V8 inspector source files will be included only in Release mode
+            ${INSPECTOR_SOURCES}
+            )
+
+set_target_properties(NativeScript PROPERTIES LINK_FLAGS -Wl,--allow-multiple-definition)
 
 
 MESSAGE( STATUS "# General cmake Info" )

--- a/test-app/runtime/build.gradle
+++ b/test-app/runtime/build.gradle
@@ -4,6 +4,12 @@ def optimized = project.hasProperty("optimized")
 if (optimized) {
     println "Optimized build triggered."
 }
+
+def optimizedWithInspector = project.hasProperty("optimizedWithInspector")
+if (optimizedWithInspector) {
+    println "Optimized build with inspector triggered."
+}
+
 def onlyX86 = project.hasProperty("onlyX86")
 if (onlyX86) {
     println "OnlyX86 build triggered."
@@ -30,16 +36,24 @@ android {
         versionCode 1
         versionName "1.0"
 
-        if (optimized) {
-            project.archivesBaseName = "${archivesBaseName}-optimized"
-        } else {
+        if (!optimized && !optimizedWithInspector) {
             project.archivesBaseName = "${archivesBaseName}-regular"
+        } else {
+            if (optimized) {
+                project.archivesBaseName = "${archivesBaseName}-optimized"
+            } else if (optimizedWithInspector) {
+                project.archivesBaseName = "${archivesBaseName}-optimized-with-inspector"
+            }
         }
 
         externalNativeBuild {
             cmake {
                 if (optimized) {
                     arguments.push("-DOPTIMIZED_BUILD=true")
+                }
+
+                if (optimizedWithInspector) {
+                    arguments.push("-DOPTIMIZED_WITH_INSPECTOR_BUILD=true")
                 }
 
                 //https://developer.android.com/ndk/guides/cmake.html

--- a/test-app/runtime/src/main/cpp/JsV8InspectorClient.h
+++ b/test-app/runtime/src/main/cpp/JsV8InspectorClient.h
@@ -33,6 +33,7 @@ class JsV8InspectorClient : V8InspectorClient, v8_inspector::V8Inspector::Channe
         void flushProtocolNotifications() override;
 
         static void sendToFrontEndCallback(const v8::FunctionCallbackInfo<v8::Value>& args);
+        static void consoleLogCallback(const std::string& message, const std::string& logLevel);
 
         void runMessageLoopOnPause(int context_group_id) override;
         void quitMessageLoopOnPause() override;

--- a/test-app/runtime/src/main/cpp/console/Console.h
+++ b/test-app/runtime/src/main/cpp/console/Console.h
@@ -10,9 +10,12 @@
 #include <ArgConverter.h>
 
 namespace tns {
+
+typedef void (*ConsoleCallback)(const std::string& message, const std::string& logLevel);
+
 class Console {
     public:
-        static v8::Local<v8::Object> createConsole(v8::Local<v8::Context> context, const std::string& filesPath);
+        static v8::Local<v8::Object> createConsole(v8::Local<v8::Context> context, ConsoleCallback callback);
 
         static void assertCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
         static void errorCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
@@ -25,6 +28,7 @@ class Console {
         static void timeEndCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
 
     private:
+        static ConsoleCallback m_callback;
         static const char* LOG_TAG;
         static std::map<v8::Isolate*, std::map<std::string, double>> s_isolateToConsoleTimersMap;
 


### PR DESCRIPTION
Currently the V8 inspector source files are compiled into the android runtime regardless of whether the developer is making a Debug or Release build of his application. To reduce the final app size we can remove this unused source code from the Release build.

This is achieved by providing 2 distinct android runtime packages (`nativescript-optimized.aar` and `nativescript-optimized-with-inspector.aar`) and use the correct one depending on the build type.