### PR TITLE
Ensure open frontend connection before sending data

### DIFF
--- a/test-app/app/src/main/java/com/tns/AndroidJsV8Inspector.java
+++ b/test-app/app/src/main/java/com/tns/AndroidJsV8Inspector.java
@@ -98,7 +98,10 @@ class AndroidJsV8Inspector {
 
     @RuntimeCallable
     private static void send(Object connection, String payload) throws IOException {
-        ((JsV8InspectorWebSocket) connection).send(payload);
+        JsV8InspectorWebSocket socketConnection = (JsV8InspectorWebSocket) connection;
+        if (socketConnection.isOpen()) {
+            socketConnection.send(payload);
+        }
     }
 
     @RuntimeCallable


### PR DESCRIPTION
Currently the android runtime will crash if the Chrome DevTools frontend disconnects. This PR addresses this issue by checking if the connection is open before sending any data through it.