### PR TITLE
Added a setting to wrap calls to CallJSMethod in try catch

### DIFF
--- a/test-app/app/src/main/assets/app/package.json
+++ b/test-app/app/src/main/assets/app/package.json
@@ -8,7 +8,8 @@
 		"freeMemoryRatio": 0.50,
 		"markingMode": "full",
 		"maxLogcatObjectSize": 1024,
-		"forceLog": false
+		"forceLog": false,
+		"suppressCallJSMethodExceptions": false
 	},
 	"discardUncaughtJsExceptions": false
 }

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/DefaultValues.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/DefaultValues.java
@@ -1,0 +1,30 @@
+package org.nativescript.staticbindinggenerator;
+
+import org.apache.bcel.generic.Type;
+
+import java.util.HashMap;
+import java.util.Map;
+
+class DefaultValues {
+    static final Map<Type, String> defaultValues = new HashMap<>();
+
+    // load
+    static {
+        defaultValues.put(Type.BOOLEAN, "false");
+        defaultValues.put(Type.BYTE, "0");
+        defaultValues.put(Type.SHORT, "0");
+        defaultValues.put(Type.INT, "0");
+        defaultValues.put(Type.LONG, "0L");
+        defaultValues.put(Type.CHAR, "'\u0000'");
+        defaultValues.put(Type.FLOAT, "0.0F");
+        defaultValues.put(Type.DOUBLE, "0.0");
+    }
+
+    public static final String defaultStringValueFor(Type type) {
+        if(defaultValues.containsKey(type)) {
+            return defaultValues.get(type);
+        } else {
+            return "null";
+        }
+    }
+}

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/Main.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/Main.java
@@ -74,7 +74,7 @@ public class Main {
             pjson = new JSONObject(jsonContent);
             if (pjson.has("android")) {
                 JSONObject androidSettings = (JSONObject) pjson.get("android");
-                if(androidSettings.has("suppressCallJSMethodExceptions") && androidSettings.get("suppressCallJSMethodExceptions").toString() == "true") {
+                if(androidSettings.has("suppressCallJSMethodExceptions") && androidSettings.get("suppressCallJSMethodExceptions").toString().equals("true")) {
                     return true;
                 }
             }

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/Main.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/Main.java
@@ -68,6 +68,9 @@ public class Main {
 
     private static boolean isSuppressCallJSMethodExceptionsEnabled() throws IOException{
         File jsonFile = new File(inputDir, "package.json");
+        if (!jsonFile.exists()) {
+            return false;
+        }
         String jsonContent = FileUtils.readFileToString(jsonFile, "UTF-8");
         JSONObject pjson = null;
         try {

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/Main.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/Main.java
@@ -33,7 +33,6 @@ public class Main {
     }
 
     public static void main(String[] args) throws IOException, ClassNotFoundException {
-
         validateInput();
 
         getWorkerExcludeFile();
@@ -45,7 +44,7 @@ public class Main {
 
         // generate java bindings
         String inputBindingFilename = Paths.get(System.getProperty("user.dir"), SBG_BINDINGS_NAME).toString();
-        new Generator(outputDir, rows).writeBindings(inputBindingFilename);
+        new Generator(outputDir, rows, isSuppressCallJSMethodExceptionsEnabled(), false).writeBindings(inputBindingFilename);
     }
 
     /*
@@ -65,6 +64,24 @@ public class Main {
         }
         pw.flush();
         pw.close();
+    }
+
+    private static boolean isSuppressCallJSMethodExceptionsEnabled() throws IOException{
+        File jsonFile = new File(inputDir, "package.json");
+        String jsonContent = FileUtils.readFileToString(jsonFile, "UTF-8");
+        JSONObject pjson = null;
+        try {
+            pjson = new JSONObject(jsonContent);
+            if (pjson.has("android")) {
+                JSONObject androidSettings = (JSONObject) pjson.get("android");
+                if(androidSettings.has("suppressCallJSMethodExceptions") && androidSettings.get("suppressCallJSMethodExceptions").toString() == "true") {
+                    return true;
+                }
+            }
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        return false;
     }
 
     private static void validateInput() throws IOException {


### PR DESCRIPTION
Added a setting to wrap the calls in to CallJSMethod generated from the SBG in try-catch block to avoid throwing exceptions from their execution.

The setting can be enabled in the **app/package.json** file:
```JSON
{
    "main": "main.js",
    "android": {
        "suppressCallJSMethodExceptions": true
    }
}
```

If enabled instead of generating code like this:
```Java
public boolean onQueryTextChange(java.lang.String param_0)  {
    java.lang.Object[] args = new java.lang.Object[1];
    args[0] = param_0;
    return (boolean)com.tns.Runtime.callJSMethod(this, "onQueryTextChange", boolean.class, args);
}
```
SBG will generate code like this:
```Java
public boolean onQueryTextChange(java.lang.String param_0)  {
    java.lang.Object[] args = new java.lang.Object[1];
    args[0] = param_0;
    try {
        return (boolean)com.tns.Runtime.callJSMethod(this, "onQueryTextChange", boolean.class, args);
    } catch (Throwable t) {
        android.util.Log.w("Error", t);
        return false;
    }
}
```