### PR TITLE
Remove unnecessary class loading and improve generic interface name writing

### DIFF
--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/GetInterfaceNames.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/GetInterfaceNames.java
@@ -1,21 +1,22 @@
 package org.nativescript.staticbindinggenerator;
 
+import org.apache.bcel.classfile.ClassParser;
+import org.apache.bcel.classfile.JavaClass;
+
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Enumeration;
 import java.util.List;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
+import java.util.jar.JarInputStream;
+import java.util.zip.ZipEntry;
 
 public class GetInterfaceNames {
+    private static final String CLASS_EXT = ".class";
     private static String currentDir;
 
     /*
@@ -45,37 +46,41 @@ public class GetInterfaceNames {
         out.close();
     }
 
-    private static void generateInterfaceNames(String pathToJar, List<String> interfacesList) throws IOException, ClassNotFoundException {
+    private static void generateInterfaceNames(String pathToJar, List<String> interfacesList) {
         if (pathToJar == null) {
             return;
         }
-
-        JarFile jarFile = new JarFile(pathToJar);
-        Enumeration<JarEntry> currentJarFile = jarFile.entries();
-
-        URLClassLoader cl = getClassLoader(pathToJar);
-
-        while (currentJarFile.hasMoreElements()) {
-            JarEntry jarEntry = currentJarFile.nextElement();
-
-            if ((!jarEntry.isDirectory()) && (jarEntry.getName().endsWith(".class"))) {
-                String className = jarEntry.getName().substring(0, jarEntry.getName().length() - 6);
-                className = className.replace('/', '.');
-
-                @SuppressWarnings("rawtypes")
-                Class c = null;
+        JarInputStream jis = null;
+        try {
+            String name;
+            jis = new JarInputStream(new FileInputStream(pathToJar));
+            for (ZipEntry ze = jis.getNextEntry(); ze != null; ze = jis.getNextEntry()) {
                 try {
-                    c = cl.loadClass(className);
-                } catch (IllegalAccessError e) {
-                } catch (NoClassDefFoundError localNoClassDefFoundError) {
+                    name = ze.getName();
+                    if (name.endsWith(CLASS_EXT)) {
+                        name = name.substring(0, name.length() - CLASS_EXT.length()).replace('/', '.').replace('$', '.');
+                        ClassParser cp = new ClassParser(jis, name);
+                        JavaClass clazz = cp.parse();
+                        if (clazz.isInterface()) {
+                            String res = clazz.getClassName().replace('$', '.');
+                            interfacesList.add(res);
+                        }
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException("Error while parsing class file!", e);
                 }
-                if ((c != null) && (c.isInterface() == true)) {
-                    String res = c.getName().replace('$', '.');
-                    interfacesList.add(res);
+            }
+        } catch (IOException ioe) {
+            throw new RuntimeException("Error while reading JAR entry!", ioe);
+        } finally {
+            if (jis != null) {
+                try {
+                    jis.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
                 }
             }
         }
-        jarFile.close();
     }
 
     public static PrintWriter ensureOutputFile(String outputFileName) throws IOException {
@@ -88,11 +93,5 @@ public class GetInterfaceNames {
         }
 
         return new PrintWriter(new BufferedWriter(new FileWriter(checkFile.getAbsolutePath(), true)));
-    }
-
-    private static URLClassLoader getClassLoader(String pathToJar) throws MalformedURLException {
-        URL[] urls = {new URL("jar:file:" + pathToJar + "!/")};
-        return URLClassLoader.newInstance(urls, null);
-        // do not delegate later class loading for the parent class loader to do it first
     }
 }

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/parsing/methods/impl/InheritedMethodsCollectorImpl.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/parsing/methods/impl/InheritedMethodsCollectorImpl.java
@@ -20,6 +20,7 @@ public class InheritedMethodsCollectorImpl implements InheritedMethodsCollector 
     private final JavaMethodUtils javaMethodUtils;
     private final JavaClassUtils javaClassUtils;
     private final GenericHierarchyView genericHierarchyView;
+    private final Map<JavaClass, GenericHierarchyView> interfacesGenericHierarchyViews;
     private final String packageName;
     private final JavaClass javaClass;
     private final List<JavaClass> implementedInterfaces;
@@ -27,6 +28,7 @@ public class InheritedMethodsCollectorImpl implements InheritedMethodsCollector 
     private InheritedMethodsCollectorImpl(Builder builder) {
         this.classesCache = builder.classesCache;
         this.genericHierarchyView = builder.genericHierarchyView;
+        this.interfacesGenericHierarchyViews = builder.interfacesGenericHierarchyViews;
         this.packageName = builder.packageName;
         this.javaClass = builder.javaClass;
         this.implementedInterfaces = builder.interfaces;
@@ -75,7 +77,7 @@ public class InheritedMethodsCollectorImpl implements InheritedMethodsCollector 
         HashSet<JavaClass> visited = new HashSet<>(); // saves some interface traversing
 
         for (JavaClass interfaze : implementedInterfaces) {
-            GenericHierarchyView interfaceGenView = new GenericsAwareClassHierarchyParserImpl(new GenericSignatureReader(), classesCache).getClassHierarchy(interfaze);
+            GenericHierarchyView interfaceGenView = interfacesGenericHierarchyViews.get(interfaze);
             findUnimplementedInterfaceMethods(interfaze, visited, allMethods, packageName, toImplement, overridable, interfaceGenView);
         }
 
@@ -180,6 +182,7 @@ public class InheritedMethodsCollectorImpl implements InheritedMethodsCollector 
     public static class Builder {
         private Map<String, JavaClass> classesCache;
         private GenericHierarchyView genericHierarchyView;
+        private Map<JavaClass, GenericHierarchyView> interfacesGenericHierarchyViews;
         private JavaClass javaClass;
         private List<JavaClass> interfaces;
         private String packageName;
@@ -191,6 +194,11 @@ public class InheritedMethodsCollectorImpl implements InheritedMethodsCollector 
 
         public Builder withGenericHierarchyView(GenericHierarchyView genericHierarchyView) {
             this.genericHierarchyView = genericHierarchyView;
+            return this;
+        }
+
+        public Builder withInterfacesGenericHierarchyViews(Map<JavaClass, GenericHierarchyView> interfacesGenericHierarchyViews){
+            this.interfacesGenericHierarchyViews = interfacesGenericHierarchyViews;
             return this;
         }
 

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/writing/ClassWriter.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/writing/ClassWriter.java
@@ -3,9 +3,7 @@ package org.nativescript.staticbindinggenerator.generating.writing;
 import java.util.List;
 
 public interface ClassWriter extends JavaCodeWriter {
-    void writeBeginningOfClassImplementingSingleInterface(String className, String implementedInterfaceName);
     void writeBeginningOfChildClass(String className, String extendedClassName, List<String> implementedInterfacesNames);
-    void writeBeginningOfNamedClassImplementingSingleInterface(String className, String jsFileName, String implementedInterfaceName);
     void writeBeginningOfNamedChildClass(String className, String jsFileName, String extendedClassName, List<String> implementedInterfacesNames);
     void writeClassEnd();
 }

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/writing/MethodsWriter.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/writing/MethodsWriter.java
@@ -4,7 +4,6 @@ import org.nativescript.staticbindinggenerator.generating.parsing.methods.Reifie
 
 public interface MethodsWriter extends JavaCodeWriter {
     void writeMethod(ReifiedJavaMethod method);
-    void writeDefaultConstructor(String className);
     void writeConstructor(String className, ReifiedJavaMethod method, boolean hasUserImplementedInitMethod);
     void writeGetInstanceMethod(String className);
     void writeInternalRuntimeEqualsMethod();

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/writing/impl/ClassWriterImpl.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/writing/impl/ClassWriterImpl.java
@@ -19,17 +19,6 @@ public class ClassWriterImpl implements ClassWriter {
         this.writer = writer;
     }
 
-    @Override
-    public void writeBeginningOfClassImplementingSingleInterface(String className, String implementedInterfaceName) {
-        writeClassWithName(className);
-        writer.write(SPACE_LITERAL);
-        writer.write(IMPLEMENTS_KEYWORD);
-        writer.write(SPACE_LITERAL);
-        writer.write(implementedInterfaceName);
-        writer.write(SPACE_LITERAL);
-        writer.writeln(OPENING_CURLY_BRACKET_LITERAL);
-    }
-
     private void writeClassWithName(String className) {
         writer.write(PUBLIC_CLASS_KEYWORD);
         writer.write(SPACE_LITERAL);
@@ -70,12 +59,6 @@ public class ClassWriterImpl implements ClassWriter {
         }
 
         writer.write(OPENING_CURLY_BRACKET_LITERAL);
-    }
-
-    @Override
-    public void writeBeginningOfNamedClassImplementingSingleInterface(String className, String jsFileName, String implementedInterfaceName) {
-        writer.writeln(String.format(JAVASCRIPT_IMPLEMENTATION_FILE_NAME_PATTERN, jsFileName));
-        writeBeginningOfClassImplementingSingleInterface(className, implementedInterfaceName);
     }
 
     @Override

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/writing/impl/MethodsWriterImpl.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/writing/impl/MethodsWriterImpl.java
@@ -130,18 +130,6 @@ public class MethodsWriterImpl implements MethodsWriter {
         }
     }
 
-    @Override
-    public void writeDefaultConstructor(String className) {
-        writer.write(PUBLIC_MODIFIER);
-        writer.write(SPACE_LITERAL);
-        writer.write(className);
-        writer.write(OPENING_ROUND_BRACKET_LITERAL);
-        writer.write(CLOSING_ROUND_BRACKET_LITERAL);
-        writer.write(OPENING_CURLY_BRACKET_LITERAL);
-        writer.write(RUNTIME_INIT_INSTANCE_METHOD_CALL_STATEMENT);
-        writer.write(CLOSING_CURLY_BRACKET_LITERAL);
-    }
-
     private void writeRuntimeInitCallIfNecessary(ReifiedJavaMethod method) {
         if (method.getName().equals(ON_CREATE_METHOD_NAME) && isForApplicationClass) {
             writer.write(RUNTIME_INIT_METHOD_CALL_STATEMENT);

--- a/test-app/build-tools/static-binding-generator/src/test/java/org/nativescript/staticbindinggenerator/test/GeneratorTest.java
+++ b/test-app/build-tools/static-binding-generator/src/test/java/org/nativescript/staticbindinggenerator/test/GeneratorTest.java
@@ -86,7 +86,7 @@ public class GeneratorTest {
         Class<?> helloClass = InMemoryJavaCompiler.compile("com.tns.gen.com.example.MyInterface", sourceCode.toString(), options);
 
         Assert.assertNotNull(helloClass);
-        Assert.assertEquals(1, helloClass.getDeclaredMethods().length);
+        Assert.assertEquals(3, helloClass.getDeclaredMethods().length);
     }
 
     @Test


### PR DESCRIPTION
Fixes class loader issues when using Java 11 and writing of names of generic interfaces when user has implemented such one.