### PR TITLE
Removed the broken link from the top of the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Android Runtime for NativeScript
 [![Build Status](https://travis-ci.org/NativeScript/android-runtime.svg?branch=master)](https://travis-ci.org/NativeScript/android-runtime)
-[![Waffle.io - NativeScript Android Runtime](https://badge.waffle.io/NativeScript/android-runtime.svg?columns=In%20Progress)](https://waffle.io/NativeScript/android-runtime)
 
 Contains the source code for the NativeScript's Android Runtime. [NativeScript](https://www.nativescript.org/) is a framework which enables developers to write truly native mobile applications for Android and iOS using JavaScript and CSS. Each mobile platform has its own ecosystem and offers completely different development tools and language(s) - Java for Android and Objective C (Swift) for iOS. In order to translate JavaScript code to the corresponding native APIs some kind of proxy mechanism is needed. This is exactly what the "Runtime" parts of NativeScript are responsible for. The Android Runtime may be thought of as "The Bridge" between the JavaScript and Android worlds. A NativeScript application for Android is a standard native package (apk) which besides the JavaScript files embed the runtime as well.
 


### PR DESCRIPTION
<!--Dear friend, we, the rest of the NativeScript community thank you for your
contribution! Because we want to present a really nice, readable changelog with each
release, please provide the following information: -->

### Create a meaningful title
<!-- Please, ensure your title is less than 50 characters and starts with a capital letter. We strive to follow the guidelines in the
[How to Write a Git Commit Message] (http://chris.beams.io/posts/git-commit/) article for PR titles. -->

### Description:
Link the waffle.io android runtime is not working. I believe waffle.io is not in service. A replacement should be linked or removed all together. 

### Does your commit message include the wording below to reference a specific issue in this repo?
<!--Fixes/Implements #[I1383]. -->

### Related Pull Requests
<!-- List links related to this Pull Request from other repos/branches: -->

### Does your pull request have [unit tests](https://github.com/NativeScript/NativeScript/blob/master/running-tests.md)?
<!--If not, why?
If not, please tell us why tests are not included, and list all steps needed to test your pull request manually. -->
No unit tests needed because this is a documentation issue. To duplicate the issue, open README.md and click the top link that says Waffle.io - NativeScript Android Runtime. 

