### PR TITLE
Added a setting for enabling line breakpoints

### DIFF
--- a/test-app/app/src/main/assets/app/package.json
+++ b/test-app/app/src/main/assets/app/package.json
@@ -9,7 +9,8 @@
 		"markingMode": "full",
 		"maxLogcatObjectSize": 1024,
 		"forceLog": false,
-		"suppressCallJSMethodExceptions": false
+		"suppressCallJSMethodExceptions": false,
+		"enableLineBreakpoints": false
 	},
 	"discardUncaughtJsExceptions": false
 }

--- a/test-app/runtime/CMakeLists.txt
+++ b/test-app/runtime/CMakeLists.txt
@@ -63,6 +63,7 @@ if (NOT OPTIMIZED_BUILD OR OPTIMIZED_WITH_INSPECTOR_BUILD)
         src/main/cpp/JsV8InspectorClient.cpp
         src/main/cpp/DOMDomainCallbackHandlers.cpp
         src/main/cpp/NetworkDomainCallbackHandlers.cpp
+        src/main/cpp/NSV8DebuggerAgentImpl.cpp
 
         src/main/cpp/v8_inspector/src/inspector/protocol/CSS.cpp
         src/main/cpp/v8_inspector/src/inspector/protocol/Console.cpp

--- a/test-app/runtime/src/main/cpp/NSV8DebuggerAgentImpl.cpp
+++ b/test-app/runtime/src/main/cpp/NSV8DebuggerAgentImpl.cpp
@@ -1,0 +1,38 @@
+// Copyright 2015 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "NSV8DebuggerAgentImpl.h"
+
+namespace v8_inspector {
+
+NSV8DebuggerAgentImpl::NSV8DebuggerAgentImpl(
+    V8InspectorSessionImpl* session, protocol::FrontendChannel* frontendChannel,
+    protocol::DictionaryValue* state)
+    : V8DebuggerAgentImpl(session, frontendChannel, state),
+    m_env(tns::JEnv()){
+
+    auto runtimeClass = m_env.FindClass("com/tns/Runtime");
+    assert(runtimeClass != nullptr);
+
+    auto getLineBreakpointsEnabledMethodID = m_env.GetStaticMethodID(runtimeClass, "getLineBreakpointsEnabled", "()Z");
+    assert(getLineBreakpointsEnabledMethodID != nullptr);
+
+    auto lineBreakpointsEnabled = m_env.CallStaticBooleanMethod(runtimeClass, getLineBreakpointsEnabledMethodID);
+    m_lineBreakpointsEnabled = lineBreakpointsEnabled == JNI_TRUE;
+}
+
+Response NSV8DebuggerAgentImpl::getPossibleBreakpoints(
+    std::unique_ptr<protocol::Debugger::Location> start,
+    Maybe<protocol::Debugger::Location> end, Maybe<bool> restrictToFunction,
+    std::unique_ptr<protocol::Array<protocol::Debugger::BreakLocation>>*
+        locations) {
+    if(m_lineBreakpointsEnabled) {
+        return V8DebuggerAgentImpl::getPossibleBreakpoints(std::move(start), std::move(end), std::move(restrictToFunction), locations);
+    } else {
+        *locations = protocol::Array<protocol::Debugger::BreakLocation>::create();
+        return Response::OK();
+    }
+}
+
+}  // namespace v8_inspector

--- a/test-app/runtime/src/main/cpp/NSV8DebuggerAgentImpl.h
+++ b/test-app/runtime/src/main/cpp/NSV8DebuggerAgentImpl.h
@@ -1,0 +1,29 @@
+// Copyright 2015 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef V8_INSPECTOR_NS_V8_DEBUGGER_AGENT_IMPL_H_
+#define V8_INSPECTOR_NS_V8_DEBUGGER_AGENT_IMPL_H_
+
+#include <JEnv.h>
+#include "src/inspector/v8-debugger-agent-impl.h"
+
+namespace v8_inspector {
+
+    class NSV8DebuggerAgentImpl : public V8DebuggerAgentImpl {
+    public:
+        NSV8DebuggerAgentImpl(V8InspectorSessionImpl *, protocol::FrontendChannel *,
+                              protocol::DictionaryValue *state);
+
+        Response getPossibleBreakpoints(
+                std::unique_ptr<protocol::Debugger::Location> start,
+                Maybe<protocol::Debugger::Location> end, Maybe<bool> restrictToFunction,
+                std::unique_ptr<protocol::Array<protocol::Debugger::BreakLocation>> *
+                locations) override;
+        DISALLOW_COPY_AND_ASSIGN(NSV8DebuggerAgentImpl);
+    private:
+        tns::JEnv m_env;
+        bool m_lineBreakpointsEnabled;
+    };
+}
+#endif  // V8_INSPECTOR_NS_V8_DEBUGGER_AGENT_IMPL_H_

