### PR TITLE
set dex jumboMode to true

### DIFF
--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -171,6 +171,9 @@ android {
                 abiFilters 'x86', 'armeabi-v7a'//, 'arm64-v8a'
             }
         }
+        dexOptions {
+            jumboMode = true
+        }
     }
 
     sourceSets.main {


### PR DESCRIPTION
Fixes the following issue:

 Gradle build...
         + applying user-defined configuration from D:\git\NS-Issues-2018-II\nativescript-cli\issue_3587\app\App_Resources\Android\app.gradle
Configuration 'compile' in project ':app' is deprecated. Use 'implementation' instead.
Configuration 'debugCompile' in project ':app' is deprecated. Use 'debugImplementation' instead.
         + adding nativescript runtime package dependency: nativescript-optimized
         + adding aar plugin dependency: D:\git\NS-Issues-2018-II\nativescript-cli\issue_3587\node_modules\nativescript-geolocation\platforms\android\nativescript_geolocation.aar
         + adding aar plugin dependency: D:\git\NS-Issues-2018-II\nativescript-cli\issue_3587\node_modules\nativescript-imagepicker\platforms\android\nativescript_imagepicker.aar
         + adding aar plugin dependency: D:\git\NS-Issues-2018-II\nativescript-cli\issue_3587\node_modules\nativescript-push-notifications\platforms\android\pushplugin.aar
         + adding aar plugin dependency: D:\git\NS-Issues-2018-II\nativescript-cli\issue_3587\node_modules\nativescript-social-login\platforms\android\nativescript_social_login.aar
         + adding aar plugin dependency: D:\git\NS-Issues-2018-II\nativescript-cli\issue_3587\node_modules\nativescript-social-share\platforms\android\nativescript_social_share.aar
         + adding aar plugin dependency: D:\git\NS-Issues-2018-II\nativescript-cli\issue_3587\node_modules\tns-core-modules-widgets\platforms\android\widgets-release.aar
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
Dex: Error converting bytecode to dex:
Cause: com.android.dex.DexException: Multiple dex files define Lcom/google/android/gms/common/api/internal/zzda;
    UNEXPECTED TOP-LEVEL EXCEPTION:
com.android.dex.DexException: Multiple dex files define Lcom/google/android/gms/common/api/internal/zzda;

com.android.dex.DexException: Multiple dex files define Lcom/google/android/gms/common/api/internal/zzda;
        at com.android.dx.merge.DexMerger.readSortableTypes(DexMerger.java:661)
        at com.android.dx.merge.DexMerger.getSortedTypes(DexMerger.java:616)
        at com.android.dx.merge.DexMerger.mergeClassDefs(DexMerger.java:598)
        at com.android.dx.merge.DexMerger.mergeDexes(DexMerger.java:171)
        at com.android.dx.merge.DexMerger.merge(DexMerger.java:198)
        at com.android.builder.dexing.DexArchiveMergerCallable.call(DexArchiveMergerCallable.java:61)
        at com.android.builder.dexing.DexArchiveMergerCallable.call(DexArchiveMergerCallable.java:36)
        at java.util.concurrent.ForkJoinTask$AdaptedCallable.exec(ForkJoinTask.java:1424)
        at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
        at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
        at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
        at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:transformDexArchiveWithDexMergerForDebug'.
> com.android.build.api.transform.TransformException: com.android.dex.DexException: Multiple dex files define Lcom/google/android/gms/common/api/internal/zzda;