### PR TITLE
Increase the org.gradle.workers.max value

### DIFF
--- a/build-artifacts/project-template-gradle/gradle.properties
+++ b/build-artifacts/project-template-gradle/gradle.properties
@@ -15,3 +15,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx16384M
+
+# When configured, Gradle will use a maximum of the given number of workers.
+# Default is number of CPU processors.
+org.gradle.workers.max=400

--- a/test-app/gradle.properties
+++ b/test-app/gradle.properties
@@ -15,3 +15,7 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+# When configured, Gradle will use a maximum of the given number of workers.
+# Default is number of CPU processors.
+org.gradle.workers.max=400


### PR DESCRIPTION
By default in gradle 4.8, the WorkerExecutor limits the number of active work items to the number of available CPU cores ([#4502](https://github.com/gradle/gradle/issues/4502)). This leads to a very slow `mergeDebugAssets` step for angular projects due to the large number of javascript files that need to be processed.

Setting `org.gradle.workers.max` to a sufficiently large number improves the build times.

In the future we might also consider to enable bundle by default for Angular projects to reduce the number of js assets and further improve the build time.