### PR TITLE
Invalidate V8 DateTime cache on timezone changes

### DIFF
--- a/test-app/app/src/main/java/com/tns/RuntimeHelper.java
+++ b/test-app/app/src/main/java/com/tns/RuntimeHelper.java
@@ -3,9 +3,14 @@ package com.tns;
 import java.io.File;
 
 import android.app.Application;
+import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.SharedPreferences;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.os.Build;
+import android.preference.PreferenceManager;
 import android.util.Log;
 
 import java.io.IOException;
@@ -13,6 +18,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.TimeZone;
 
 public final class RuntimeHelper {
     private RuntimeHelper() {
@@ -233,6 +239,13 @@ public final class RuntimeHelper {
                     }
                     e.printStackTrace();
                 }
+
+                if (appConfig.handleTimeZoneChanges()) {
+                    // If the user sets this flag, we will register a broadcast receiver
+                    // that will listen for the TIMEZONE_CHANGED event and update V8's cache
+                    // so that subsequent calls to "new Date()" return the new timezone
+                    registerTimezoneChangedListener(app, runtime);
+                }
             }
             return runtime;
         } finally {
@@ -240,5 +253,40 @@ public final class RuntimeHelper {
         }
     }
 
+    private static void registerTimezoneChangedListener(Context context, final Runtime runtime) {
+        IntentFilter timezoneFilter = new IntentFilter(Intent.ACTION_TIMEZONE_CHANGED);
+
+        BroadcastReceiver timezoneReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                String action = intent.getAction();
+                if (action == null || !action.equals(Intent.ACTION_TIMEZONE_CHANGED)) {
+                    return;
+                }
+
+                SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+
+                String oldTimezone = prefs.getString(PREF_TIMEZONE, null);
+                String newTimezone = TimeZone.getDefault().getID();
+                if (newTimezone == null) {
+                    newTimezone = "";
+                }
+
+                if (oldTimezone == null) {
+                    oldTimezone = "";
+                }
+
+                if (!oldTimezone.equals(newTimezone)) {
+                    prefs.edit().putString(PREF_TIMEZONE, newTimezone).commit();
+                    // Notify V8 for the timezone change
+                    runtime.ResetDateTimeConfigurationCache();
+                }
+            }
+        };
+
+        context.registerReceiver(timezoneReceiver, timezoneFilter);
+    }
+
     private static final String logTag = "MyApp";
+    private static final String PREF_TIMEZONE = "_android_runtime_pref_timezone_";
 }

--- a/test-app/runtime/src/main/cpp/com_tns_Runtime.cpp
+++ b/test-app/runtime/src/main/cpp/com_tns_Runtime.cpp
@@ -348,3 +348,13 @@ extern "C" JNIEXPORT void Java_com_tns_Runtime_CallWorkerObjectOnErrorHandleMain
         e.ReThrowToJava();
     }
 }
+
+extern "C" JNIEXPORT void Java_com_tns_Runtime_ResetDateTimeConfigurationCache(JNIEnv* _env, jobject obj, jint runtimeId) {
+    auto runtime = TryGetRuntime(runtimeId);
+    if (runtime == nullptr) {
+        return;
+    }
+
+    auto isolate = runtime->GetIsolate();
+    Date::DateTimeConfigurationChangeNotification(isolate);
+}

--- a/test-app/runtime/src/main/java/com/tns/AppConfig.java
+++ b/test-app/runtime/src/main/java/com/tns/AppConfig.java
@@ -16,7 +16,8 @@ class AppConfig {
         MemoryCheckInterval("memoryCheckInterval", 0),
         FreeMemoryRatio("freeMemoryRatio", 0.0),
         Profiling("profiling", ""),
-        MarkingMode("markingMode", com.tns.MarkingMode.full);
+        MarkingMode("markingMode", com.tns.MarkingMode.full),
+        HandleTimeZoneChanges("handleTimeZoneChanges", false);
 
         private final String name;
         private final Object defaultValue;
@@ -100,6 +101,9 @@ class AppConfig {
                             Log.v("JS", "Failed to parse marking mode. The default " + ((MarkingMode)KnownKeys.MarkingMode.getDefaultValue()).name() + " will be used.");
                         }
                     }
+                    if (androidObject.has(KnownKeys.HandleTimeZoneChanges.getName())) {
+                        values[KnownKeys.HandleTimeZoneChanges.ordinal()] = androidObject.getBoolean(KnownKeys.HandleTimeZoneChanges.getName());
+                    }
                 }
             }
         } catch (Exception e) {
@@ -137,5 +141,9 @@ class AppConfig {
 
     public MarkingMode getMarkingMode() {
         return (MarkingMode)values[KnownKeys.MarkingMode.ordinal()];
+    }
+
+    public boolean handleTimeZoneChanges() {
+        return (boolean)values[KnownKeys.HandleTimeZoneChanges.ordinal()];
     }
 }

--- a/test-app/runtime/src/main/java/com/tns/Runtime.java
+++ b/test-app/runtime/src/main/java/com/tns/Runtime.java
@@ -66,6 +66,8 @@ public class Runtime {
 
     private static native void CallWorkerObjectOnErrorHandleMain(int runtimeId, int workerId, String message, String stackTrace, String filename, int lineno, String threadName) throws NativeScriptException;
 
+    private static native void ResetDateTimeConfigurationCache(int runtimeId);
+
     void passUncaughtExceptionToJs(Throwable ex, String stackTrace) {
         passUncaughtExceptionToJsNative(getRuntimeId(), ex, stackTrace);
     }
@@ -222,6 +224,13 @@ public class Runtime {
 
     public Handler getHandler() {
         return this.threadScheduler.getHandler();
+    }
+
+    public void ResetDateTimeConfigurationCache() {
+        Runtime runtime = getCurrentRuntime();
+        if (runtime != null) {
+            ResetDateTimeConfigurationCache(runtime.getRuntimeId());
+        }
     }
 
     private static class WorkerThreadHandler extends Handler {


### PR DESCRIPTION
Related to #961.

Added new flag `handleTimeZoneChanges` to `app/package.json` which invalidates V8 cache when the timezone is changed:

```json
{
    "android": {
        "v8Flags": "--expose_gc",
        "handleTimeZoneChanges": true
    },
    "main": "app.js",
    "name": "tns-template-hello-world",
    "version": "4.0.0"
}
```

Because this functionality is not a common requirement for most apps, the default value for the flag is `false`.