### PR TITLE
Support the new gradle 4.4 flavor dimension configurations

### DIFF
--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -18,6 +18,8 @@
 
 import groovy.json.JsonSlurper
 import java.nio.file.Paths
+import java.util.regex.Matcher
+import java.util.regex.Pattern
 
 apply plugin: "com.android.application"
 
@@ -403,12 +405,20 @@ task extractAllJars {
     outputs.dir extractedDependenciesDir
 
     doLast {
-        def iter;
-        if (project.selectedBuildType == "release") {
-            iter = configurations.releaseCompileClasspath.resolve()
-        } else {
-            iter = configurations.debugCompileClasspath.resolve()
+        def buildType = project.selectedBuildType == "release" ? "Release" : "Debug"
+        def iter = []
+        Pattern pattern = Pattern.compile("^(.+)${buildType}CompileClasspath\$")
+        configurations.all{ config ->
+            Matcher matcher = pattern.matcher(config.name)
+            if (matcher.find() || config.name == "${buildType.toLowerCase()}CompileClasspath") {
+                config.resolve().each {
+                    if (!iter.contains(it)) {
+                        iter.push(it)
+                    }
+                }
+            }
         }
+
         def dependencyCounter = 0
         iter.each {
             def nextDependency = it


### PR DESCRIPTION
Related to #1062.

Add support for the new gradle 4.4 flavor dimension configurations.

This PR fixes an issue if custom dimensions are used in `app/App_Resources/Android/app.gradle`:

```groovy
flavorDimensions "arch", "mode"

productFlavors {
  demo {
    dimension "mode"
  }
  full {
    dimension "mode"
  }
  x86 {
    dimension "arch"
  }
  arm {
    dimension "arch"
  }
  arm64 {
    dimension "arch"
  }
}
```

The build will fail with:

```
Could not get unknown property 'debugCompileClasspath' for configuration container of type org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer
```