### PR TITLE
Add initialization check in case of extending android.app.Service

### DIFF
--- a/test-app/app/src/main/java/com/tns/RuntimeHelper.java
+++ b/test-app/app/src/main/java/com/tns/RuntimeHelper.java
@@ -1,7 +1,5 @@
 package com.tns;
 
-import java.io.File;
-
 import android.app.Application;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -13,6 +11,7 @@ import android.os.Build;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -28,13 +27,13 @@ public final class RuntimeHelper {
 
     // hasErrorIntent tells you if there was an event (with an uncaught
     // exception) raised from ErrorReport
-    private static boolean hasErrorIntent(Application app) {
+    private static boolean hasErrorIntent(Context context) {
         boolean hasErrorIntent = false;
 
         try {
             // empty file just to check if there was a raised uncaught error by
             // ErrorReport
-            if (Util.isDebuggableApp(app)) {
+            if (Util.isDebuggableApp(context)) {
                 String fileName = "";
 
                 try {
@@ -45,7 +44,7 @@ public final class RuntimeHelper {
                     return false;
                 }
 
-                File errFile = new File(app.getFilesDir(), fileName);
+                File errFile = new File(context.getFilesDir(), fileName);
 
                 if (errFile.exists()) {
                     errFile.delete();
@@ -59,7 +58,7 @@ public final class RuntimeHelper {
         return hasErrorIntent;
     }
 
-    public static Runtime initRuntime(Application app) {
+    public static Runtime initRuntime(Context context) {
         if (Runtime.isInitialized()) {
             return Runtime.getCurrentRuntime();
         }
@@ -73,21 +72,21 @@ public final class RuntimeHelper {
                 loadLibraryFrame.close();
             }
 
-            Logger logger = new LogcatLogger(app);
+            Logger logger = new LogcatLogger(context);
 
             Runtime runtime = null;
-            boolean showErrorIntent = hasErrorIntent(app);
+            boolean showErrorIntent = hasErrorIntent(context);
             if (!showErrorIntent) {
-                NativeScriptUncaughtExceptionHandler exHandler = new NativeScriptUncaughtExceptionHandler(logger, app);
+                NativeScriptUncaughtExceptionHandler exHandler = new NativeScriptUncaughtExceptionHandler(logger, context);
 
                 Thread.setDefaultUncaughtExceptionHandler(exHandler);
 
                 DefaultExtractPolicy extractPolicy = new DefaultExtractPolicy(logger);
-                boolean skipAssetExtraction = Util.runPlugin(logger, app);
+                boolean skipAssetExtraction = Util.runPlugin(logger, context);
 
-                String appName = app.getPackageName();
-                File rootDir = new File(app.getApplicationInfo().dataDir);
-                File appDir = app.getFilesDir();
+                String appName = context.getPackageName();
+                File rootDir = new File(context.getApplicationInfo().dataDir);
+                File appDir = context.getFilesDir();
 
                 try {
                     appDir = appDir.getCanonicalFile();
@@ -103,14 +102,14 @@ public final class RuntimeHelper {
 
                         AssetExtractor aE = new AssetExtractor(null, logger);
 
-                        String outputDir = app.getFilesDir().getPath() + File.separator;
+                        String outputDir = context.getFilesDir().getPath() + File.separator;
 
                         // will force deletion of previously extracted files in app/files directories
                         // see https://github.com/NativeScript/NativeScript/issues/4137 for reference
                         boolean removePreviouslyInstalledAssets = true;
-                        aE.extractAssets(app, "app", outputDir, extractPolicy, removePreviouslyInstalledAssets);
-                        aE.extractAssets(app, "internal", outputDir, extractPolicy, removePreviouslyInstalledAssets);
-                        aE.extractAssets(app, "metadata", outputDir, extractPolicy, false);
+                        aE.extractAssets(context, "app", outputDir, extractPolicy, removePreviouslyInstalledAssets);
+                        aE.extractAssets(context, "internal", outputDir, extractPolicy, removePreviouslyInstalledAssets);
+                        aE.extractAssets(context, "metadata", outputDir, extractPolicy, false);
 
                         boolean shouldExtractSnapshots = true;
 
@@ -122,10 +121,10 @@ public final class RuntimeHelper {
 
                             @SuppressWarnings("deprecation")
                             String cpu_abi = Build.CPU_ABI;
-                            aE.extractAssets(app, "snapshots/" + cpu_abi, outputDir, extractPolicy, removePreviouslyInstalledAssets);
+                            aE.extractAssets(context, "snapshots/" + cpu_abi, outputDir, extractPolicy, removePreviouslyInstalledAssets);
                         }
 
-                        extractPolicy.setAssetsThumb(app);
+                        extractPolicy.setAssetsThumb(context);
                     } finally {
                         extractionFrame.close();
                     }
@@ -134,11 +133,11 @@ public final class RuntimeHelper {
                 AppConfig appConfig = new AppConfig(appDir);
                 ManualInstrumentation.setMode(appConfig.getProfilingMode());
 
-                ClassLoader classLoader = app.getClassLoader();
+                ClassLoader classLoader = context.getClassLoader();
                 File dexDir = new File(rootDir, "code_cache/secondary-dexes");
                 String dexThumb = null;
                 try {
-                    dexThumb = Util.getDexThumb(app);
+                    dexThumb = Util.getDexThumb(context);
                 } catch (NameNotFoundException e) {
                     if (logger.isEnabled()) {
                         logger.write("Error while getting current proxy thumb");
@@ -148,24 +147,24 @@ public final class RuntimeHelper {
 
                 String nativeLibDir = null;
                 try {
-                    nativeLibDir = app.getPackageManager().getApplicationInfo(appName, 0).nativeLibraryDir;
+                    nativeLibDir = context.getPackageManager().getApplicationInfo(appName, 0).nativeLibraryDir;
                 } catch (NameNotFoundException e) {
                     e.printStackTrace();
                 }
 
-                boolean isDebuggable = Util.isDebuggableApp(app);
+                boolean isDebuggable = Util.isDebuggableApp(context);
                 StaticConfiguration config = new StaticConfiguration(logger, appName, nativeLibDir, rootDir,
                         appDir, classLoader, dexDir, dexThumb, appConfig, isDebuggable);
 
                 runtime = Runtime.initializeRuntimeWithConfiguration(config);
                 if (isDebuggable) {
                     try {
-                        v8Inspector = new AndroidJsV8Inspector(app.getFilesDir().getAbsolutePath(), app.getPackageName());
+                        v8Inspector = new AndroidJsV8Inspector(context.getFilesDir().getAbsolutePath(), context.getPackageName());
                         v8Inspector.start();
 
                         // the following snippet is used as means to notify the VSCode extension
                         // debugger that the debugger agent has started
-                        File debuggerStartedFile = new File("/data/local/tmp", app.getPackageName() + "-debugger-started");
+                        File debuggerStartedFile = new File("/data/local/tmp", context.getPackageName() + "-debugger-started");
                         if (debuggerStartedFile.exists() && !debuggerStartedFile.isDirectory() && debuggerStartedFile.length() == 0) {
                             java.io.FileWriter fileWriter = new java.io.FileWriter(debuggerStartedFile);
                             fileWriter.write("started");
@@ -175,7 +174,7 @@ public final class RuntimeHelper {
                         // check if --debug-brk flag has been set. If positive:
                         // write to the file to invalidate the flag
                         // inform the v8Inspector to pause the main thread
-                        File debugBreakFile = new File("/data/local/tmp", app.getPackageName() + "-debugbreak");
+                        File debugBreakFile = new File("/data/local/tmp", context.getPackageName() + "-debugbreak");
                         boolean shouldBreak = false;
                         if (debugBreakFile.exists() && !debugBreakFile.isDirectory() && debugBreakFile.length() == 0) {
                             java.io.FileWriter fileWriter = new java.io.FileWriter(debugBreakFile);
@@ -192,9 +191,9 @@ public final class RuntimeHelper {
 
                     // if app is in debuggable mode run livesync service
                     // runtime needs to be initialized before the NativeScriptSyncService is enabled because it uses runtime.runScript(...)
-                    initLiveSync(runtime, logger, app);
+                    initLiveSync(runtime, logger, context);
 
-                    waitForLiveSync(app);
+                    waitForLiveSync(context);
                 }
 
                 runtime.runScript(new File(appDir, "internal/ts_helpers.js"));
@@ -206,9 +205,9 @@ public final class RuntimeHelper {
 
                 try {
                     // put this call in a try/catch block because with the latest changes in the modules it is not granted that NativeScriptApplication is extended through JavaScript.
-                    JavaScriptImplementation jsImpl = app.getClass().getAnnotation(JavaScriptImplementation.class);
-                    if (jsImpl != null) {
-                        Runtime.initInstance(app);
+                    JavaScriptImplementation jsImpl = context.getClass().getAnnotation(JavaScriptImplementation.class);
+                    if (jsImpl != null && !(context instanceof android.app.Service)) {
+                        Runtime.initInstance(context);
                     }
                 } catch (Exception e) {
                     if (logger.isEnabled()) {
@@ -221,7 +220,7 @@ public final class RuntimeHelper {
                     // If the user sets this flag, we will register a broadcast receiver
                     // that will listen for the TIMEZONE_CHANGED event and update V8's cache
                     // so that subsequent calls to "new Date()" return the new timezone
-                    registerTimezoneChangedListener(app, runtime);
+                    registerTimezoneChangedListener(context, runtime);
                 }
             }
             return runtime;
@@ -230,16 +229,16 @@ public final class RuntimeHelper {
         }
     }
 
-    private static void waitForLiveSync(Application app) {
+    private static void waitForLiveSync(Context context) {
         boolean needToWait = false;
 
         // CLI will create this file when initial sync is needed and then will remove it after syncing the fails and restarting the app
-        File liveSyncFile = new File("/data/local/tmp/" + app.getPackageName() + "-livesync-in-progress");
-        if(liveSyncFile.exists()) {
+        File liveSyncFile = new File("/data/local/tmp/" + context.getPackageName() + "-livesync-in-progress");
+        if (liveSyncFile.exists()) {
             needToWait = true;
             Long lastModified = liveSyncFile.lastModified();
             // we check for lastModified == 0 as this might happen if we cannot get the actual modified date
-            if(lastModified > 0) {
+            if (lastModified > 0) {
                 Long fileCreatedBeforeMillis = System.currentTimeMillis() - lastModified;
                 // if last modified date is more than a minute before the current time discard the file as most probably this is a leftover
                 if (fileCreatedBeforeMillis > 60000) {
@@ -248,11 +247,12 @@ public final class RuntimeHelper {
             }
         }
 
-        if(needToWait) {
+        if (needToWait) {
             try {
                 // wait for the livesync to complete and it should restart the app after deleting the livesync-in-progress file
                 Thread.sleep(30000);
-            } catch (Exception ex) { }
+            } catch (Exception ex) {
+            }
         }
     }
 
@@ -299,10 +299,10 @@ public final class RuntimeHelper {
 
     }
 
-    public static void initLiveSync(Runtime runtime, Logger logger, Application app){
-        boolean isDebuggable = Util.isDebuggableApp(app);
+    public static void initLiveSync(Runtime runtime, Logger logger, Context context) {
+        boolean isDebuggable = Util.isDebuggableApp(context);
 
-        if(!isDebuggable){
+        if (!isDebuggable) {
             return;
         }
 
@@ -313,8 +313,8 @@ public final class RuntimeHelper {
             Class NativeScriptSyncService = Class.forName("com.tns.NativeScriptSyncServiceSocketImpl");
 
             @SuppressWarnings("unchecked")
-            Constructor cons = NativeScriptSyncService.getConstructor(new Class[] {Runtime.class, Logger.class, Context.class});
-            Object syncService = cons.newInstance(runtime, logger, app);
+            Constructor cons = NativeScriptSyncService.getConstructor(new Class[]{Runtime.class, Logger.class, Context.class});
+            Object syncService = cons.newInstance(runtime, logger, context);
 
             @SuppressWarnings("unchecked")
             Method startServerMethod = NativeScriptSyncService.getMethod("startServer");

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/Generator.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/Generator.java
@@ -378,8 +378,9 @@ public class Generator {
         ImportsWriter importsWriter = new ImportsWriterImpl(writer);
 
         boolean isApplicationClass = androidClassChecker.isApplicationClass(clazz);
+        boolean isServiceClass = androidClassChecker.isServiceClass(clazz);
 
-        if (isApplicationClass && !packageName.equals("com.tns")) {
+        if ((isServiceClass || isApplicationClass) && !packageName.equals("com.tns")) {
             importsWriter.writeRuntimeHelperImport();
             importsWriter.writeRuntimeImport();
         }
@@ -402,8 +403,10 @@ public class Generator {
 
     private void writeConstructorsToWriter(Writer writer, JavaClass clazz, DataRow dataRow, String generatedClassName, GenericHierarchyView genericHierarchyView) {
         boolean isApplicationClass = androidClassChecker.isApplicationClass(clazz);
+        boolean isServiceClass = androidClassChecker.isServiceClass(clazz);
+
         MethodSignatureReifier methodSignatureReifier = new MethodSignatureReifier(genericHierarchyView);
-        MethodsWriter methodsWriter = new MethodsWriterImpl(writer, suppressCallJSMethodExceptions, isApplicationClass);
+        MethodsWriter methodsWriter = new MethodsWriterImpl(writer, suppressCallJSMethodExceptions, isApplicationClass, isServiceClass);
         ImplementationObjectChecker implementationObjectChecker = new ImplementationObjectCheckerImpl();
 
         List<String> implObjectMethods = Arrays.asList(dataRow.getMethods());
@@ -421,8 +424,9 @@ public class Generator {
 
     private void writeMethodsToWriter(Writer writer, GenericHierarchyView genericHierarchyView, Map<JavaClass, GenericHierarchyView> interfaceGenericHierarchyViews, JavaClass clazz, List<String> userImplementedMethods, List<JavaClass> userImplementedInterfaces, String packageName) {
         boolean isApplicationClass = androidClassChecker.isApplicationClass(clazz);
+        boolean isServiceClass = androidClassChecker.isServiceClass(clazz);
 
-        MethodsWriter methodsWriter = new MethodsWriterImpl(writer, suppressCallJSMethodExceptions, isApplicationClass);
+        MethodsWriter methodsWriter = new MethodsWriterImpl(writer, suppressCallJSMethodExceptions, isApplicationClass, isServiceClass);
 
         InheritedMethodsCollector inheritedMethodsCollector = new InheritedMethodsCollectorImpl.Builder()
                 .forJavaClass(clazz)

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/parsing/checkers/AndroidClassChecker.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/parsing/checkers/AndroidClassChecker.java
@@ -5,4 +5,5 @@ import org.apache.bcel.classfile.JavaClass;
 public interface AndroidClassChecker {
     boolean isActivityClass(JavaClass clazz);
     boolean isApplicationClass(JavaClass clazz);
+    boolean isServiceClass(JavaClass javaClass);
 }

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/parsing/checkers/impl/AndroidClassCheckerImpl.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/parsing/checkers/impl/AndroidClassCheckerImpl.java
@@ -13,6 +13,7 @@ import java.util.Map;
 public class AndroidClassCheckerImpl implements AndroidClassChecker {
 
     private static final String APPLICATION_CLASS_NAME = "android.app.Application";
+    private static final String SERVICE_CLASS_NAME = "android.app.Service";
     private static final List<String> ACTIVITY_TYPES = Arrays.asList("android.app.Activity","android.support.v7.app.AppCompatActivity","androidx.appcompat.app.AppCompatActivity");
 
     private final ClassHierarchyParser classHierarchyParser;
@@ -46,5 +47,15 @@ public class AndroidClassCheckerImpl implements AndroidClassChecker {
 
         HierarchyView hierarchyView = classHierarchyParser.getClassHierarchy(javaClass);
         return hierarchyView.getAllParentClassesNames().contains(APPLICATION_CLASS_NAME);
+    }
+
+    @Override
+    public boolean isServiceClass(JavaClass javaClass){
+        if(javaClass.getClassName().equals(SERVICE_CLASS_NAME)){
+            return true;
+        }
+
+        HierarchyView hierarchyView = classHierarchyParser.getClassHierarchy(javaClass);
+        return hierarchyView.getAllParentClassesNames().contains(SERVICE_CLASS_NAME);
     }
 }


### PR DESCRIPTION
Currently, the SBG generated `onCreate` methods for extended `android.app.Service` does not check if the runtime is initialized. In cases of sticky background services, there could be a case when the application is not running and there is no initialized NativeScript runtime. This commit ensures the runtime will be initialized in case it is not.