### PR TITLE
Add a concrete exception when the runtime cannot be found

### DIFF
--- a/test-app/runtime/src/main/java/com/tns/Runtime.java
+++ b/test-app/runtime/src/main/java/com/tns/Runtime.java
@@ -980,6 +980,10 @@ public class Runtime {
             runtime = getObjectRuntime(javaObject);
         }
 
+        if (runtime == null) {
+            throw new NativeScriptException("Cannot find runtime for instance=" + ((javaObject == null) ? "null" : javaObject));
+        }
+
         return runtime.callJSMethodImpl(javaObject, methodName, retType, isConstructor, delay, args);
     }
 


### PR DESCRIPTION
The idea is to have a concrete exception so that we can differentiate those type of errors instead of throwing null reference exception