### PR TITLE
feat: bump supportVer fallback value to 28.0.0

### DIFF
--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -257,7 +257,7 @@ repositories {
 }
 
 dependencies {
-    def supportVer = "27.0.1"
+    def supportVer = "28.0.0"
     if (project.hasProperty("supportVersion")) {
         supportVer = supportVersion
     }

--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -72,10 +72,10 @@ version of the {N} CLI install a previous version of the runtime package - 'tns 
 project.ext.extractedDependenciesDir = "${project.buildDir}/exploded-dependencies"
 def nativescriptDependencies = new JsonSlurper().parseText(dependenciesJson.text)
 
-def computeCompileSdkVersion = { -> project.hasProperty("compileSdk") ? compileSdk : 26 }
-def computeTargetSdkVersion = { -> project.hasProperty("targetSdk") ? targetSdk : 26 }
+def computeCompileSdkVersion = { -> project.hasProperty("compileSdk") ? compileSdk : 28 }
+def computeTargetSdkVersion = { -> project.hasProperty("targetSdk") ? targetSdk : 28 }
 def computeBuildToolsVersion = { ->
-    project.hasProperty("buildToolsVersion") ? buildToolsVersion : "28.0.2"
+    project.hasProperty("buildToolsVersion") ? buildToolsVersion : "28.0.3"
 }
 
 project.ext.selectedBuildType = project.hasProperty("release") ? "release" : "debug"

--- a/test-app/runtime/build.gradle
+++ b/test-app/runtime/build.gradle
@@ -20,7 +20,7 @@ if (useCCache) {
     println "Use CCache build triggered."
 }
 
-project.ext._buildToolsVersion = "28.0.2"
+project.ext._buildToolsVersion = "28.0.3"
 
 android {
     sourceSets {


### PR DESCRIPTION
Related to https://github.com/NativeScript/tns-core-modules-widgets/pull/145
Related to https://github.com/NativeScript/nativescript-cli/pull/3992

In theory bumping up the same value in the widgets PR should ensure that Android is smart enough to use the latest version of the support library required by any of the app dependencies but in any case the println would be misleading: https://github.com/NativeScript/android-runtime/blob/b440a4687dfd212b2b1905563466b583f01ff4e1/test-app/app/build.gradle#L265