### PR TITLE
Fixing NoClassDefFoundError when using older APIs

### DIFF
--- a/test-app/app/src/main/assets/app/tests/testsWithContext.js
+++ b/test-app/app/src/main/assets/app/tests/testsWithContext.js
@@ -1,20 +1,20 @@
 exports.run = function(cntxt)
 {
 	describe("Tests with context ", function () {
-		
+
 		var context = cntxt;
 		var myCustomEquality = function(first, second) {
 			return first == second;
 		};
-		
+
 		beforeEach(function() {
 			jasmine.addCustomEqualityTester(myCustomEquality);
 		});
-		
+
 		it("TestConstructorOverrideForBuiltinType", function () {
-			
+
 			__log("TEST: TestConstructorOverrideForBuiltinType");
-			
+
 			var ctorCalled = false;
 			var isConstructor = false;
 
@@ -24,17 +24,17 @@ exports.run = function(cntxt)
 					isConstructor = arguments[arguments.length - 1];
 				}
 			});
-			
+
 			var btn = new MyButton(context);
-			
+
 			expect(ctorCalled).toEqual(true);
 			expect(isConstructor).toEqual(true);
 		});
-		
+
 		it("TestConstructorOverrideForBuiltinTypeWithInitMethod", function () {
-			
+
 			__log("TEST: TestConstructorOverrideForBuiltinTypeWithInitMethod");
-			
+
 			var initInvocationCount = 0;
 
 			var MyDatePicker = android.widget.DatePicker.extend({
@@ -42,30 +42,30 @@ exports.run = function(cntxt)
 					++initInvocationCount;
 				}
 			});
-			
+
 			var datePicker = new MyDatePicker(context);
-			
+
 			__log("datePicker=" + datePicker);
-			
+
 			var count1 = initInvocationCount;
-			
+
 			expect(count1).toBeGreaterThan(0);
-			
+
 			datePicker.init(2014, 3, 25, null);
-			
+
 			var count2 = initInvocationCount;
-			
+
 			expect(count2).toBeGreaterThan(count1);
 		});
-		
+
 		it("TestBuiltinNestedClassCreation", function () {
-			
+
 			__log("TEST: TestBuiltinNestedClassCreation");
-			
+
 			var loader = new android.content.Loader(context);
 
 			var observer = new android.content.Loader.ForceLoadContentObserver(loader);
-			
+
 			expect(observer).not.toEqual(null);
 		});
 
@@ -82,35 +82,47 @@ exports.run = function(cntxt)
 
             expect(exceptionCaught).toBe(true);
         });
-		
+
 		it("TestPublicWindowManagerImplWithoutMetadata", function () {
-			
+
 			__log("TEST: TestPublicWindowManagerImplWithoutMetadata");
-			
+
 			var windowManagerImpl = context.getSystemService(android.content.Context.WINDOW_SERVICE);
-			
+
 			var display = windowManagerImpl.getDefaultDisplay();
-			
+
 			//__log("display.isValid=" + display.isValid());
-			
+
 			var displayInfo = display.toString();
-			
+
 			expect(displayInfo.length).toBeGreaterThan(0);
 		});
-		
+
 		it("TestCanPassCharSequenceArray", function () {
-			
+
 			__log("TEST: TestCanPassCharSequenceArray");
-			
+
 			var alert = new android.app.AlertDialog.Builder(context);
-		    
+
 		    var builder = alert.setItems(["One", "Two" ], new android.content.DialogInterface.OnClickListener({
 		        onClick: function (dialog, which) {
 		            //
 		        }
 		    }));
-		    
+
 			expect(builder).not.toEqual(null);
 		});
+
+		it("TestOldAPIForGettingMethodsListForMethodsWithParametersFromMissingType", function () {
+            __log("TEST: TestOldAPIForGettingMethodsListForMethodsWithParametersFromMissingType");
+
+            var til = new android.support.design.widget.TextInputLayout(context);
+            var editText = new android.widget.EditText(context);
+            var relativeLayout = new android.widget.RelativeLayout(context);
+            var relativeLayoutParams = new android.widget.RelativeLayout.LayoutParams(android.widget.RelativeLayout.LayoutParams.MATCH_PARENT, android.widget.RelativeLayout.LayoutParams.MATCH_PARENT);
+            relativeLayout.setLayoutParams(relativeLayoutParams);
+            editText.setHint("TEST");
+            til.addView(editText);
+        });
 	});
 };

--- a/test-app/runtime/src/main/java/com/tns/MethodResolver.java
+++ b/test-app/runtime/src/main/java/com/tns/MethodResolver.java
@@ -112,11 +112,19 @@ class MethodResolver {
                 methodOverloadsForClass.put(c, finder);
             }
 