--- a/test-app/runtime/src/main/cpp/v8_inspector/src/inspector/v8-inspector-session-impl.cc
+++ b/test-app/runtime/src/main/cpp/v8_inspector/src/inspector/v8-inspector-session-impl.cc
@@ -24,6 +24,7 @@
 #include "src/inspector/v8-css-agent-impl.h"
 #include "src/inspector/v8-overlay-agent-impl.h"
 #include "src/inspector/v8-log-agent-impl.h"
+#include "NSV8DebuggerAgentImpl.h"
 
 namespace v8_inspector {
 
@@ -106,7 +107,7 @@ V8InspectorSessionImpl::V8InspectorSessionImpl(V8InspectorImpl* inspector,
       this, this, agentState(protocol::Runtime::Metainfo::domainName)));
   protocol::Runtime::Dispatcher::wire(&m_dispatcher, m_runtimeAgent.get());
 
-  m_debuggerAgent.reset(new V8DebuggerAgentImpl(
+  m_debuggerAgent.reset(new NSV8DebuggerAgentImpl(
       this, this, agentState(protocol::Debugger::Metainfo::domainName)));
   protocol::Debugger::Dispatcher::wire(&m_dispatcher, m_debuggerAgent.get());
 

--- a/test-app/runtime/src/main/java/com/tns/AppConfig.java
+++ b/test-app/runtime/src/main/java/com/tns/AppConfig.java
@@ -20,7 +20,8 @@ class AppConfig {
         HandleTimeZoneChanges("handleTimeZoneChanges", false),
         MaxLogcatObjectSize("maxLogcatObjectSize", 1024),
         ForceLog("forceLog", false),
-        DiscardUncaughtJsExceptions("discardUncaughtJsExceptions", false);
+        DiscardUncaughtJsExceptions("discardUncaughtJsExceptions", false),
+        EnableLineBreakpoins("enableLineBreakpoints", false);
 
         private final String name;
         private final Object defaultValue;
@@ -116,6 +117,9 @@ class AppConfig {
                     if (androidObject.has(KnownKeys.ForceLog.getName())) {
                         values[KnownKeys.ForceLog.ordinal()] = androidObject.getBoolean(KnownKeys.ForceLog.getName());
                     }
+                    if (androidObject.has(KnownKeys.EnableLineBreakpoins.getName())) {
+                        values[KnownKeys.EnableLineBreakpoins.ordinal()] = androidObject.getBoolean(KnownKeys.EnableLineBreakpoins.getName());
+                    }
                 }
             }
         } catch (Exception e) {
@@ -165,6 +169,10 @@ class AppConfig {
 
     public boolean getForceLog() {
         return (boolean)values[KnownKeys.ForceLog.ordinal()];
+    }
+
+    public boolean getLineBreakpointsEnabled() {
+        return (boolean)values[KnownKeys.EnableLineBreakpoins.ordinal()];
     }
 
     public boolean getDiscardUncaughtJsExceptions() {

--- a/test-app/runtime/src/main/java/com/tns/Runtime.java
+++ b/test-app/runtime/src/main/java/com/tns/Runtime.java
@@ -273,6 +273,15 @@ public class Runtime {
     }
 
     @RuntimeCallable
+    public static boolean getLineBreakpointsEnabled() {
+        if (staticConfiguration != null && staticConfiguration.appConfig != null) {
+            return staticConfiguration.appConfig.getLineBreakpointsEnabled();
+        } else {
+            return ((boolean) AppConfig.KnownKeys.EnableLineBreakpoins.getDefaultValue());
+        }
+    }
+
+    @RuntimeCallable
     public int getMarkingModeOrdinal() {
         if (staticConfiguration != null && staticConfiguration.appConfig != null) {
             return staticConfiguration.appConfig.getMarkingMode().ordinal();


### PR DESCRIPTION
Related to #1271

A new setting in app's package.json file is added to enable line breakpoints which default value is false as calculating those breakpoints slows a lot adding breakpoints when using bundle.
```Json
{
	...
	"android": {
		...
		"enableLineBreakpoints": true
	}
}
``` 