### PR TITLE
Make ls socket connection wait for ls operation indefinitely

### DIFF
--- a/test-app/app/src/debug/java/com/tns/NativeScriptSyncServiceSocketImpl.java
+++ b/test-app/app/src/debug/java/com/tns/NativeScriptSyncServiceSocketImpl.java
@@ -58,7 +58,6 @@ public class NativeScriptSyncServiceSocketImpl {
                 deviceSystemSocket = new LocalServerSocket(this.name);
                 while (running) {
                     LocalSocket systemSocket = deviceSystemSocket.accept();
-                    systemSocket.setSoTimeout(70000);
                     livesyncWorker = new LiveSyncWorker(systemSocket);
                     Thread liveSyncThread = setUpLivesyncThread();
                     liveSyncThread.start();
@@ -116,7 +115,7 @@ public class NativeScriptSyncServiceSocketImpl {
         public static final String FILE_CONTENT = "fileContent";
         public static final String FILE_CONTENT_LENGTH = FILE_CONTENT + "Length";
         public static final int DEFAULT_OPERATION = -1;
-        private static final String PROTOCOL_VERSION = "0.1.0";
+        private static final String PROTOCOL_VERSION = "0.2.0";
         private byte[] handshakeMessage;
         private final DigestInputStream input;
         private Closeable livesyncSocket;


### PR DESCRIPTION
<!--Dear friend, we, the rest of the NativeScript community thank you for your
contribution! Because we want to present a really nice, readable changelog with each
release, please provide the following information: -->

### Create a meaningful title
<!-- Please, ensure your title is less than 50 characters and starts with a capital letter. We strive to follow the guidelines in the
[How to Write a Git Commit Message] (http://chris.beams.io/posts/git-commit/) article for PR titles. -->

### Description
We want to reuse the connection for multiple LS operations. In order to do this we have to disable the so timeout.

### Does your commit message include the wording below to reference a specific issue in this repo?
<!--Fixes/Implements #[Issue Number]. -->

### Related Pull Requests
<!-- List links related to this Pull Request from other repos/branches: -->

### Does your pull request have [unit tests](https://github.com/NativeScript/NativeScript/blob/master/running-tests.md)?
<!--If not, why?
If not, please tell us why tests are not included, and list all steps needed to test your pull request manually. -->

