### PR TITLE
fix: cyclic task dependency with nativescript-plugin-firebase plugin

### DIFF
--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -369,7 +369,7 @@ tasks.whenTaskAdded({ org.gradle.api.DefaultTask currentTask ->
         ensureMetadataOutDir.finalizedBy(buildMetadata)
     }
     if (currentTask =~ /merge.*Assets/) {
-        currentTask.dependsOn(buildMetadata);
+        currentTask.shouldRunAfter(buildMetadata);
     }
     if (currentTask =~ /assemble.*Debug/ || currentTask =~ /assemble.*Release/) {
         currentTask.finalizedBy("validateAppIdMatch")


### PR DESCRIPTION
<!--Dear friend, we, the rest of the NativeScript community thank you for your
contribution! Because we want to present a really nice, readable changelog with each
release, please provide the following information: -->

### Fix cyclic task dependency with nativescript-plugin-firebase plugin
<!-- Please, ensure your title is less than 50 characters and starts with a capital letter. We strive to follow the guidelines in the
[How to Write a Git Commit Message] (http://chris.beams.io/posts/git-commit/) article for PR titles. -->

### Description
Invoking `bundleDebug` reordered tasks in `gradle` build in a manner that caused the `mergeDebugAssets` to be executed before the metadata was generated by the `buildMetadata` task. This led to adding `currentTask.dependsOn(buildMetadata);`, which fixed the problem, but caused cyclic task dependency issues, when the nativescript-plugin-firebase plugin is used.

The solution is to use `shouldRunAfter` instead of `dependsOn`, which will fix the ordering in the general case, but ignore the rule if a cyclic dependency issue is detected. Reference for `shouldRunAfter` [here](https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:ordering_tasks).

### Does your commit message include the wording below to reference a specific issue in this repo?
<!--Fixes/Implements #[Issue Number]. -->

### Related Pull Requests
<!-- List links related to this Pull Request from other repos/branches: -->
https://github.com/NativeScript/android-runtime/pull/1217

### Does your pull request have [unit tests](https://github.com/NativeScript/NativeScript/blob/master/running-tests.md)?
<!--If not, why?
If not, please tell us why tests are not included, and list all steps needed to test your pull request manually. -->

