### PR TITLE
Add support for indirect ByteBuffer

### DIFF
--- a/test-app/app/src/main/assets/app/tests/byte-buffer-test.js
+++ b/test-app/app/src/main/assets/app/tests/byte-buffer-test.js
@@ -1,5 +1,5 @@
 describe("Tests mapped ByteBuffer conversion", function () {
-	it("should convert ByteBuffer to ArrayBuffer", function () {
+	it("should convert ByteBuffer to ArrayBuffer [Direct ByteBuffer]", function () {
 		var bb = java.nio.ByteBuffer.allocateDirect(12);
 		var ab = ArrayBuffer.from(bb);
 		var int8arr = new Int8Array(ab);
@@ -8,7 +8,16 @@ describe("Tests mapped ByteBuffer conversion", function () {
 		expect(int32arr.length).toBe(3);
 	});
 
-	it("should share the same memory of all typed arrays", function () {
+	it("should convert ByteBuffer to ArrayBuffer [Indirect ByteBuffer]", function () {
+        var bb = java.nio.ByteBuffer.allocate(12);
+        var ab = ArrayBuffer.from(bb);
+        var int8arr = new Int8Array(ab);
+        expect(int8arr.length).toBe(12);
+        var int32arr = new Int32Array(ab);
+        expect(int32arr.length).toBe(3);
+    });
+
+	it("should share the same memory of all typed arrays [Direct ByteBuffer]", function () {
 		var bb = java.nio.ByteBuffer.allocateDirect(12);
 		var ab = ArrayBuffer.from(bb);
 		var int8arr = new Int8Array(ab);
@@ -23,12 +32,34 @@ describe("Tests mapped ByteBuffer conversion", function () {
 		expect(value).toBe(0x44332211);
 	});
 
-	it("should keep original ByteBuffer after conversion", function () {
+	it("should share the same memory of all typed arrays [Indirect ByteBuffer]", function () {
+        var bb = java.nio.ByteBuffer.allocate(12);
+        var ab = ArrayBuffer.from(bb);
+        var int8arr = new Int8Array(ab);
+        expect(int8arr.length).toBe(12);
+        var int32arr = new Int32Array(ab);
+        expect(int32arr.length).toBe(3);
+        int8arr[0] = 0x11;
+        int8arr[1] = 0x22;
+        int8arr[2] = 0x33;
+        int8arr[3] = 0x44;
+        var value = int32arr[0];
+        expect(value).toBe(0x44332211);
+    });
+
+	it("should keep original ByteBuffer after conversion [Direct ByteBuffer]", function () {
 		var bb = java.nio.ByteBuffer.allocateDirect(12);
 		var ab = ArrayBuffer.from(bb);
 		var same = bb === ab.nativeObject;
 		expect(same).toBe(true);
 	});
+
+	it("should keep original ByteBuffer after conversion [Indirect ByteBuffer]", function () {
+        var bb = java.nio.ByteBuffer.allocate(12);
+        var ab = ArrayBuffer.from(bb);
+        var same = bb === ab.nativeObject;
+        expect(same).toBe(true);
+    });
 
 	it("should throw exception when ArrayBuffer.from is called with wrong number of arguments", function () {
 		var exceptionCaught = false;

--- a/test-app/runtime/src/main/cpp/ArrayBufferHelper.h
+++ b/test-app/runtime/src/main/cpp/ArrayBufferHelper.h
@@ -5,24 +5,25 @@
 #include "ObjectManager.h"
 
 namespace tns {
-class ArrayBufferHelper {
-    public:
-        ArrayBufferHelper();
+    class ArrayBufferHelper {
+        public:
+            ArrayBufferHelper();
 
-        void CreateConvertFunctions(v8::Isolate* isolate, const v8::Local<v8::Object>& global, ObjectManager* objectManager);
+            void CreateConvertFunctions(v8::Isolate* isolate, const v8::Local<v8::Object>& global, ObjectManager* objectManager);
 
-    private:
+        private:
 
-        static void CreateFromCallbackStatic(const v8::FunctionCallbackInfo<v8::Value>& info);
+            static void CreateFromCallbackStatic(const v8::FunctionCallbackInfo<v8::Value>& info);
 
-        void CreateFromCallbackImpl(const v8::FunctionCallbackInfo<v8::Value>& info);
+            void CreateFromCallbackImpl(const v8::FunctionCallbackInfo<v8::Value>& info);
 
-        ObjectManager* m_objectManager;
+            ObjectManager* m_objectManager;
 
-        jclass m_ByteBufferClass;
-
-        jmethodID m_isDirectMethodID;
-};
+            jclass m_ByteBufferClass;
+            jmethodID m_isDirectMethodID;
+            jmethodID m_remainingMethodID;
+            jmethodID m_getMethodID;
+    };
 }
 
 


### PR DESCRIPTION
Related to #1060

Now we support indirect ByteBuffers, however they are slower as we are copying the buffer content to the result array.