### PR TITLE
Fix handling of extending generic class with bounded generic arguments

### DIFF
--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/parsing/classes/hierarchy/generics/impl/GenericsAwareClassHierarchyParserImpl.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/parsing/classes/hierarchy/generics/impl/GenericsAwareClassHierarchyParserImpl.java
@@ -279,7 +279,8 @@ public class GenericsAwareClassHierarchyParserImpl implements GenericsAwareClass
 
     private boolean hasFormalTypeParameterInsideBound(String bound, String formalTypeParameter) {
         Pattern p = getNestedGenericArgumentRegexPattern(formalTypeParameter);
-        return p.matcher(bound).matches();
+        Matcher matcher = p.matcher(bound);
+        return matcher.find();
     }
 
     private Pattern getNestedGenericArgumentRegexPattern(String providedFormalTypeParameterKey) {


### PR DESCRIPTION
When extending a class with a signature like `public abstract class GenericAbstractClassBase<K extends List<T>, T extends String>` from JS, the first generic parameter's erasure was not resolved to `java.util.List<java.lang.String>` as expected. Bug was due to improper parsing of the generic signature of the class.