### PR TITLE
Added forceLog setting to log in release

### DIFF
--- a/test-app/app/src/main/assets/app/package.json
+++ b/test-app/app/src/main/assets/app/package.json
@@ -7,6 +7,7 @@
 		"memoryCheckInterval": 10,
 		"freeMemoryRatio": 0.50,
 		"markingMode": "full",
-		"maxLogcatObjectSize": 1024
+		"maxLogcatObjectSize": 1024,
+		"forceLog": false
 	}
 }

--- a/test-app/runtime/src/main/cpp/Runtime.h
+++ b/test-app/runtime/src/main/cpp/Runtime.h
@@ -29,11 +29,12 @@ class Runtime {
 
         static void Init(JavaVM* vm, void* reserved);
 
-        static void Init(JNIEnv* _env, jobject obj, int runtimeId, jstring filesPath, jstring nativeLibsDir, jboolean verboseLoggingEnabled, jboolean isDebuggable, jstring packageName, jobjectArray args, jstring callingDir, int maxLogcatObjectSize);
+        static void Init(JNIEnv* _env, jobject obj, int runtimeId, jstring filesPath, jstring nativeLibsDir, jboolean verboseLoggingEnabled, jboolean isDebuggable, jstring packageName, jobjectArray args, jstring callingDir, int maxLogcatObjectSize,
+                         bool forceLog);
 
         static void SetManualInstrumentationMode(jstring mode);
 
-        void Init(jstring filesPath, jstring nativeLibsDir, bool verboseLoggingEnabled, bool isDebuggable, jstring packageName, jobjectArray args, jstring callingDir, int maxLogcatObjectSize);
+        void Init(jstring filesPath, jstring nativeLibsDir, bool verboseLoggingEnabled, bool isDebuggable, jstring packageName, jobjectArray args, jstring callingDir, int maxLogcatObjectSize, bool forceLog);
 
         v8::Isolate* GetIsolate() const;
 
@@ -83,7 +84,7 @@ class Runtime {
         v8::Persistent<v8::Function>* m_gcFunc;
         volatile bool m_runGC;
 
-        v8::Isolate* PrepareV8Runtime(const std::string& filesPath, const std::string& nativeLibsDir, const std::string& packageName, bool isDebuggable, const std::string& callingDir, const std::string& profilerOutputDir, const int maxLogcatObjectSize);
+        v8::Isolate* PrepareV8Runtime(const std::string& filesPath, const std::string& nativeLibsDir, const std::string& packageName, bool isDebuggable, const std::string& callingDir, const std::string& profilerOutputDir, const int maxLogcatObjectSize, const bool forceLog);
         jobject ConvertJsValueToJavaObject(JEnv& env, const v8::Local<v8::Value>& value, int classReturnType);
         static int GetAndroidVersion();
         static int m_androidVersion;

--- a/test-app/runtime/src/main/cpp/com_tns_Runtime.cpp
+++ b/test-app/runtime/src/main/cpp/com_tns_Runtime.cpp
@@ -34,9 +34,9 @@ extern "C" JNIEXPORT void Java_com_tns_Runtime_SetManualInstrumentationMode(JNIE
     }
 }
 
-extern "C" JNIEXPORT void Java_com_tns_Runtime_initNativeScript(JNIEnv* _env, jobject obj, jint runtimeId, jstring filesPath, jstring nativeLibDir, jboolean verboseLoggingEnabled, jboolean isDebuggable, jstring packageName, jobjectArray args, jstring callingDir, jint maxLogcatObjectSize) {
+extern "C" JNIEXPORT void Java_com_tns_Runtime_initNativeScript(JNIEnv* _env, jobject obj, jint runtimeId, jstring filesPath, jstring nativeLibDir, jboolean verboseLoggingEnabled, jboolean isDebuggable, jstring packageName, jobjectArray args, jstring callingDir, jint maxLogcatObjectSize, jboolean forceLog) {
     try {
-        Runtime::Init(_env, obj, runtimeId, filesPath, nativeLibDir, verboseLoggingEnabled, isDebuggable, packageName, args, callingDir, maxLogcatObjectSize);
+        Runtime::Init(_env, obj, runtimeId, filesPath, nativeLibDir, verboseLoggingEnabled, isDebuggable, packageName, args, callingDir, maxLogcatObjectSize, forceLog);
     } catch (NativeScriptException& e) {
         e.ReThrowToJava();
     } catch (std::exception e) {

--- a/test-app/runtime/src/main/cpp/console/Console.cpp
+++ b/test-app/runtime/src/main/cpp/console/Console.cpp
@@ -15,9 +15,10 @@
 
 namespace tns {
 
-v8::Local<v8::Object> Console::createConsole(v8::Local<v8::Context> context, ConsoleCallback callback, const int maxLogcatObjectSize) {
+v8::Local<v8::Object> Console::createConsole(v8::Local<v8::Context> context, ConsoleCallback callback, const int maxLogcatObjectSize, const bool forceLog) {
     m_callback = callback;
     m_maxLogcatObjectSize = maxLogcatObjectSize;
+    m_forceLog = forceLog;
     v8::Context::Scope contextScope(context);
     v8::Isolate* isolate = context->GetIsolate();
 
@@ -165,7 +166,7 @@ const std::string buildLogString(const v8::FunctionCallbackInfo<v8::Value>& info
 }
 
 void Console::assertCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
-    if (!isApplicationInDebug) {
+    if (!shouldLog()) {
         return;
     }
     try {
@@ -203,7 +204,7 @@ void Console::assertCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
 }
 
 void Console::errorCallback(const v8::FunctionCallbackInfo <v8::Value>& info) {
-    if (!isApplicationInDebug) {
+    if (!shouldLog()) {
         return;
     }
     try {
@@ -225,7 +226,7 @@ void Console::errorCallback(const v8::FunctionCallbackInfo <v8::Value>& info) {
 }
 
 void Console::infoCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
-    if (!isApplicationInDebug) {
+    if (!shouldLog()) {
         return;
     }
     try {
@@ -247,7 +248,7 @@ void Console::infoCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
 }
 
 void Console::logCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
-    if (!isApplicationInDebug) {
+    if (!shouldLog()) {
         return;
     }
     try {
@@ -269,7 +270,7 @@ void Console::logCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
 }
 
 void Console::warnCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
-    if (!isApplicationInDebug) {
+    if (!shouldLog()) {
         return;
     }
     try {
@@ -291,7 +292,7 @@ void Console::warnCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
 }
 
 void Console::dirCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
-    if (!isApplicationInDebug) {
+    if (!shouldLog()) {
         return;
     }
     try {
@@ -408,7 +409,7 @@ const std::string buildStacktraceFrameMessage(v8::Local<v8::StackFrame> frame) {
 }
 
 void Console::traceCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
-    if (!isApplicationInDebug) {
+    if (!shouldLog()) {
         return;
     }
     try {
@@ -454,7 +455,7 @@ void Console::traceCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
 }
 
 void Console::timeCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
-    if (!isApplicationInDebug) {
+    if (!shouldLog()) {
         return;
     }
     try {
@@ -493,7 +494,7 @@ void Console::timeCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
 }
 
 void Console::timeEndCallback(const v8::FunctionCallbackInfo<v8::Value>& info) {
-    if (!isApplicationInDebug) {
+    if (!shouldLog()) {
         return;
     }
     try {
@@ -555,6 +556,7 @@ const char* Console::LOG_TAG = "JS";
 std::map<v8::Isolate*, std::map<std::string, double>> Console::s_isolateToConsoleTimersMap;
 ConsoleCallback Console::m_callback = nullptr;
 int Console::m_maxLogcatObjectSize;
+bool Console::m_forceLog;
 
 #ifdef APPLICATION_IN_DEBUG
 bool Console::isApplicationInDebug = true;

--- a/test-app/runtime/src/main/cpp/console/Console.h
+++ b/test-app/runtime/src/main/cpp/console/Console.h
@@ -15,7 +15,7 @@ typedef void (*ConsoleCallback)(const std::string& message, const std::string& l
 
 class Console {
     public:
-        static v8::Local<v8::Object> createConsole(v8::Local<v8::Context> context, ConsoleCallback callback, const int maxLogcatObjectSize);
+        static v8::Local<v8::Object> createConsole(v8::Local<v8::Context> context, ConsoleCallback callback, const int maxLogcatObjectSize, const bool forceLog);
 
         static void assertCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
         static void errorCallback(const v8::FunctionCallbackInfo<v8::Value>& info);
@@ -29,11 +29,15 @@ class Console {
 
     private:
         static int m_maxLogcatObjectSize;
+        static bool m_forceLog;
         static ConsoleCallback m_callback;
         static const char* LOG_TAG;
         static std::map<v8::Isolate*, std::map<std::string, double>> s_isolateToConsoleTimersMap;
 
         static bool isApplicationInDebug;
+        static bool shouldLog() {
+            return m_forceLog || isApplicationInDebug;
+        }
 
         // heavily inspired by 'createBoundFunctionProperty' of V8's v8-console.h
         static void bindFunctionProperty(v8::Local<v8::Context> context,

--- a/test-app/runtime/src/main/java/com/tns/AppConfig.java
+++ b/test-app/runtime/src/main/java/com/tns/AppConfig.java
@@ -18,7 +18,8 @@ class AppConfig {
         Profiling("profiling", ""),
         MarkingMode("markingMode", com.tns.MarkingMode.full),
         HandleTimeZoneChanges("handleTimeZoneChanges", false),
-        MaxLogcatObjectSize("maxLogcatObjectSize", 1024);
+        MaxLogcatObjectSize("maxLogcatObjectSize", 1024),
+        ForceLog("forceLog", false);
 
         private final String name;
         private final Object defaultValue;
@@ -108,6 +109,9 @@ class AppConfig {
                     if (androidObject.has(KnownKeys.MaxLogcatObjectSize.getName())) {
                         values[KnownKeys.MaxLogcatObjectSize.ordinal()] = androidObject.getInt(KnownKeys.MaxLogcatObjectSize.getName());
                     }
+                    if (androidObject.has(KnownKeys.ForceLog.getName())) {
+                        values[KnownKeys.ForceLog.ordinal()] = androidObject.getBoolean(KnownKeys.ForceLog.getName());
+                    }
                 }
             }
         } catch (Exception e) {
@@ -153,5 +157,9 @@ class AppConfig {
 
     public int getMaxLogcatObjectSize() {
         return (int)values[KnownKeys.MaxLogcatObjectSize.ordinal()];
+    }
+
+    public boolean getForceLog() {
+        return (boolean)values[KnownKeys.ForceLog.ordinal()];
     }
 }

--- a/test-app/runtime/src/main/java/com/tns/Runtime.java
+++ b/test-app/runtime/src/main/java/com/tns/Runtime.java
@@ -32,7 +32,7 @@ import android.util.SparseArray;
 import com.tns.bindings.ProxyGenerator;
 
 public class Runtime {
-    private native void initNativeScript(int runtimeId, String filesPath, String nativeLibDir, boolean verboseLoggingEnabled, boolean isDebuggable, String packageName, Object[] v8Options, String callingDir, int maxLogcatObjectSize);
+    private native void initNativeScript(int runtimeId, String filesPath, String nativeLibDir, boolean verboseLoggingEnabled, boolean isDebuggable, String packageName, Object[] v8Options, String callingDir, int maxLogcatObjectSize, boolean forceLog);
 
     private native void runModule(int runtimeId, String filePath) throws NativeScriptException;
 
@@ -490,7 +490,8 @@ public class Runtime {
                 throw new RuntimeException("Fail to initialize Require class", ex);
             }
 
-            initNativeScript(getRuntimeId(), Module.getApplicationFilesPath(), nativeLibDir, logger.isEnabled(), isDebuggable, appName, appConfig.getAsArray(), callingJsDir, appConfig.getMaxLogcatObjectSize());
+            initNativeScript(getRuntimeId(), Module.getApplicationFilesPath(), nativeLibDir, logger.isEnabled(), isDebuggable, appName, appConfig.getAsArray(), callingJsDir, appConfig.getMaxLogcatObjectSize(),
+                appConfig.getForceLog() || appConfig.getProfilingMode() == "timeline");
 
             //clearStartupData(getRuntimeId()); // It's safe to delete the data after the V8 debugger is initialized
 


### PR DESCRIPTION
Related to #1056
The new setting should be added in `app/package.json` file under `android`:
```JavaScript
{
    "main": "main.js",
    "android": {
        "forceLog": true
    }
    // setting profiling timeline should also force log in release
    // "profiling": "timeline"
}
```


