### PR TITLE
fix(gradle): Change outputs directory of runSbg

### DIFF
--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -427,7 +427,7 @@ task runSbg(type: JavaExec) {
         dependsOn ':static-binding-generator:jar'
     }
 
-    outputs.dir(OUTPUT_JAVA_DIR)
+    outputs.dir("$OUTPUT_JAVA_DIR/com/tns/gen")
     inputs.dir(INPUT_JS_DIR)
     inputs.dir(extractedDependenciesDir)
 


### PR DESCRIPTION
It's better to be "com/tns/gen" because otherwise it includes all the source code 
of the project -- not only the java files generated by the SBG

related to #1317 