### PR TITLE
fix(crash): Fix for #887

### DIFF
--- a/test-app/runtime/src/main/java/com/tns/Runtime.java
+++ b/test-app/runtime/src/main/java/com/tns/Runtime.java
@@ -1098,7 +1098,12 @@ public class Runtime {
 
         if (isWorkThread) {
             Object[] packagedArgs = packageArgs(tmpArgs);
-            ret = callJSMethodNative(getRuntimeId(), javaObjectID, methodName, returnType, isConstructor, packagedArgs);
+            try {
+                ret = callJSMethodNative(getRuntimeId(), javaObjectID, methodName, returnType, isConstructor, packagedArgs);
+            } catch (NativeScriptException e) {
+                logger.write("Error on currentThread for callJSMethodNative:", e.getMessage());
+                e.printStackTrace();
+            }
         } else {
             final Object[] arr = new Object[2];
 
@@ -1110,6 +1115,9 @@ public class Runtime {
                         try {
                             final Object[] packagedArgs = packageArgs(tmpArgs);
                             arr[0] = callJSMethodNative(getRuntimeId(), javaObjectID, methodName, returnType, isCtor, packagedArgs);
+                        } catch (NativeScriptException e) {
+                            logger.write("Error off currentThread for callJSMethodNative:", e.getMessage());
+                            e.printStackTrace();
                         } finally {
                             this.notify();
                             arr[1] = Boolean.TRUE;


### PR DESCRIPTION
https://www.telerik.com/account/support-tickets/view-ticket?threadid=1175125
#887 

We enabled "markingMode: none" some month back which noticeably improve performance, however, there has been an increase in crashes that seem to appear related to these garbage collected objects when traversing the app rapidly.

All are caused by "Fatal Exception: com.tns.NativeScriptException"

They generally fall into a few different types:

1. `Calling js method onCreateView failed Error: java.lang.NoSuchMethodError: no non-static method`
Seen with multiple classes/methods:
   * `"Landroid/widget/TextView;.setHint()Ljava/util/Set;"`
   * `"Lorg/nativescript/widgets/GridLayout;.addView()Z"`
   * `"Lcom/facebook/drawee/view/SimpleDraweeView;.setImageURI(Ljava/lang/Object;)Ljava/lang/Object;"`
   * `"Landroid/widget/TextView;.setPadding()Ljava/util/Set;"`
   * `"Landroid/animation/AnimatorSet;.clone()Ljava/util/Iterator;"`
   * `"Lorg/nativescript/widgets/GridLayout;.addView()Ljava/lang/Object;"`
   * `"Lorg/nativescript/widgets/GridLayout;.addView(Ljava/lang/Object;)Ljava/lang/Object;"`
   * `"Lorg/nativescript/widgets/GridLayout;.addView()Z"`
2. `Attempt to use cleared object reference id=`
3. `Calling js method onCreateView failed Error: java.lang.Exception: Failed resolving method addView on class`
Various classes:
   * `Calling js method onCreateView failed Error: java.lang.Exception: Failed resolving method addView on class android.view.ViewGroup com.tns.Runtime.resolveMethodOverload(Runtime.java:1062) com.tns.Runtime.callJSMethodNative(Native Method) com.tns.Runtime.dispatchCallJSMethodNative(Runtime.java:1101)`
   * `Calling js method onCreateView failed Error: java.lang.Exception: Failed resolving method addView on class org.nativescript.widgets.GridLayout com.tns.Runtime.resolveMethodOverload(Runtime.java:1062) com.tns.Runtime.callJSMethodNative(Native Method) com.tns.Runtime.dispatchCallJSMethodNative(Runtime.java:1101)`
4. `Calling js method onDismiss failed Error: java.lang.IllegalStateException: Activity has been destroyed android.app.FragmentManagerImpl.enqueueAction(FragmentManager.java:1460)`
4b. `Calling js method onDismiss failed TypeError: Cannot read property 'setOnTouchListener' of null File: "<embedded>, line: 37, column: 522034 StackTrace: Frame: function:'t.onUnloaded',`
5. Possible others:
   * `Unable to start activity ComponentInfo{com.ugroupmedia.pnp14/com.tns.NativeScriptActivity}: com.tns.NativeScriptException: Calling js method onCreate failed Error: Could not find a page for fragment3[3]. File: "<embedded>, line: 37, column: 640522 StackTrace: Frame: function:'c', file:'<embedded>', line: 37, column: 1307106 Frame: function:'L', file:'<embedded>', line: 37, column: 637193 Frame: function:'e.onCreate', file:'<embedded>', line: 37, column: 638611 Frame: function:'n.onCreate', file:'<embedded>', line: 37, column: 1690605 Frame: function:'e.onCreate', file:'<embedded>', line: 37, column: 640523 Frame: function:'n.onCreate', file:'<embedded>', line: 37, column: 1689023`
   * `Failure delivering result ResultInfo{who=null, request=64206, result=-1, data=Intent { (has extras) }} to activity {com.ugroupmedia.pnp14/com.tns.NativeScriptActivity}: com.tns.NativeScriptException: Calling js method onActivityResult failed Error: Cannot convert object to Lcom/google/android/gms/tasks/OnCompleteListener; at index 0 File: "<embedded>, line: 37, column: 729120 StackTrace: Frame: function:'onSuccess', file:'<embedded>', line: 37, column: 746398 Frame: function:'', file:'<embedded>', line: 37, column: 729121 Frame: function:'e.notify', file:'<embedded>', line: 37, column: 779309 Frame: function:'e.onActivityResult', file:'<embedded>', line: 37, column: 642514 Frame: function:'n.onActivityResult', file:'<embedded>', line: 37, column: 1689820`
   * `Calling js method run failed TypeError: Cannot read property 'getWindow' of undefined`
   * `Calling js method run failed Error: java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState android.app.FragmentManagerImpl.checkStateLoss(FragmentManager.java:1411)`

While all, or none of these may not all be related to the garbage collection, I though I would just include some of them for now.

I think the main issue is that the method may through an error, but is never caught, and many of these are occurring in asynchronous contexts. Strangely enough, the same method when not called on the main thread (for workers?) is silently caught but no logging is preformed, which may explain some difficulty I've encounter in the pas when workers have failed silently; so this PR catching and logging both. (I wasn't sure if there is a preference for logging, so I included both the `logger.write` and `e.printStackTrace()`.)