### PR TITLE
Fix creation of URLClassLoader

### DIFF
--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/GetInterfaceNames.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/GetInterfaceNames.java
@@ -92,6 +92,7 @@ public class GetInterfaceNames {
 
     private static URLClassLoader getClassLoader(String pathToJar) throws MalformedURLException {
         URL[] urls = {new URL("jar:file:" + pathToJar + "!/")};
-        return URLClassLoader.newInstance(urls);
+        return URLClassLoader.newInstance(urls, null);
+        // do not delegate later class loading for the parent class loader to do it first
     }
 }


### PR DESCRIPTION
With the current URLClassLoader initialisation, it has the system class loader as a parent. Due to the implementation of the Java class loaders, when loadClass() is invoked, it calls the parent loadClass() method first. So, in our case, when loading up a class coming from a jar file, it is resolved first by the system class loader and if it can't resolve it - uses the URLClassLoader. This is not a problem in most cases, however when parsing classes coming from a jar file which can also be found in the SBG dependencies, class versioning problems may occur.