### PR TITLE
remove min/target SdkVersion from manifest 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,7 @@ matrix:
         - emulator -avd $EMULATOR_NAME-$EMULATOR_API_LEVEL -no-skin -no-audio -no-window &
         - android-wait-for-emulator
         - npm install --prefix ./test-app/tools
-        - "./gradlew runSbgTests --stacktrace"
-        - "./gradlew runtestsAndVerifyResults -PnoCCache --stacktrace"
+        - "./gradlew runSbgTests --stacktrace" && "./gradlew runtestsAndVerifyResults -PnoCCache --stacktrace"
         - adb -e logcat -d
       before_install:
         - echo "y" | sdkmanager "cmake;3.6.4111459"

--- a/build-artifacts/project-template-gradle/app/src/main/AndroidManifest.xml
+++ b/build-artifacts/project-template-gradle/app/src/main/AndroidManifest.xml
@@ -9,24 +9,20 @@
         android:normalScreens="true"
         android:largeScreens="true"
         android:xlargeScreens="true"/>
-	
-   <uses-sdk
-        android:minSdkVersion="17"
-		android:targetSdkVersion="__APILEVEL__"/>
-    
+
     <uses-permission android:name="android.permission.INTERNET"/>
-    
+
     <application
         android:name="com.tns.NativeScriptApplication"
         android:allowBackup="true"
         android:icon="@drawable/icon"
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
-		<activity
+        <activity
             android:name="com.tns.NativeScriptActivity"
             android:label="@string/title_activity_kimera"
             android:configChanges="keyboardHidden|orientation|screenSize">
-            
+
              <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -34,7 +30,7 @@
             </intent-filter>
         </activity>
         <activity android:name="com.tns.ErrorReportActivity"
-				  android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
+                  android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
     </application>
 
 </manifest>


### PR DESCRIPTION
We don't need **minSdkVersion** and **targetSdkVersion** in the manifest file and it even gives errors when you open a nativescript app in android studio