### PR TITLE
Refactor build.gradle not to add configuration:'default'

### DIFF
--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -339,7 +339,7 @@ dependencies {
         println "\t + adding nativescript runtime package dependency: $runtime"
         project.dependencies.add("implementation", [name: runtime, ext: "aar"])
     } else {
-        implementation project(path: ':runtime', configuration: 'default')
+        implementation project(':runtime')
     }
 
 }
@@ -475,12 +475,17 @@ task extractAllJars {
         def buildType = project.selectedBuildType == "release" ? "Release" : "Debug"
         def iter = []
         Pattern pattern = Pattern.compile("^(.+)${buildType}CompileClasspath\$")
+        def artifactType = Attribute.of('artifactType', String)
         configurations.all { config ->
             Matcher matcher = pattern.matcher(config.name)
             if (matcher.find() || config.name == "${buildType.toLowerCase()}CompileClasspath") {
-                config.resolve().each {
-                    if (!iter.contains(it)) {
-                        iter.push(it)
+                config.incoming.artifactView {
+                    attributes {
+                        it.attribute(artifactType, 'jar')
+                    }
+                }.artifacts.each {
+                    if (!iter.contains(it.file)) {
+                        iter.push(it.file)
                     }
                 }
             }

--- a/test-app/runtime/build.gradle
+++ b/test-app/runtime/build.gradle
@@ -25,10 +25,10 @@ project.ext._buildToolsVersion = "28.0.3"
 android {
     sourceSets {
         main {
-            def defaultSrcPath = "src/main/java";
+            def defaultSrcPath = "src/main/java"
             def bindingGeneratorSourcePath = new File(project(":runtime-binding-generator").projectDir, defaultSrcPath)
 
-            // embedd runtime binding generator in runtime, while keeping it in a sperate project
+            // embed runtime binding generator in runtime, while keeping it in a separate project
             java.srcDirs = [bindingGeneratorSourcePath, defaultSrcPath]
         }
     }


### PR DESCRIPTION
Seems like using:
```Groovy
implementation project(path: ':runtime', configuration: 'default')
```
is not the right solution as stated [here](https://github.com/jeremylong/dependency-check-gradle/issues/71#issuecomment-367931630)
The only place that doesn't work without the `configuration: 'default'` is the `config.resolve()` which is used to get the dependencies, but by getting them through the `config.incoming.artifactView` we even can get only the **.jar** files, but not **.aar** as they are already unarchived in the gradle cache and the **.jar** files are in the artifactView list already.