### PR TITLE
Log the Runtime and V8 versions under the TNS.Runtime category

### DIFF
--- a/test-app/runtime/src/main/cpp/MetadataNode.cpp
+++ b/test-app/runtime/src/main/cpp/MetadataNode.cpp
@@ -1615,12 +1615,12 @@ void MetadataNode::BuildMetadata(const string& filesPath) {
     timeval time2;
     gettimeofday(&time2, nullptr);
 
-    __android_log_print(ANDROID_LOG_DEBUG, "TNS.Native", "lenNodes=%d, lenNames=%d, lenValues=%d", lenNodes, lenNames, lenValues);
+    DEBUG_WRITE("lenNodes=%d, lenNames=%d, lenValues=%d", lenNodes, lenNames, lenValues);
 
     long millis1 = (time1.tv_sec * 1000) + (time1.tv_usec / 1000);
     long millis2 = (time2.tv_sec * 1000) + (time2.tv_usec / 1000);
 
-    __android_log_print(ANDROID_LOG_DEBUG, "TNS.Native", "time=%ld", (millis2 - millis1));
+    DEBUG_WRITE("time=%ld", (millis2 - millis1));
 
     BuildMetadata(lenNodes, reinterpret_cast<uint8_t*>(nodes), lenNames, reinterpret_cast<uint8_t*>(names), lenValues, reinterpret_cast<uint8_t*>(values));
 

--- a/test-app/runtime/src/main/cpp/Runtime.cpp
+++ b/test-app/runtime/src/main/cpp/Runtime.cpp
@@ -46,8 +46,7 @@ void SIGABRT_handler(int sigNumber) {
 }
 
 void Runtime::Init(JavaVM* vm, void* reserved) {
-    __android_log_print(ANDROID_LOG_INFO, "TNS.Native", "NativeScript Runtime Version %s, commit %s", NATIVE_SCRIPT_RUNTIME_VERSION, NATIVE_SCRIPT_RUNTIME_COMMIT_SHA);
-    DEBUG_WRITE("JNI_ONLoad");
+    __android_log_print(ANDROID_LOG_INFO, "TNS.Runtime", "NativeScript Runtime Version %s, commit %s", NATIVE_SCRIPT_RUNTIME_VERSION, NATIVE_SCRIPT_RUNTIME_COMMIT_SHA);
 
     if (Runtime::s_jvm == nullptr) {
         s_jvm = vm;
@@ -61,8 +60,6 @@ void Runtime::Init(JavaVM* vm, void* reserved) {
         action.sa_handler = SIGABRT_handler;
         sigaction(SIGABRT, &action, NULL);
     }
-
-    DEBUG_WRITE("JNI_ONLoad END");
 }
 
 int Runtime::GetAndroidVersion() {
@@ -376,7 +373,7 @@ void Runtime::PassExceptionToJsNative(JNIEnv* env, jobject obj, jthrowable excep
 
     //create error message
     string errMsg = isDiscarded ? "An exception was caught and discarded. You can look at \"stackTrace\" or \"nativeException\" for more detailed information about the exception.":
-        "The application crashed because of an uncaught exception. You can look at \"stackTrace\" or \"nativeException\" for more detailed information about the exception.";
+                    "The application crashed because of an uncaught exception. You can look at \"stackTrace\" or \"nativeException\" for more detailed information about the exception.";
 
     auto errObj = Exception::Error(ArgConverter::ConvertToV8String(isolate, errMsg)).As<Object>();
 
@@ -563,7 +560,7 @@ Isolate* Runtime::PrepareV8Runtime(const string& filesPath, const string& native
 
     isolate->AddMessageListener(NativeScriptException::OnUncaughtError);
 
-    __android_log_print(ANDROID_LOG_DEBUG, "TNS.Native", "V8 version %s", V8::GetVersion());
+    __android_log_print(ANDROID_LOG_DEBUG, "TNS.Runtime", "V8 version %s", V8::GetVersion());
 
     auto globalFunctionTemplate = FunctionTemplate::New(isolate);
     globalFunctionTemplate->SetClassName(ArgConverter::ConvertToV8String(isolate, "NativeScriptGlobalObject"));


### PR DESCRIPTION
Related to https://github.com/NativeScript/nativescript-cli/issues/4300

The Android runtime and V8 versions are now logged under the `TNS.Runtime` category allowing the CLI to start showing `TNS.Native` and `TNS.Java` if needed.