### PR TITLE
fix: merges assets executed before the metadata is generated

### DIFF
--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -368,6 +368,9 @@ tasks.whenTaskAdded({ org.gradle.api.DefaultTask currentTask ->
         currentTask.finalizedBy(ensureMetadataOutDir)
         ensureMetadataOutDir.finalizedBy(buildMetadata)
     }
+    if (currentTask =~ /merge.*Assets/) {
+        currentTask.dependsOn(buildMetadata);
+    }
     if (currentTask =~ /assemble.*Debug/ || currentTask =~ /assemble.*Release/) {
         currentTask.finalizedBy("validateAppIdMatch")
     }


### PR DESCRIPTION
### Description
When task `bundleDebug` is executed in the test app, sometimes `mergeDebugAssets` task is executed before `buildMetadata` task. This causes the resulting `.aab` and the `apk`-s produced later on to lack the metadata information in their `assets` directory. This causes the application to crash on start.

### This fix will cause a circular task dependency with [nativescript-firebase](https://github.com/EddyVerbruggen/nativescript-plugin-firebase) plugin.