### PR TITLE
Improve handling of nested Java class name writing

### DIFF
--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/parsing/classes/hierarchy/generics/impl/GenericsAwareClassHierarchyParserImpl.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/parsing/classes/hierarchy/generics/impl/GenericsAwareClassHierarchyParserImpl.java
@@ -276,7 +276,7 @@ public class GenericsAwareClassHierarchyParserImpl implements GenericsAwareClass
         Pattern cachedPattern = NESTED_GENERICS_REGEX_CACHE.get(providedFormalTypeParameterKey);
 
         if (cachedPattern == null) {
-            Pattern pattern = Pattern.compile("([^\\w\\[]*)" + providedFormalTypeParameterKey + "([^\\w\\[]*)");
+            Pattern pattern = Pattern.compile("([^\\w\\.])" + providedFormalTypeParameterKey + "(\\W)");
             NESTED_GENERICS_REGEX_CACHE.put(providedFormalTypeParameterKey, pattern);
             return pattern;
         }

--- a/test-app/build-tools/static-binding-generator/src/test/java/org/nativescript/staticbindinggenerator/generating/parsing/classes/hierarchy/generics/impl/GenericsAwareClassHierarchyParserImplTest.java
+++ b/test-app/build-tools/static-binding-generator/src/test/java/org/nativescript/staticbindinggenerator/generating/parsing/classes/hierarchy/generics/impl/GenericsAwareClassHierarchyParserImplTest.java
@@ -1,7 +1,5 @@
 package org.nativescript.staticbindinggenerator.generating.parsing.classes.hierarchy.generics.impl;
 
-import com.google.gson.GsonBuilder;
-
 import org.apache.bcel.classfile.JavaClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -10,7 +8,6 @@ import org.junit.rules.TestName;
 import org.nativescript.staticbindinggenerator.files.FileSystemHelper;
 import org.nativescript.staticbindinggenerator.files.impl.FileSystemHelperImpl;
 import org.nativescript.staticbindinggenerator.generating.parsing.classes.hierarchy.generics.GenericHierarchyView;
-import org.nativescript.staticbindinggenerator.generating.parsing.classes.hierarchy.generics.GenericParameters;
 import java.util.Map;
 
 public class GenericsAwareClassHierarchyParserImplTest {


### PR DESCRIPTION
There was an issue when writing nested classes name. The BCEL lib gives their name as Class$NestedClass. This was written as output of the SBG. It should be Class.NestedClass and this commit fixes that.