### PR TITLE
Sleep 500ms before displaying the error activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+4.2.1
+==
+
+## Bug Fixes
+
+ - [Exceptions in Android app entry point are sporadically not shown in the terminal(#1150)](https://github.com/NativeScript/android-runtime/issues/1150)
+
 4.2.0
 ==
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tns-android",
   "description": "NativeScript Runtime for Android",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/NativeScript/android-runtime.git"

--- a/test-app/app/src/debug/java/com/tns/ErrorReport.java
+++ b/test-app/app/src/debug/java/com/tns/ErrorReport.java
@@ -135,6 +135,12 @@ class ErrorReport implements TabLayout.OnTabSelectedListener {
             Log.d("ErrorReport", "Couldn't send pending intent! Exception: " + e.getMessage());
         }
 
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException ex) {
+            Log.d("ErrorReport", "failed to sleep: " + ex.getMessage());
+        }
+
         killProcess(context);
 
         return true;


### PR DESCRIPTION
Related to https://github.com/NativeScript/nativescript-cli/issues/3812