### PR TITLE
Metadata generator fixes

### DIFF
--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -531,6 +531,20 @@ afterEvaluate { project ->
             }.artifacts.each {
                 processJar(it.file, jars)
             }
+
+            def projectDependencies = config.getAllDependencies().withType(ProjectDependency)
+            def dependentProjects = projectDependencies*.dependencyProject
+            dependentProjects.findAll {
+                // if there's a project dependency search for its result jar file in the build/intermediates/runtime_library_classes folder
+                def jarDir = new File("${it.getBuildDir()}/intermediates/runtime_library_classes/${buildType.toLowerCase()}")
+                if(jarDir.exists()) {
+                    jarDir.eachFileRecurse(FileType.FILES) { file ->
+                        if (file.path.endsWith(".jar")) {
+                            processJar(file, jars)
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -483,7 +483,7 @@ def explodeAar(File compileDependency, File outputDir) {
                 def targetFile = new File(outputDir, file.name)
                 InputStream inputStream = jar.getInputStream(file)
                 new File(targetFile.parent).mkdirs()
-                Files.copy(inputStream, targetFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                Files.copy(inputStream, targetFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
             }
             if (file.isDirectory()) {
                 continue
@@ -499,9 +499,9 @@ def explodeAar(File compileDependency, File outputDir) {
 }
 
 def md5(String string) {
-    MessageDigest digest = MessageDigest.getInstance("MD5") ;
-    digest.update(string.bytes);
-    return new BigInteger(1, digest.digest()).toString(16).padLeft(32, '0');
+    MessageDigest digest = MessageDigest.getInstance("MD5")
+    digest.update(string.bytes)
+    return new BigInteger(1, digest.digest()).toString(16).padLeft(32, '0')
 }
 
 class WorkerTask extends DefaultTask {
@@ -597,7 +597,7 @@ task cleanupAllJars {
     outputs.files cleanupAllJarsTimestamp
 
     doLast {
-        def allDests = project.ext.allJars*.outputDir*.name;
+        def allDests = project.ext.allJars*.outputDir*.name
         def dir = new File(extractedDependenciesDir)
         if (dir.exists()) {
             dir.eachDir {

--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -20,8 +20,7 @@ import groovy.json.JsonSlurper
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
-import java.util.regex.Matcher
-import java.util.regex.Pattern
+import groovy.io.FileType
 import java.security.MessageDigest
 import javax.inject.Inject
 apply plugin: "com.android.application"
@@ -518,60 +517,61 @@ class EmptyRunnable implements Runnable {
 }
 
 // Discover all jars and dynamically create tasks for the extraction of each of them
-def allJars = []
+project.ext.allJars = []
 afterEvaluate { project ->
     def buildType = project.selectedBuildType == "release" ? "Release" : "Debug"
     def jars = []
-    Pattern pattern = Pattern.compile("^(.+)${buildType}CompileClasspath\$")
     def artifactType = Attribute.of('artifactType', String)
     configurations.all { config ->
-        Matcher matcher = pattern.matcher(config.name)
-        if (matcher.find() || config.name == "${buildType.toLowerCase()}CompileClasspath") {
+        if (config.name == "${buildType.toLowerCase()}RuntimeClasspath") {
             config.incoming.artifactView {
                 attributes {
                     it.attribute(artifactType, 'jar')
                 }
             }.artifacts.each {
-                def jar = it.file;
-                if (!jars.contains(jar)) {
-                    jars.add(jar)
-                    def destDir = md5(jar.path);
-                    def outputDir = new File(Paths.get(extractedDependenciesDir, destDir).normalize().toString())
-
-                    def taskName = "extract_${jar.name}_to_${destDir}"
-                    logger.debug("Creating dynamic task ${taskName}")
-
-                    // Add discovered jars as dependencies of cleanupAllJars.
-                    // This is cruicial for cloud builds because they are different
-                    // on each incremental build (as each time the gradle user home
-                    // directory is a randomly generated string)
-                    cleanupAllJars.inputs.files jar
-
-                    task "${taskName}" (type: WorkerTask) {
-                        dependsOn cleanupAllJars
-                        extractAllJars.dependsOn it
-
-                        // This dependency seems redundant but probably due to some Gradle issue with workers,
-                        // without it `runSbg` sporadically starts before all extraction tasks have finished and
-                        // fails due to missing JARs
-                        runSbg.dependsOn it
-
-                        inputs.files jar
-                        outputs.dir outputDir
-
-                        doLast {
-                            // Runing in parallel no longer seems to bring any benefit.
-                            // It mattered only when we were extracting JARs from AARs.
-                            // To try it simply remove the following comments.
-                            // workerExecutor.submit(EmptyRunnable.class) {
-                            explodeAar(jar, outputDir)
-                            // }
-                        }
-                    }
-                    allJars.add([file: jar, outputDir: outputDir])
-                }
+                processJar(it.file, jars)
             }
         }
+    }
+}
+
+def processJar(File jar, jars) {
+    if (!jars.contains(jar)) {
+        jars.add(jar)
+        def destDir = md5(jar.path)
+        def outputDir = new File(Paths.get(extractedDependenciesDir, destDir).normalize().toString())
+
+        def taskName = "extract_${jar.name}_to_${destDir}"
+        logger.debug("Creating dynamic task ${taskName}")
+
+        // Add discovered jars as dependencies of cleanupAllJars.
+        // This is cruicial for cloud builds because they are different
+        // on each incremental build (as each time the gradle user home
+        // directory is a randomly generated string)
+        cleanupAllJars.inputs.files jar
+
+        task "${taskName}" (type: WorkerTask) {
+            dependsOn cleanupAllJars
+            extractAllJars.dependsOn it
+
+            // This dependency seems redundant but probably due to some Gradle issue with workers,
+            // without it `runSbg` sporadically starts before all extraction tasks have finished and
+            // fails due to missing JARs
+            runSbg.dependsOn it
+
+            inputs.files jar
+            outputs.dir outputDir
+
+            doLast {
+                // Runing in parallel no longer seems to bring any benefit.
+                // It mattered only when we were extracting JARs from AARs.
+                // To try it simply remove the following comments.
+                // workerExecutor.submit(EmptyRunnable.class) {
+                explodeAar(jar, outputDir)
+                // }
+            }
+        }
+        project.ext.allJars.add([file: jar, outputDir: outputDir])
     }
 }
 
@@ -583,7 +583,7 @@ task cleanupAllJars {
     outputs.files cleanupAllJarsTimestamp
 
     doLast {
-        def allDests = allJars*.outputDir*.name;
+        def allDests = project.ext.allJars*.outputDir*.name;
         def dir = new File(extractedDependenciesDir)
         if (dir.exists()) {
             dir.eachDir {

--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -536,6 +536,7 @@ afterEvaluate { project ->
             def dependentProjects = projectDependencies*.dependencyProject
             dependentProjects.findAll {
                 // if there's a project dependency search for its result jar file in the build/intermediates/runtime_library_classes folder
+                // this is the output folder in gradle 5.1.1, but it can be changed in the future versions of gradle
                 def jarDir = new File("${it.getBuildDir()}/intermediates/runtime_library_classes/${buildType.toLowerCase()}")
                 if(jarDir.exists()) {
                     jarDir.eachFileRecurse(FileType.FILES) { file ->
@@ -543,6 +544,8 @@ afterEvaluate { project ->
                             processJar(file, jars)
                         }
                     }
+                } else {
+                    println "WARNING: Folder ${jarDir.path} does not exists, the dependent project's classess won't be included in the metadata"
                 }
             }
         }

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/parsing/ClassParser.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/parsing/ClassParser.java
@@ -29,6 +29,11 @@ public final class ClassParser {
         for (String implementedInterfaceName : implementedInterfacesNames) {
             ClassDescriptor interfaceClass = ClassRepo.findClass(implementedInterfaceName);
 
+            if (interfaceClass == null) {
+                System.out.println(String.format("WARNING: Skipping interface %s implemented in %s as it cannot be resolved", implementedInterfaceName, clazz.getClassName()));
+                continue;
+            }
+
             for (MethodDescriptor md : interfaceClass.getMethods()) {
                 if (!md.isStatic() && !md.isAbstract()) {
                     collectedDefaultMethods.add(md);


### PR DESCRIPTION
Related to #1379 

Seems that in the latest gradle version that we use - 5.1.1 not all dependencies can be found as artefacts of the **...CompileClasspath** configuration and we need to use **...RuntimeClasspath** to get all of them.

In addition to that we are not getting the jars of dependent projects as in the **test-app** inside the current repository. A fix for this is made trying to find the project jar in its `/build/intermediates/runtime_library_classes` folder.