### PR TITLE
Add support for parsing object spread operator in SBG's jsparser

### DIFF
--- a/test-app/build-tools/jsparser/js_parser.js
+++ b/test-app/build-tools/jsparser/js_parser.js
@@ -132,6 +132,7 @@ function getFileAst(tsHelpersFilePath) {
                 plugins: ["decorators"]
             });
 
+
             return resolve(ast);
         });
     });
@@ -219,7 +220,7 @@ var astFromFileContent = function (path, data, err) {
 
         var ast = babelParser.parse(data.data, {
             minify: false,
-            plugins: ["decorators"]
+            plugins: ["decorators", "objectRestSpread"]
         });
         data.ast = ast;
         return resolve(data);


### PR DESCRIPTION
Related to https://github.com/NativeScript/NativeScript/issues/7205

Currently, the jsparser in the SBG does not support parsing the object spread operator:
```
var options = {
  priority: 0,
  ...options
};
```

This issue may result in a runtime crash of a NS app as the SBG would not generate some or most of the needed Java mirror classes. 
Bug is due to improper babel parser usage. 