-            ArrayList<Method> matchingMethods = finder.getMatchingMethods(methodName);
-            tryFindMatches(methodName, candidates, args, argLength, matchingMethods);
-            if (candidates.size() > iterationIndex && candidates.get(iterationIndex).y == 0) {
-                // direct matching (distance 0) found
-                break;
+            if(!finder.errorGettingMethods()) {
+                ArrayList<Method> matchingMethods = finder.getMatchingMethods(methodName);
+                tryFindMatches(methodName, candidates, args, argLength, matchingMethods);
+                if (candidates.size() > iterationIndex && candidates.get(iterationIndex).y == 0) {
+                    // direct matching (distance 0) found
+                    break;
+                }
+            } else {
+                Method method = finder.getMatchingMethodWithArguments(methodName, args);
+                if(method != null) {
+                    candidates.add(new Tuple<>(method, 0));
+                    break;
+                }
             }
 
             c = c.getSuperclass();
@@ -479,11 +487,34 @@ class MethodResolver {
     static class MethodFinder {
         private Method[] declaredMethods;
         private HashMap<String, ArrayList<Method>> matchingMethods = new HashMap<String, ArrayList<Method>>();
+        private final Class<?> clazz;
+        private final boolean couldNotGetMethods;
+
         public MethodFinder(Class<?> clazz) {
-            this.declaredMethods = clazz.getDeclaredMethods();
+            this.clazz = clazz;
+            boolean errorGettingMethods = false;
+            try {
+                this.declaredMethods = clazz.getDeclaredMethods();
+            } catch (NoClassDefFoundError error) {
+                // it is not a good practice to catch Errors in Java, but we have the following case:
+                // when using support library > 26.0.0 and android API < 23
+                // if we try to create android.support.design.widget.TextInputLayout and call its addView method
+                // such error is thrown for android.view.ViewStructure as it is not present in older APIs
+                // but it is used as a parameter in one of the TextInputLayout methods and this cause NoClassDefFoundError
+                this.declaredMethods = new Method[]{};
+                errorGettingMethods = true;
+            }
+            this.couldNotGetMethods = errorGettingMethods;
+        }
+
+        public boolean errorGettingMethods() {
+            return couldNotGetMethods;
         }
 
         public ArrayList<Method> getMatchingMethods(String methodName) {
+            if(this.errorGettingMethods()) {
+                return null;
+            }
             ArrayList<Method> matches = this.matchingMethods.get(methodName);
             if (matches == null) {
                 matches = new ArrayList<Method>();
@@ -504,6 +535,20 @@ class MethodResolver {
             }
 
             return matches;
+        }
+
+        public Method getMatchingMethodWithArguments(String methodName, Object[] args) {
+            // this method is not so useful as the arguments need to match the method types directly, but still it can find a method in some cases
+            Class<?>[] types = new Class<?>[args.length];
+            for (int i = 0; i < args.length; i++) {
+                types[i] = args[i].getClass();
+            }
+
+            try {
+                return this.clazz.getDeclaredMethod(methodName, types);
+            } catch (NoSuchMethodException ex) {
+                return null;
+            }
         }
     }
 }


### PR DESCRIPTION
Related to #1158 
When using support library > 26.0.0 and android API < 23 if we try to create **android.support.design.widget.TextInputLayout** and call its addView method **NoClassDefFoundError** is thrown (for **android.view.ViewStructure** as it is not present in older APIs when trying to find the corresponding java method of a javascript method). This happens as in the method resolver we are trying to get the list of all class methods, but some of the methods accept **android.view.ViewStructure** parameter and this class is not present in older android APIs. As a result the **getDeclaredMethods** throws **NoClassDefFoundError** and the application crashes. 

So catch for such error is added to the method getting all the method definitions and we are trying to get the exact method by name when needed.
To reproduce this you can set the following method as a StackLayout loaded event handler:
```TypeScript
load(args) {
    console.log("loaded");
    const context = args.object.android.getContext();
    const androidView = args.object.android;
    const til = new android.support.design.widget.TextInputLayout(context);
    const editText = new android.widget.EditText(context);
    const relativeLayout = new android.widget.RelativeLayout(context);
    const relativeLayoutParams = new android.widget.RelativeLayout.LayoutParams(android.widget.RelativeLayout.LayoutParams.MATCH_PARENT, android.widget.RelativeLayout.LayoutParams.MATCH_PARENT);
    relativeLayout.setLayoutParams(relativeLayoutParams);
    editText.setHint("TEST");

    console.log("this will crash on android api <23 and support 27.1.0+");
    til.addView(editText);

    androidView.addView(til);
}
```
then set the **supportVersion** in the **App_Resources/Android/app.gradle** file to a version > 26.0.0:
```Gradle
ext {
    supportVersion = "27.1.0"
}
```
and run the application on a device with API level < 23.
[Here](https://play.nativescript.org/?template=play-ng&id=SODUNG)'s a playground application with the code from above, so downloading it and setting the **supportVersion** should also reproduce the issue.