### PR TITLE
Handle NullPointerException in metadata generator

### DIFF
--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/Builder.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/Builder.java
@@ -112,8 +112,9 @@ public class Builder {
         }
 
         TreeNode node = getOrCreateNode(root, clazz, predefinedSuperClassname);
-
-        setNodeMembers(clazz, node, root, hasClassMetadataInfo);
+        if (node != null) {
+            setNodeMembers(clazz, node, root, hasClassMetadataInfo);
+        }
     }
 
     private static void setNodeMembers(ClassDescriptor clazz, TreeNode node, TreeNode root, boolean hasClassMetadataInfo) throws Exception {


### PR DESCRIPTION
With the upgrade of Android Support Library to 28 we have encountered the following nested class: `android.support.design.widget.AppBarLayout$BaseBehavior$BaseDragCallback`.

`$BaseDragCallback` is public but its containing class is protected (`$BaseBehavior`) and can only be accessed from within the `AppBarLayout` class implementation. 

The metadata generator doesn't properly support this scenario and is throwing a `NullPointerException` logged to the console at build time.