### PR TITLE
Use NDK 17b to build the runtime in travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
   global:
   - NODE_VERSION=6.11.1
-  - NDK_VERSION=r16b
+  - NDK_VERSION=r17b
   - DATE=$(date +%Y-%m-%d)
   - PACKAGE_VERSION=next-$DATE-$TRAVIS_BUILD_NUMBER
   - EMULATOR_API_LEVEL=21


### PR DESCRIPTION
Using NDK 17b to build the runtime in Travis CI.