### PR TITLE
Non blocking LiveSync call

### DIFF
--- a/test-app/app/src/debug/java/com/tns/NativeScriptSyncServiceSocketImpl.java
+++ b/test-app/app/src/debug/java/com/tns/NativeScriptSyncServiceSocketImpl.java
@@ -165,7 +165,7 @@ public class NativeScriptSyncServiceSocketImpl {
 
                         validateData();
                         if(runtime != null && doRefreshInt == DO_REFRESH_VALUE) {
-                            runtime.runScript(new File(NativeScriptSyncServiceSocketImpl.this.context.getFilesDir(), "internal/livesync.js"));
+                            runtime.runScript(new File(NativeScriptSyncServiceSocketImpl.this.context.getFilesDir(), "internal/livesync.js"), false);
                             operationReportCode = OPERATION_END_REPORT_CODE;
                         } else {
                             operationReportCode = OPERATION_END_NO_REFRESH_REPORT_CODE;

--- a/test-app/runtime/src/main/java/com/tns/Runtime.java
+++ b/test-app/runtime/src/main/java/com/tns/Runtime.java
@@ -590,6 +590,10 @@ public class Runtime {
     }
 
     public Object runScript(File jsFile) throws NativeScriptException {
+        return this.runScript(jsFile, true);
+    }
+
+    public Object runScript(File jsFile, final boolean waitForResultOnMainThread) throws NativeScriptException {
         Object result = null;
 
         if (jsFile.exists() && jsFile.isFile()) {
@@ -621,7 +625,7 @@ public class Runtime {
                 if (success) {
                     synchronized (r) {
                         try {
-                            if (arr[1] == null) {
+                            if (arr[1] == null && waitForResultOnMainThread) {
                                 r.wait();
                             }
                         } catch (InterruptedException e) {


### PR DESCRIPTION
Related to #1243 
Add an option to runScript without waiting for result which is used when calling LiveSync, so that the call is not blocking.
