### PR TITLE
Add $ in front when the root namespace matches JS keyword

### DIFF
--- a/test-app/app/src/main/assets/app/tests/testMetadata.js
+++ b/test-app/app/src/main/assets/app/tests/testMetadata.js
@@ -1,10 +1,10 @@
 describe("Tests metadata", function () {
-	
+
 	it("Can_access_protected_static_members_of_protected_interface", function () {
 		var accountType = android.provider.ContactsContract.SyncColumns.ACCOUNT_TYPE;
 		expect(accountType).toBeTruthy(accountType !== undefined);
 	});
-	
+
 	it("should access public methods of non-public base classes", function () {
 		var c = new com.tns.tests.MyTestDerivedClass();
 		var exceptionCaught = false;
@@ -23,10 +23,16 @@ describe("Tests metadata", function () {
 
 	it("should be able to access static fields declared in interface from implementing class", function () {
 		var c = new com.tns.tests.MyTestDerivedClass();
-		
+
 		var staticFieldFromInterface = android.app.Activity.TRIM_MEMORY_RUNNING_MODERATE;
 		var expected = 5;
-		
+
 		expect(staticFieldFromInterface).toBe(expected);
+	});
+
+	it("should be able to access keyword namespace bu prefixing the namespace with $", function () {
+		var keywordClass = new $in.tns.tests.JavascriptKeywordClass();
+		var expected = 5;
+		expect(keywordClass.getValue5()).toBe(expected);
 	});
 });

--- a/test-app/app/src/main/java/in/tns/tests/JavascriptKeywordClass.java
+++ b/test-app/app/src/main/java/in/tns/tests/JavascriptKeywordClass.java
@@ -1,0 +1,8 @@
+package in.tns.tests;
+
+public class JavascriptKeywordClass {
+    public int getValue5()
+    {
+        return 5;
+    }
+}

--- a/test-app/runtime/src/main/cpp/MetadataNode.h
+++ b/test-app/runtime/src/main/cpp/MetadataNode.h
@@ -56,7 +56,6 @@ namespace tns {
         static MetadataNode* GetOrCreate(const std::string& className);
 
         static std::string GetTypeMetadataName(v8::Isolate* isolate, v8::Local<v8::Value>& value);
-
     private:
         struct MethodCallbackData;
 
@@ -70,6 +69,7 @@ namespace tns {
 
         MetadataNode(MetadataTreeNode* treeNode);
 
+        static bool IsJavascriptKeyword(std::string word);
         v8::Local<v8::Object> CreatePackageObject(v8::Isolate* isolate);
 
         v8::Local<v8::Function> GetConstructorFunction(v8::Isolate* isolate);


### PR DESCRIPTION
Related to #1046

When the root namespace matches a JavaScript keyword, it should be used with $ in front e.g.:
```
declare var $in;
var keywordClass = new $in.tns.tests.JavascriptKeywordClass();
```