### PR TITLE
Respect the minSdkVersion from AndroidManifest.xml

### DIFF
--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -169,7 +169,9 @@ android {
     buildToolsVersion computeBuildToolsVersion()
 
     defaultConfig {
-        minSdkVersion 17
+        def manifest = new XmlSlurper().parse(file(android.sourceSets.main.manifest.srcFile))
+        def minSdkVer = manifest."uses-sdk"."@android:minSdkVersion".text() ?: 17
+        minSdkVersion minSdkVer
         targetSdkVersion computeTargetSdkVersion()
         ndk {
             if (onlyX86) {


### PR DESCRIPTION
The `minSdkVersion` set in `app/App_Resources/Android/src/main/AndroidManifest.xml` should be respected by the project gradle (related to #1104).