### PR TITLE
HashMaps improvements

### DIFF
--- a/test-app/runtime/src/main/cpp/ObjectManager.cpp
+++ b/test-app/runtime/src/main/cpp/ObjectManager.cpp
@@ -750,7 +750,7 @@ void ObjectManager::MakeRegularObjectsWeak(const set<int> &instances, DirectBuff
  * so we tell java to take the JAVA objects out of strong, BUT KEEP THEM AS WEEK REFERENCES,
  * so that if java needs to release them, it can, on a later stage.
  * */
-void ObjectManager::MakeImplObjectsWeak(const map<int, Persistent<Object> *> &instances,
+void ObjectManager::MakeImplObjectsWeak(const unordered_map<int, Persistent<Object> *> &instances,
                                         DirectBuffer &inputBuff) {
     jboolean keepAsWeak = JNI_TRUE;
 

--- a/test-app/runtime/src/main/cpp/ObjectManager.h
+++ b/test-app/runtime/src/main/cpp/ObjectManager.h
@@ -155,7 +155,7 @@ class ObjectManager {
 
         void MakeRegularObjectsWeak(const std::set<int>& instances, DirectBuffer& inputBuff);
 
-        void MakeImplObjectsWeak(const std::map<int, v8::Persistent<v8::Object>*>& instances, DirectBuffer& inputBuff);
+        void MakeImplObjectsWeak(const std::unordered_map<int, v8::Persistent<v8::Object>*>& instances, DirectBuffer& inputBuff);
 
         void CheckWeakObjectsAreAlive(const std::vector<PersistentObjectIdPair>& instances, DirectBuffer& inputBuff, DirectBuffer& outputBuff);
 
@@ -201,7 +201,7 @@ class ObjectManager {
 
         std::stack<GarbageCollectionInfo> m_markedForGC;
 
-        std::map<int, v8::Persistent<v8::Object>*> m_idToObject;
+        std::unordered_map<int, v8::Persistent<v8::Object>*> m_idToObject;
 
         PersistentObjectIdSet m_released;
 
@@ -211,7 +211,7 @@ class ObjectManager {
 
         std::set<v8::Persistent<v8::Object>*> m_visitedPOs;
         std::vector<PersistentObjectIdPair> m_implObjWeak;
-        std::map<int, v8::Persistent<v8::Object>*> m_implObjStrong;
+        std::unordered_map<int, v8::Persistent<v8::Object>*> m_implObjStrong;
 
         volatile int m_currentObjectId;
 

--- a/test-app/runtime/src/main/java/com/tns/NativeScriptHashMap.java
+++ b/test-app/runtime/src/main/java/com/tns/NativeScriptHashMap.java
@@ -40,7 +40,7 @@ import java.io.Serializable;
  * @param <V> the type of mapped values
  */
 
-public class NativeScriptHashMap<K, V> extends AbstractMap<K, V> implements Cloneable, Serializable {
+public class NativeScriptHashMap<K, V extends Number> extends AbstractMap<K, V> implements Cloneable, Serializable {
     /**
      * Min capacity (other than zero) for a HashMap. Must be a power of two
      * greater than 1 (and less than 1 << 30).
@@ -283,7 +283,7 @@ public class NativeScriptHashMap<K, V> extends AbstractMap<K, V> implements Clon
         HashMapEntry<K, V>[] tab = table;
         for (HashMapEntry<K, V> e = tab[hash & (tab.length - 1)]; e != null; e = e.next) {
             K eKey = e.key;
-            if (eKey == key || (e.hash == hash && key.equals(eKey))) {
+            if (eKey == key) {
                 return e.value;
             }
         }
@@ -306,7 +306,7 @@ public class NativeScriptHashMap<K, V> extends AbstractMap<K, V> implements Clon
         HashMapEntry<K, V>[] tab = table;
         for (HashMapEntry<K, V> e = tab[hash & (tab.length - 1)]; e != null; e = e.next) {
             K eKey = e.key;
-            if (eKey == key || (e.hash == hash && key.equals(eKey))) {
+            if (eKey == key) {
                 return true;
             }
         }
@@ -337,7 +337,7 @@ public class NativeScriptHashMap<K, V> extends AbstractMap<K, V> implements Clon
         // value is non-null
         for (int i = 0; i < len; i++) {
             for (HashMapEntry<K, V> e = tab[i]; e != null; e = e.next) {
-                if (value.equals(e.value)) {
+                if (value == e.value) {
                     return true;
                 }
             }
@@ -363,7 +363,7 @@ public class NativeScriptHashMap<K, V> extends AbstractMap<K, V> implements Clon
         int index = hash & (tab.length - 1);
         for (HashMapEntry<K, V> e = tab[index]; e != null; e = e.next) {
             K eKey = e.key;
-            if (eKey == key || (e.hash == hash && key.equals(eKey))) {
+            if (eKey == key) {
                 preModify(e);
                 V oldValue = e.value;
                 e.value = value;
@@ -428,7 +428,7 @@ public class NativeScriptHashMap<K, V> extends AbstractMap<K, V> implements Clon
         int index = hash & (tab.length - 1);
         HashMapEntry<K, V> first = tab[index];
         for (HashMapEntry<K, V> e = first; e != null; e = e.next) {
-            if (e.hash == hash && key.equals(e.key)) {
+            if (key == e.key) {
                 e.value = value;
                 return;
             }
@@ -599,7 +599,7 @@ public class NativeScriptHashMap<K, V> extends AbstractMap<K, V> implements Clon
         int index = hash & (tab.length - 1);
         for (HashMapEntry<K, V> e = tab[index], prev = null; e != null; prev = e, e = e.next) {
             K eKey = e.key;
-            if (eKey == key || (e.hash == hash && key.equals(eKey))) {
+            if (eKey == key) {
                 if (prev == null) {
                     tab[index] = e.next;
                 } else {
@@ -726,7 +726,7 @@ public class NativeScriptHashMap<K, V> extends AbstractMap<K, V> implements Clon
                 return false;
             }
             Entry<?, ?> e = (Entry<?, ?>) o;
-            return Objects.equal(e.getKey(), key) && Objects.equal(e.getValue(), value);
+            return key == e.getKey() && value == e.getValue();
         }
 
         @Override
@@ -823,7 +823,7 @@ public class NativeScriptHashMap<K, V> extends AbstractMap<K, V> implements Clon
         HashMapEntry<K, V>[] tab = table;
         int index = hash & (tab.length - 1);
         for (HashMapEntry<K, V> e = tab[index]; e != null; e = e.next) {
-            if (e.hash == hash && key.equals(e.key)) {
+            if (key == e.key) {
                 return Objects.equal(value, e.value);
             }
         }
@@ -851,7 +851,7 @@ public class NativeScriptHashMap<K, V> extends AbstractMap<K, V> implements Clon
         HashMapEntry<K, V>[] tab = table;
         int index = hash & (tab.length - 1);
         for (HashMapEntry<K, V> e = tab[index], prev = null; e != null; prev = e, e = e.next) {
-            if (e.hash == hash && key.equals(e.key)) {
+            if (key == e.key) {
                 if (!Objects.equal(value, e.value)) {
                     return false; // Map has wrong value for key
                 }

--- a/test-app/runtime/src/main/java/com/tns/NativeScriptWeakHashMap.java
+++ b/test-app/runtime/src/main/java/com/tns/NativeScriptWeakHashMap.java
@@ -40,7 +40,7 @@ import java.util.Set;
  * @see HashMap
  * @see WeakReference
  */
-public class NativeScriptWeakHashMap<K, V> extends NativeScriptAbstractMap<K, V> implements Map<K, V> {
+public class NativeScriptWeakHashMap<K, V extends Number> extends NativeScriptAbstractMap<K, V> implements Map<K, V> {
 
     private static final int DEFAULT_SIZE = 16;
 
@@ -103,7 +103,7 @@ public class NativeScriptWeakHashMap<K, V> extends NativeScriptAbstractMap<K, V>
             }
             Map.Entry<?, ?> entry = (Map.Entry<?, ?>) other;
             Object key = super.get();
-            return (key == null ? key == entry.getKey() : key.equals(entry.getKey())) && (value == null ? value == entry.getValue() : value.equals(entry.getValue()));
+            return (key == null ? key == entry.getKey() : key == entry.getKey()) && (value == null ? value == entry.getValue() : value == entry.getValue());
         }
 
         @Override
@@ -449,7 +449,7 @@ public class NativeScriptWeakHashMap<K, V> extends NativeScriptAbstractMap<K, V>
             int index = (secondaryHashForObject(key) & 0x7FFFFFFF) % elementData.length;
             Entry<K, V> entry = elementData[index];
             while (entry != null) {
-                if (key.equals(entry.get())) {
+                if (key == entry.get()) {
                     return entry.value;
                 }
                 entry = entry.next;
@@ -472,7 +472,7 @@ public class NativeScriptWeakHashMap<K, V> extends NativeScriptAbstractMap<K, V>
             int index = (secondaryHashForObject(key) & 0x7FFFFFFF) % elementData.length;
             Entry<K, V> entry = elementData[index];
             while (entry != null) {
-                if (key.equals(entry.get())) {
+                if (key == entry.get()) {
                     return entry;
                 }
                 entry = entry.next;
@@ -504,7 +504,7 @@ public class NativeScriptWeakHashMap<K, V> extends NativeScriptAbstractMap<K, V>
                 Entry<K, V> entry = elementData[i];
                 while (entry != null) {
                     K key = entry.get();
-                    if ((key != null || entry.isNull) && value.equals(entry.value)) {
+                    if ((key != null || entry.isNull) && value == entry.value) {
                         return true;
                     }
                     entry = entry.next;
@@ -582,7 +582,7 @@ public class NativeScriptWeakHashMap<K, V> extends NativeScriptAbstractMap<K, V>
         if (key != null) {
             index = (secondaryHashForObject(key) & 0x7FFFFFFF) % elementData.length;
             entry = elementData[index];
-            while (entry != null && !key.equals(entry.get())) {
+            while (entry != null && key != entry.get()) {
                 entry = entry.next;
             }
         } else {
@@ -658,7 +658,7 @@ public class NativeScriptWeakHashMap<K, V> extends NativeScriptAbstractMap<K, V>
         if (key != null) {
             index = (secondaryHashForObject(key) & 0x7FFFFFFF) % elementData.length;
             entry = elementData[index];
-            while (entry != null && !key.equals(entry.get())) {
+            while (entry != null && key != entry.get()) {
                 last = entry;
                 entry = entry.next;
             }


### PR DESCRIPTION
When comparing strong/weak references we shouldn't compare them using `equals` but using `==`. Otherwise we risk collisions in hash code generation of two objects to end up with not adding a new object in the strong/weak reference but reusing the old one.