### PR TITLE
Limit the size of logged objects to 1024 symbols

### DIFF
--- a/test-app/app/src/main/assets/app/package.json
+++ b/test-app/app/src/main/assets/app/package.json
@@ -6,6 +6,7 @@
 		"gcThrottleTime": 500,
 		"memoryCheckInterval": 10,
 		"freeMemoryRatio": 0.50,
-		"markingMode": "full"
+		"markingMode": "full",
+		"maxLogcatObjectSize": 1024
 	}
 }

--- a/test-app/app/src/main/assets/app/tests/tests.js
+++ b/test-app/app/src/main/assets/app/tests/tests.js
@@ -29,7 +29,7 @@ describe("Tests ", function () {
 		__log("TEST: Creating MyButton");
 		var MyButton = com.tns.tests.Button1.extend("MyButton", {
 			toString : function() {
-				return "button1";	
+				return "button1";
 			}
 		});
 
@@ -42,7 +42,7 @@ describe("Tests ", function () {
 		__log("TEST: Creating MyButton2 class");
 		var MyButton2 = com.tns.tests.Button1.extend("MyButton", {
 			toString : function() {
-				return "button2";	
+				return "button2";
 			}});
 
 		var button2 = new MyButton2();
@@ -68,7 +68,7 @@ describe("Tests ", function () {
 		__log("TEST: Creating MyButton");
 		var MyButton = com.tns.tests.Button1.extend({
 			toString : function() {
-				return "button1";	
+				return "button1";
 			}
 		});
 
@@ -81,7 +81,7 @@ describe("Tests ", function () {
 		__log("TEST: Creating MyButton2 class");
 		var MyButton2 = com.tns.tests.Button1.extend({
 			toString : function() {
-				return "button2";	
+				return "button2";
 			}});
 
 		var button2 = new MyButton2();
@@ -106,7 +106,7 @@ describe("Tests ", function () {
 		__log("TEST: Creating MyButton");
 		var MyButton = com.tns.tests.Button1.extend({
 			method2 : function(arg1) {
-				return arg1.toString();	
+				return arg1.toString();
 			}
 		});
 
@@ -138,8 +138,8 @@ describe("Tests ", function () {
 
 		var MyButton = com.tns.tests.Button1.extend("MyButton60", {
 			toString : function() {
-				return "button1";	
-			} 
+				return "button1";
+			}
 		});
 
 		var button1 = new MyButton();
@@ -160,7 +160,7 @@ describe("Tests ", function () {
 
 		var MyButton = com.tns.tests.Button1.extend("MyButton81", {
 			toString : function() {
-				return "button1";	
+				return "button1";
 			},
 		});
 
@@ -178,7 +178,7 @@ describe("Tests ", function () {
 
 		var MyButton = com.tns.tests.Button1.extend("MyButton98", {
 			toString : function() {
-				return "button1";	
+				return "button1";
 			},
 		});
 
@@ -198,7 +198,7 @@ describe("Tests ", function () {
 
 		var MyButton = com.tns.tests.Button1.extend("MyButton115", {
 			toString : function() {
-				return "button1";	
+				return "button1";
 			},
 
 			methodDummyClassAsObjectInArgs: function(object) {
@@ -212,7 +212,7 @@ describe("Tests ", function () {
 		expect(isInstanceOf).toEqual(true);
 	});
 
-	//originally wasn't run 
+	//originally wasn't run
 	it("When_calling_instanceof_on_interface_it_should_work", function () {
 
 		__log("TEST: When_calling_instanceof_on_interface_it_should_work");
@@ -253,7 +253,7 @@ describe("Tests ", function () {
 
 		var MyButton = com.tns.tests.Button1.extend("MyButton148", {
 			toString : function() {
-				return "button1";	
+				return "button1";
 			}
 		});
 
@@ -271,7 +271,7 @@ describe("Tests ", function () {
 		__log("TEST: When_calling_instance_and_static_member_with_same_name_the_calls_should_succeed");
 		var MyButton = com.tns.tests.Button1.extend("MyButton213", {
 			toString : function() {
-				return "button1";	
+				return "button1";
 			}
 		});
 
@@ -304,7 +304,7 @@ describe("Tests ", function () {
 		__log("TEST: When_calling_toString_on_an_java_object_that_has_overriden_toString_in_js_it_should_call_the_js_method");
 		var MyButton = com.tns.tests.Button1.extend("MyButton240", {
 			toString : function() {
-				return "button1";	
+				return "button1";
 			}
 		});
 
@@ -320,7 +320,7 @@ describe("Tests ", function () {
 
 		var MyButton = com.tns.tests.Button1.extend("MyButton257", {
 			toString : function() {
-				return "button1";	
+				return "button1";
 			}
 		});
 
@@ -383,7 +383,7 @@ describe("Tests ", function () {
 
 		var MyButton = com.tns.tests.Button1.extend("MyButton", {
 			toString : function() {
-				return this.super.toString() + this.super.echo("success");	
+				return this.super.toString() + this.super.echo("success");
 			},
 
 			echo : function(s) {
@@ -405,7 +405,7 @@ describe("Tests ", function () {
 		__log("TEST: When_extending_a_class_and_calling_super_method_it_should_work");
 		var MyButton = com.tns.tests.Button1.extend("MyButton318", {
 			toString : function() {
-				return "toString overriden";	
+				return "toString overriden";
 			},
 
 			getIMAGE_ID_PROP : function() {
@@ -428,13 +428,13 @@ describe("Tests ", function () {
 
 		var MyButton = com.tns.tests.Button1.extend("MyButton341", {
 			hashCode : function() {
-				return 5454;	
+				return 5454;
 			}
 		});
 
 		var MyButton2 = com.tns.tests.Button1.extend("MyButton347", {
 			hashCode : function() {
-				return 1212;	
+				return 1212;
 			}
 		});
 
@@ -455,8 +455,8 @@ describe("Tests ", function () {
 
 		var MyButton = com.tns.tests.Button1.extend({
 			toString : function() {
-				return "button1";	
-			} 
+				return "button1";
+			}
 		});
 
 		var button1 = new MyButton();
@@ -479,7 +479,7 @@ describe("Tests ", function () {
 
 		var MyButton = com.tns.tests.Button1.extend("MyButton381", {
 			toString : function() {
-				return "button1";	
+				return "button1";
 			}
 		});
 
@@ -488,7 +488,7 @@ describe("Tests ", function () {
 
 		var exceptionCaught = false;
 		try {
-			var res = dummy.dummyMethod(123); //this will fail if button2 is not valid proxy object and properly exposed to js	
+			var res = dummy.dummyMethod(123); //this will fail if button2 is not valid proxy object and properly exposed to js
 		}
 		catch (e) {
 			exceptionCaught = true;
@@ -503,7 +503,7 @@ describe("Tests ", function () {
 
 		var Button = com.tns.tests.Button1.extend("MyButton397", {
 			toString : function() {
-				return "button1";	
+				return "button1";
 			}
 		});
 
@@ -520,7 +520,7 @@ describe("Tests ", function () {
 
 		var Button = com.tns.tests.Button1.extend("MyButton413", {
 			toString : function() {
-				return "button1";	
+				return "button1";
 			}
 		});
 
@@ -538,7 +538,7 @@ describe("Tests ", function () {
 		var name = "";
 		var Button = com.tns.tests.Button1.extend("MyButton418", {
 			toString : function() {
-				return "button1";	
+				return "button1";
 			},
 
 			methodDummyClassAsObjectInArgs: function(object) {
@@ -559,7 +559,7 @@ describe("Tests ", function () {
 
 		var Button = com.tns.tests.Button1.extend("MyButton450", {
 			toString : function() {
-				return "button1";	
+				return "button1";
 			}
 		});
 
@@ -576,11 +576,11 @@ describe("Tests ", function () {
 
 		var MyButton = com.tns.tests.Button1.extend("MyButton455", {
 			hashCode : function() {
-				return 5454;	
+				return 5454;
 			},
 
 			toString : function() {
-				return "button1";	
+				return "button1";
 			},
 
 			equals : function() {
@@ -658,7 +658,7 @@ describe("Tests ", function () {
 			},
 
 			toString : function() {
-				return "button1";	
+				return "button1";
 			}
 		});
 
@@ -737,7 +737,7 @@ describe("Tests ", function () {
 
 		var MyButton = com.tns.tests.Button1.extend("MyButton726", {
 			toString : function() {
-				return "button1"	
+				return "button1"
 			}});
 
 		var button1 = new MyButton();
@@ -1020,7 +1020,7 @@ describe("Tests ", function () {
 		var javaValue = n.value;
 		expect(javaValue).toBe("9007199254740992");
 
-		var typeName = typeof n; 
+		var typeName = typeof n;
 		expect(typeName).toBe("object");
 	});
 
@@ -1251,7 +1251,7 @@ describe("Tests ", function () {
 		__log("TEST: TestRuntimeCurrentObjectIdIsResetProperlyWhenAnExceptionIsThrownWhileConstructingObject");
 
 		var exceptionCaught = false;
-		
+
 		try {
 			new java.io.FileInputStream("asdasd");
 		} catch (e) {
@@ -1263,11 +1263,11 @@ describe("Tests ", function () {
 				return "!!!" + s;
 			}
 		});
-		
+
 		var btn = MyButton.class.getConstructors()[0].newInstance(null);
 		var s = btn.triggerEcho("12345");
 		var expected = "!!!12345";
-		
+
 		expect(exceptionCaught).toBe(true);
 		expect(s).toContain(expected);
 	});
@@ -1345,7 +1345,7 @@ describe("Tests ", function () {
 		var MyButton = com.tns.tests.Button1.extend("btn1303", impl);
 		var btn = new MyButton();
 
-		var echo = com.tns.tests.Button1.prototype.echo; 
+		var echo = com.tns.tests.Button1.prototype.echo;
 		delete com.tns.tests.Button1.prototype.echo;
 		delete impl.echo;
 
@@ -1356,11 +1356,11 @@ describe("Tests ", function () {
 		catch (e)
 		{
 			exceptionCaught = true;
-		}	
+		}
 
 		expect(exceptionCaught).toBe(true);
 
-		exceptionCaught = false;	
+		exceptionCaught = false;
 
 		try
 		{
@@ -1369,7 +1369,7 @@ describe("Tests ", function () {
 		catch (e)
 		{
 			exceptionCaught = true;
-		}	
+		}
 
 		expect(exceptionCaught).toBe(true);
 
@@ -1400,11 +1400,11 @@ describe("Tests ", function () {
 		catch (e)
 		{
 			exceptionCaught = true;
-		}	
+		}
 
 		expect(exceptionCaught).toBe(true);
 
-		exceptionCaught = false;	
+		exceptionCaught = false;
 
 		try
 		{
@@ -1413,7 +1413,7 @@ describe("Tests ", function () {
 		catch (e)
 		{
 			exceptionCaught = true;
-		}	
+		}
 
 		expect(exceptionCaught).toBe(true);
 	});
@@ -1504,7 +1504,7 @@ describe("Tests ", function () {
 
 		try
 		{
-			d.setName(false);	
+			d.setName(false);
 		}
 		catch (e)
 		{
@@ -1518,7 +1518,7 @@ describe("Tests ", function () {
 
 		try
 		{
-			d.setName(true);	
+			d.setName(true);
 		}
 		catch (e)
 		{
@@ -1539,7 +1539,7 @@ describe("Tests ", function () {
 
 		try
 		{
-			d.setName(1);	
+			d.setName(1);
 		}
 		catch (e)
 		{
@@ -1649,7 +1649,7 @@ describe("Tests ", function () {
 
 		var MyButton = com.tns.tests.Button1.extend("MyButton1615", {
 			toString : function() {
-				return "button1"	
+				return "button1"
 			}});
 
 		var clazz1 = MyButton.class;
@@ -1664,7 +1664,7 @@ describe("Tests ", function () {
 
 	it("When_calling_non_existent_ctor_it_should_fail", function () {
 
-		__log("TEST: When_calling_non_existent_ctor_it_should_fail: Start"); 
+		__log("TEST: When_calling_non_existent_ctor_it_should_fail: Start");
 
 		try
 		{
@@ -1715,5 +1715,22 @@ describe("Tests ", function () {
         */
         var b = new com.tns.tests.Bundle();
         expect(b.getMyInt()).toBe(456);
+    });
+
+    it("should not truncate log if message is smaller than maxLogcatObjectSize", function () {
+        const maxLogcatObjectSize = 1025;
+        const str = Array(maxLogcatObjectSize).join("A");
+        console.log(str);
+        expect(com.tns.tests.LogcatUtil.logcatContainsString(str)).toBe(true);
+    });
+
+    it("should truncate log if message is larger than maxLogcatObjectSize", function () {
+        const maxLogcatObjectSize = 1025;
+        var str = Array(maxLogcatObjectSize).join("A") + "B";
+        console.log(str);
+        expect(com.tns.tests.LogcatUtil.logcatContainsString(str)).toBe(false);
+
+        console.log(str);
+        expect(com.tns.tests.LogcatUtil.logcatContainsString(str.slice(0, -1) + "...")).toBe(true);
     });
 });

--- a/test-app/app/src/main/java/com/tns/tests/LogcatUtil.java
+++ b/test-app/app/src/main/java/com/tns/tests/LogcatUtil.java
@@ -1,0 +1,24 @@
+package com.tns.tests;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public final class LogcatUtil {
+    public static boolean logcatContainsString(String str) throws Exception {
+        Runtime.getRuntime().exec("logcat -c").waitFor();
+
+        Process process = Runtime.getRuntime().exec("logcat -d");
+        InputStreamReader inputStreamReader = new InputStreamReader(process.getInputStream());
+        BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
+
+        String line;
+        StringBuilder sb = new StringBuilder();
+        while ((line = bufferedReader.readLine()) != null) {
+            sb.append(line);
+        }
+
+        String output = sb.toString();
+
+        return output.contains(str);
+    }
+}

--- a/test-app/runtime/src/main/cpp/Runtime.h
+++ b/test-app/runtime/src/main/cpp/Runtime.h
@@ -29,11 +29,11 @@ class Runtime {
 
         static void Init(JavaVM* vm, void* reserved);
 
-        static void Init(JNIEnv* _env, jobject obj, int runtimeId, jstring filesPath, jstring nativeLibsDir, jboolean verboseLoggingEnabled, jboolean isDebuggable, jstring packageName, jobjectArray args, jstring callingDir);
+        static void Init(JNIEnv* _env, jobject obj, int runtimeId, jstring filesPath, jstring nativeLibsDir, jboolean verboseLoggingEnabled, jboolean isDebuggable, jstring packageName, jobjectArray args, jstring callingDir, int maxLogcatObjectSize);
 
         static void SetManualInstrumentationMode(jstring mode);
 
-        void Init(jstring filesPath, jstring nativeLibsDir, bool verboseLoggingEnabled, bool isDebuggable, jstring packageName, jobjectArray args, jstring callingDir);
+        void Init(jstring filesPath, jstring nativeLibsDir, bool verboseLoggingEnabled, bool isDebuggable, jstring packageName, jobjectArray args, jstring callingDir, int maxLogcatObjectSize);
 
         v8::Isolate* GetIsolate() const;
 
@@ -83,7 +83,7 @@ class Runtime {
         v8::Persistent<v8::Function>* m_gcFunc;
         volatile bool m_runGC;
 
-        v8::Isolate* PrepareV8Runtime(const std::string& filesPath, const std::string& nativeLibsDir, const std::string& packageName, bool isDebuggable, const std::string& callingDir, const std::string& profilerOutputDir);
+        v8::Isolate* PrepareV8Runtime(const std::string& filesPath, const std::string& nativeLibsDir, const std::string& packageName, bool isDebuggable, const std::string& callingDir, const std::string& profilerOutputDir, const int maxLogcatObjectSize);
         jobject ConvertJsValueToJavaObject(JEnv& env, const v8::Local<v8::Value>& value, int classReturnType);
 
         static std::map<int, Runtime*> s_id2RuntimeCache;

--- a/test-app/runtime/src/main/cpp/com_tns_Runtime.cpp
+++ b/test-app/runtime/src/main/cpp/com_tns_Runtime.cpp
@@ -34,9 +34,9 @@ extern "C" JNIEXPORT void Java_com_tns_Runtime_SetManualInstrumentationMode(JNIE
     }
 }
 
-extern "C" JNIEXPORT void Java_com_tns_Runtime_initNativeScript(JNIEnv* _env, jobject obj, jint runtimeId, jstring filesPath, jstring nativeLibDir, jboolean verboseLoggingEnabled, jboolean isDebuggable, jstring packageName, jobjectArray args, jstring callingDir) {
+extern "C" JNIEXPORT void Java_com_tns_Runtime_initNativeScript(JNIEnv* _env, jobject obj, jint runtimeId, jstring filesPath, jstring nativeLibDir, jboolean verboseLoggingEnabled, jboolean isDebuggable, jstring packageName, jobjectArray args, jstring callingDir, jint maxLogcatObjectSize) {
     try {
-        Runtime::Init(_env, obj, runtimeId, filesPath, nativeLibDir, verboseLoggingEnabled, isDebuggable, packageName, args, callingDir);
+        Runtime::Init(_env, obj, runtimeId, filesPath, nativeLibDir, verboseLoggingEnabled, isDebuggable, packageName, args, callingDir, maxLogcatObjectSize);
     } catch (NativeScriptException& e) {
         e.ReThrowToJava();
     } catch (std::exception e) {

--- a/test-app/runtime/src/main/cpp/console/Console.h
+++ b/test-app/runtime/src/main/cpp/console/Console.h
@@ -15,7 +15,7 @@ typedef void (*ConsoleCallback)(const std::string& message, const std::string& l
 
 class Console {
     public:
-        static v8::Local<v8::Object> createConsole(v8::Local<v8::Context> context, ConsoleCallback callback);
+        static v8::Local<v8::Object> createConsole(v8::Local<v8::Context> context, ConsoleCallback callback, const int maxLogcatObjectSize);
 
         static void assertCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
         static void errorCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
@@ -28,6 +28,7 @@ class Console {
         static void timeEndCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
 
     private:
+        static int m_maxLogcatObjectSize;
         static ConsoleCallback m_callback;
         static const char* LOG_TAG;
         static std::map<v8::Isolate*, std::map<std::string, double>> s_isolateToConsoleTimersMap;

--- a/test-app/runtime/src/main/java/com/tns/AppConfig.java
+++ b/test-app/runtime/src/main/java/com/tns/AppConfig.java
@@ -17,7 +17,8 @@ class AppConfig {
         FreeMemoryRatio("freeMemoryRatio", 0.0),
         Profiling("profiling", ""),
         MarkingMode("markingMode", com.tns.MarkingMode.full),
-        HandleTimeZoneChanges("handleTimeZoneChanges", false);
+        HandleTimeZoneChanges("handleTimeZoneChanges", false),
+        MaxLogcatObjectSize("maxLogcatObjectSize", 1024);
 
         private final String name;
         private final Object defaultValue;
@@ -104,6 +105,9 @@ class AppConfig {
                     if (androidObject.has(KnownKeys.HandleTimeZoneChanges.getName())) {
                         values[KnownKeys.HandleTimeZoneChanges.ordinal()] = androidObject.getBoolean(KnownKeys.HandleTimeZoneChanges.getName());
                     }
+                    if (androidObject.has(KnownKeys.MaxLogcatObjectSize.getName())) {
+                        values[KnownKeys.MaxLogcatObjectSize.ordinal()] = androidObject.getInt(KnownKeys.MaxLogcatObjectSize.getName());
+                    }
                 }
             }
         } catch (Exception e) {
@@ -145,5 +149,9 @@ class AppConfig {
 
     public boolean handleTimeZoneChanges() {
         return (boolean)values[KnownKeys.HandleTimeZoneChanges.ordinal()];
+    }
+
+    public int getMaxLogcatObjectSize() {
+        return (int)values[KnownKeys.MaxLogcatObjectSize.ordinal()];
     }
 }

--- a/test-app/runtime/src/main/java/com/tns/Runtime.java
+++ b/test-app/runtime/src/main/java/com/tns/Runtime.java
@@ -32,7 +32,7 @@ import android.util.SparseArray;
 import com.tns.bindings.ProxyGenerator;
 
 public class Runtime {
-    private native void initNativeScript(int runtimeId, String filesPath, String nativeLibDir, boolean verboseLoggingEnabled, boolean isDebuggable, String packageName, Object[] v8Options, String callingDir);
+    private native void initNativeScript(int runtimeId, String filesPath, String nativeLibDir, boolean verboseLoggingEnabled, boolean isDebuggable, String packageName, Object[] v8Options, String callingDir, int maxLogcatObjectSize);
 
     private native void runModule(int runtimeId, String filePath) throws NativeScriptException;
 
@@ -490,7 +490,7 @@ public class Runtime {
                 throw new RuntimeException("Fail to initialize Require class", ex);
             }
 
-            initNativeScript(getRuntimeId(), Module.getApplicationFilesPath(), nativeLibDir, logger.isEnabled(), isDebuggable, appName, appConfig.getAsArray(), callingJsDir);
+            initNativeScript(getRuntimeId(), Module.getApplicationFilesPath(), nativeLibDir, logger.isEnabled(), isDebuggable, appName, appConfig.getAsArray(), callingJsDir, appConfig.getMaxLogcatObjectSize());
 
             //clearStartupData(getRuntimeId()); // It's safe to delete the data after the V8 debugger is initialized
 


### PR DESCRIPTION
Related to #1026

Added new flag `maxLogcatObjectSize` to `app/package.json` which allows to control the maximum size of objects sent to logcat before truncating. The default value is 1024:

```json
{
    "android": {
        "v8Flags": "--expose_gc",
        "maxLogcatObjectSize": 1024
    },
    "main": "app.js",
    "name": "tns-template-hello-world",
    "version": "4.0.0"
}
```