### PR TITLE
Use google repository as primary

### DIFF
--- a/test-app/build-tools/android-metadata-generator/build.gradle
+++ b/test-app/build-tools/android-metadata-generator/build.gradle
@@ -12,8 +12,8 @@ targetCompatibility = JavaVersion.VERSION_1_6
 
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 
     dependencies {

--- a/test-app/build-tools/static-binding-generator/runtests.gradle
+++ b/test-app/build-tools/static-binding-generator/runtests.gradle
@@ -4,8 +4,8 @@ apply plugin: 'java-library'
 defaultTasks 'runSbg'
 
 repositories {
-    jcenter()
     google()
+    jcenter()
 }
 
 dependencies {

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -3,8 +3,8 @@
 buildscript {
 
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'


### PR DESCRIPTION
Make google repository as primary due to unreliability of jcenter.