### PR TITLE
feat: use implementation for support.design

### DIFF
--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -267,7 +267,7 @@ dependencies {
     implementation "com.android.support:multidex:1.0.2"
     implementation "com.android.support:support-v4:$supportVer"
     implementation "com.android.support:appcompat-v7:$supportVer"
-    debugImplementation "com.android.support:design:$supportVer"
+    implementation "com.android.support:design:$supportVer"
 
     def sbgProjectExists = !findProject(':static-binding-generator').is(null)
     if (sbgProjectExists) {


### PR DESCRIPTION
Use implementation instead of debugImplementation for com.android.support:design.
This fixes a release build error for master/detail template with compile sdk 28 / support library 28.0.0.

Related to https://github.com/NativeScript/android-runtime/pull/1193


