### PR TITLE
Use the new ScriptCompiler::CreateCodeCache API to produce script caches

### DIFF
--- a/test-app/runtime/src/main/cpp/ModuleInternal.h
+++ b/test-app/runtime/src/main/cpp/ModuleInternal.h
@@ -61,7 +61,7 @@ class ModuleInternal {
 
         v8::ScriptCompiler::CachedData* TryLoadScriptCache(const std::string& path);
 
-        void SaveScriptCache(const v8::ScriptCompiler::Source& source, const std::string& path);
+        void SaveScriptCache(const v8::Local<v8::Script> script, const std::string& path);
 
         ModulePathKind GetModulePathKind(const std::string& path);
 


### PR DESCRIPTION
Related to #1235.

V8 has introduced new API for producing script compilation CachedData objects that can be used on subsequent runs to speed up runtime execution. This PR takes advantage of this new API as the `ScriptCompiler::kProduceCodeCache` flag no longer has any effect and will be completely removed in 7.2.