### PR TITLE
removing lazy dependency to fix buffer warning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,17 @@ task generateDtsgJar(type: Exec) {
     }
 }
 
+task jsParserNPMInstall(type: Exec) {
+    doFirst {
+        workingDir "$TEST_APP_PATH/build-tools/jsparser"
+        if (isWinOs) {
+            commandLine "cmd", "/c", "npm", "install"
+        } else {
+            commandLine "npm", "install"
+        }
+    }
+}
+
 task generateSbgJar(type: Exec) {
     doFirst {
         workingDir "$TEST_APP_PATH"
@@ -328,6 +339,7 @@ task createNpmPackage(type: Exec) {
 }
 
 generateSbgJar.dependsOn(generateDtsgJar)
+generateSbgJar.dependsOn(jsParserNPMInstall)
 generateMdgJar.dependsOn(generateSbgJar)
 createDistDir.dependsOn(generateMdgJar)
 

--- a/test-app/build-tools/jsparser/js_parser.js
+++ b/test-app/build-tools/jsparser/js_parser.js
@@ -22,10 +22,10 @@ loggingSettings = {
 var fs = require("fs"),
     babelParser = require("babylon"),
     traverse = require("babel-traverse"),
+    split = require('split'),
     logger = require('./helpers/logger')(loggingSettings),
     path = require("path"),
     es5_visitors = require("./visitors/es5-visitors"),
-    lazy = require("lazy"),
     eol = require('os').EOL,
 
     BUILD_TOOLS_DIR = `${__dirname}/../`,
@@ -99,17 +99,20 @@ readLinesFromFile(inputFilesPath, inputFiles, tsHelpersFilePath)
 */
 function readLinesFromFile(filePath, outArr, resolveParameter) {
     return new Promise(function (resolve, reject) {
-        new lazy(fs.createReadStream(filePath))
-            .lines
-            .forEach(function (line) {
+        fs.createReadStream(filePath)
+        .pipe(split())
+        .on('data', function (line) {
+            // skip empty lines
+            if(/\S/.test(line)) {
                 outArr.push(line.toString().trim());
-            }).on('pipe', function (err) {
-                if (err) {
-                    return reject(err);
-                }
-
-                return resolve(resolveParameter)
-            });
+            }
+        })
+        .on('error', function(err) {
+            return reject(err);
+        })
+        .on('close', function(e) {
+            return resolve(resolveParameter)
+        });
     });
 }
 
@@ -144,19 +147,21 @@ function getFileAst(tsHelpersFilePath) {
 */
 function readInterfaceNames(data, err) {
     return new Promise(function (resolve, reject) {
-        new lazy(fs.createReadStream(interfacesNamesFilePath))
-            .lines
-            .forEach(function (line) {
-                interfaceNames.push(line.toString());
-            }).on('pipe', function (err) {
-                if (err) {
-                    return reject(false);
-                }
-
-                inputDir = path.normalize(inputDir);
-
-                return resolve(inputDir);
-            });
+        fs.createReadStream(interfacesNamesFilePath)
+        .pipe(split())
+        .on('data', function (line) {
+            // skip empty lines
+            if(/\S/.test(line)) {
+                interfaceNames.push(line.toString().trim());
+            }
+        })
+        .on('error', function(e) {
+            return reject(false);
+        })
+        .on('close', function(e) {
+            inputDir = path.normalize(inputDir);
+            return resolve(inputDir);
+        });
     })
 }
 

--- a/test-app/build-tools/jsparser/package-lock.json
+++ b/test-app/build-tools/jsparser/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "ast-parser",
+  "name": "js-parser",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -1476,14 +1476,14 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
-      "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "^2.12.1",
+        "node-pre-gyp": "^0.12.0"
       },
       "dependencies": {
         "abbrev": {
@@ -1561,12 +1561,12 @@
           "optional": true
         },
         "debug": {
-          "version": "2.6.9",
+          "version": "4.1.1",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
         },
         "deep-extend": {
@@ -1737,24 +1737,24 @@
           }
         },
         "ms": {
-          "version": "2.0.0",
+          "version": "2.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
-          "version": "2.2.4",
+          "version": "2.3.0",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
+            "debug": "^4.1.0",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.10.3",
+          "version": "0.12.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -1782,13 +1782,13 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.5",
+          "version": "1.0.6",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.2.0",
+          "version": "1.4.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -1927,7 +1927,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.6.0",
+          "version": "5.7.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2474,11 +2474,6 @@
       "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
       "dev": true
     },
-    "lazy": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/lazy/-/lazy-1.0.11.tgz",
-      "integrity": "sha1-2qBoIGKCVCwIgojpdcKXwa53tpA="
-    },
     "lcid": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
@@ -2749,9 +2744,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nan": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "dev": true,
       "optional": true
     },
@@ -3574,6 +3569,14 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "requires": {
+        "through": "2"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -3755,6 +3758,11 @@
           "dev": true
         }
       }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "2.0.5",

--- a/test-app/build-tools/jsparser/package.json
+++ b/test-app/build-tools/jsparser/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ast-parser",
+  "name": "js-parser",
   "version": "1.0.0",
   "description": "javascript static analysis tool",
   "main": "js_parser.js",
@@ -13,7 +13,7 @@
     "babel-traverse": "6.26.0",
     "babel-types": "6.26.0",
     "babylon": "6.18.0",
-    "lazy": "1.0.11"
+    "split": "1.0.1"
   },
   "repository": "https://github.com/NativeScript/android-runtime",
   "devDependencies": {

--- a/test-app/settings.gradle
+++ b/test-app/settings.gradle
@@ -8,13 +8,3 @@ include ':app',
 project(':static-binding-generator').projectDir = new File('build-tools/static-binding-generator')
 project(':android-metadata-generator').projectDir = new File('build-tools/android-metadata-generator')
 project(':dts-generator').projectDir = new File('build-tools/android-dts-generator/dts-generator')
-
-def isWinOs = System.properties['os.name'].toLowerCase().contains('windows')
-exec {
-    workingDir "$rootDir/build-tools/jsparser"
-    if (isWinOs) {
-        commandLine "cmd", "/c", "npm", "install"
-    } else {
-        commandLine "npm", "install"
-    }
-}


### PR DESCRIPTION
Related to #1392 

The warning is shown because of the `lazy` dependency which is quite old and uses `new Buffer()`. So to remove the warning I did a small refactoring to remove the dependency.
In addition the `npm install` functionality is moved to a more appropriate place.