### PR TITLE
suppress deprecation warnings in generated code

### DIFF
--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -411,11 +411,12 @@ task addDependenciesFromAppResourcesLibraries {
     }
 }
 
-// Uncomment the code bellow to get detailed deprecation warnings
-//tasks.withType(JavaCompile) {
-//    options.compilerArgs << '-Xlint:unchecked'
-//    options.deprecation = true
-//}
+if (failOnCompilationWarningsEnabled()) {
+    tasks.withType(JavaCompile) {
+        options.compilerArgs << '-Xlint:all' << "-Werror"
+        options.deprecation = true
+    }
+}
 
 tasks.whenTaskAdded({ org.gradle.api.DefaultTask currentTask ->
     if (currentTask =~ /generate.+BuildConfig/) {
@@ -451,7 +452,15 @@ task runSbg(type: JavaExec) {
 
     workingDir "$BUILD_TOOLS_PATH"
     main "-jar"
-    args "static-binding-generator.jar"
+
+    def paramz = new ArrayList<String>()
+    paramz.add("static-binding-generator.jar")
+
+    if (failOnCompilationWarningsEnabled()) {
+        paramz.add("-show-deprecation-warnings")
+    }
+
+    args paramz
 
     doFirst {
         new File("$OUTPUT_JAVA_DIR/com/tns/gen").deleteDir()
@@ -463,6 +472,10 @@ task ensureMetadataOutDir {
         def outputDir = file("$METADATA_OUT_PATH")
         outputDir.mkdirs()
     }
+}
+
+def failOnCompilationWarningsEnabled() {
+    return project.hasProperty("failOnCompilationWarnings") && (failOnCompilationWarnings || failOnCompilationWarnings.toBoolean())
 }
 
 def explodeAar(File compileDependency, File outputDir) {

--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -411,6 +411,12 @@ task addDependenciesFromAppResourcesLibraries {
     }
 }
 
+// Uncomment the code bellow to get detailed deprecation warnings
+//tasks.withType(JavaCompile) {
+//    options.compilerArgs << '-Xlint:unchecked'
+//    options.deprecation = true
+//}
+
 tasks.whenTaskAdded({ org.gradle.api.DefaultTask currentTask ->
     if (currentTask =~ /generate.+BuildConfig/) {
         currentTask.finalizedBy(extractAllJars)

--- a/test-app/app/src/debug/java/com/tns/ErrorReport.java
+++ b/test-app/app/src/debug/java/com/tns/ErrorReport.java
@@ -318,6 +318,7 @@ class ErrorReport implements TabLayout.OnTabSelectedListener {
 
         int tabCount;
 
+        @SuppressWarnings("deprecation")
         public Pager(FragmentManager fm, int tabCount) {
             super(fm);
             this.tabCount = tabCount;

--- a/test-app/app/src/debug/java/com/tns/NativeScriptSyncService.java
+++ b/test-app/app/src/debug/java/com/tns/NativeScriptSyncService.java
@@ -40,7 +40,7 @@ public class NativeScriptSyncService {
 
     public NativeScriptSyncService(Runtime runtime, Logger logger, Context context) {
         this.runtime = runtime;
-        this.logger = logger;
+        NativeScriptSyncService.logger = logger;
         this.context = context;
 
         syncPath = SYNC_ROOT_SOURCE_DIR + context.getPackageName() + SYNC_SOURCE_DIR;

--- a/test-app/app/src/debug/java/com/tns/NativeScriptSyncServiceSocketImpl.java
+++ b/test-app/app/src/debug/java/com/tns/NativeScriptSyncServiceSocketImpl.java
@@ -25,7 +25,7 @@ public class NativeScriptSyncServiceSocketImpl {
 
     public NativeScriptSyncServiceSocketImpl(Runtime runtime, Logger logger, Context context) {
         this.runtime = runtime;
-        this.logger = logger;
+        NativeScriptSyncServiceSocketImpl.logger = logger;
         this.context = context;
         DEVICE_APP_DIR = this.context.getFilesDir().getAbsolutePath() + "/app";
     }

--- a/test-app/app/src/main/java/com/tns/DefaultExtractPolicy.java
+++ b/test-app/app/src/main/java/com/tns/DefaultExtractPolicy.java
@@ -15,6 +15,8 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 
+import androidx.core.content.pm.PackageInfoCompat;
+
 import com.tns.Logger;
 import com.tns.ExtractPolicy;
 import com.tns.FileExtractor;
@@ -67,9 +69,9 @@ public class DefaultExtractPolicy implements ExtractPolicy {
     private String generateAssetsThumb(Context context) {
         try {
             PackageInfo packageInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
-            int code = packageInfo.versionCode;
+            long code = PackageInfoCompat.getLongVersionCode(packageInfo);
             long updateTime = packageInfo.lastUpdateTime;
-            return String.valueOf(updateTime) + "-" + String.valueOf(code);
+            return updateTime + "-" + code;
         } catch (NameNotFoundException e) {
             logger.write("Error while getting current assets thumb");
             e.printStackTrace();

--- a/test-app/app/src/main/java/com/tns/RuntimeHelper.java
+++ b/test-app/app/src/main/java/com/tns/RuntimeHelper.java
@@ -34,10 +34,10 @@ public final class RuntimeHelper {
             // empty file just to check if there was a raised uncaught error by
             // ErrorReport
             if (Util.isDebuggableApp(context)) {
-                String fileName = "";
+                String fileName;
 
                 try {
-                    Class ErrReport = Class.forName("com.tns.ErrorReport");
+                    Class<?> ErrReport = Class.forName("com.tns.ErrorReport");
                     Field field = ErrReport.getDeclaredField("ERROR_FILE_NAME");
                     fileName = (String) field.get(null);
                 } catch (Exception e) {
@@ -310,10 +310,10 @@ public final class RuntimeHelper {
         // runtime needs to be initialized before the NativeScriptSyncService is enabled because it uses runtime.runScript(...)
         try {
             @SuppressWarnings("unchecked")
-            Class NativeScriptSyncService = Class.forName("com.tns.NativeScriptSyncServiceSocketImpl");
+            Class<?> NativeScriptSyncService = Class.forName("com.tns.NativeScriptSyncServiceSocketImpl");
 
             @SuppressWarnings("unchecked")
-            Constructor cons = NativeScriptSyncService.getConstructor(new Class[]{Runtime.class, Logger.class, Context.class});
+            Constructor<?> cons = NativeScriptSyncService.getConstructor(new Class<?>[]{Runtime.class, Logger.class, Context.class});
             Object syncService = cons.newInstance(runtime, logger, context);
 
             @SuppressWarnings("unchecked")

--- a/test-app/app/src/main/java/com/tns/Util.java
+++ b/test-app/app/src/main/java/com/tns/Util.java
@@ -11,15 +11,17 @@ import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.os.Bundle;
 
+import androidx.core.content.pm.PackageInfoCompat;
+
 public final class Util {
     private Util() {
     }
 
     public static String getDexThumb(Context context) throws NameNotFoundException {
         PackageInfo packageInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
-        int code = packageInfo.versionCode;
+        long code = PackageInfoCompat.getLongVersionCode(packageInfo);
         long updateTime = packageInfo.lastUpdateTime;
-        return String.valueOf(updateTime) + "-" + String.valueOf(code);
+        return updateTime + "-" + code;
     }
 
     public static boolean isDebuggableApp(Context context) {

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/InputParameters.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/InputParameters.java
@@ -1,0 +1,59 @@
+package org.nativescript.staticbindinggenerator;
+
+public class InputParameters {
+
+    // if the flag is passed the deprecation warnings will not be suppressed
+    private static final String SHOW_DEPRECATION_WARNINGS = "-show-deprecation-warnings";
+    // if the flag is passed the generation will exit on error
+    private static final String THROW_ON_ERROR = "-throw-on-error";
+
+    private static InputParameters current = new InputParameters();
+
+    private boolean showDeprecationWarnings;
+    private boolean throwOnError;
+
+    public InputParameters() {
+        this.showDeprecationWarnings = false;
+        this.throwOnError = false;
+    }
+
+    public void setShowDeprecationWarnings(boolean value) {
+        this.showDeprecationWarnings = value;
+    }
+
+    public boolean getSuppressDeprecationWarnings() {
+        return !showDeprecationWarnings;
+    }
+
+    public void setThrowOnError(boolean value) {
+        this.throwOnError = value;
+    }
+
+    public boolean getThrowOnError() {
+        return throwOnError;
+    }
+
+    public static void parseCommand(String[] args) {
+        InputParameters inputParameters = new InputParameters();
+
+        if (args != null) {
+            for (int i = 0; i < args.length; i++) {
+                String commandArg = args[i];
+
+                if (commandArg.equals(SHOW_DEPRECATION_WARNINGS)) {
+                    inputParameters.setShowDeprecationWarnings(true);
+                }
+
+                if (commandArg.equals(THROW_ON_ERROR)) {
+                    inputParameters.setThrowOnError(true);
+                }
+            }
+        }
+
+        InputParameters.current = inputParameters;
+    }
+
+    public static InputParameters getCurrent() {
+        return InputParameters.current;
+    }
+}

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/Main.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/Main.java
@@ -33,6 +33,8 @@ public class Main {
     }
 
     public static void main(String[] args) throws IOException, ClassNotFoundException {
+        InputParameters.parseCommand(args);
+
         validateInput();
 
         getWorkerExcludeFile();
@@ -44,7 +46,7 @@ public class Main {
 
         // generate java bindings
         String inputBindingFilename = Paths.get(System.getProperty("user.dir"), SBG_BINDINGS_NAME).toString();
-        Generator generator = new Generator(outputDir, rows, isSuppressCallJSMethodExceptionsEnabled(), false);
+        Generator generator = new Generator(outputDir, rows, isSuppressCallJSMethodExceptionsEnabled());
         generator.writeBindings(inputBindingFilename);
     }
 

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/parsing/methods/JavaMethod.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/parsing/methods/JavaMethod.java
@@ -18,6 +18,7 @@ public interface JavaMethod {
     boolean isStatic();
     boolean isFinal();
     boolean isSynthetic();
+    boolean isDeprecated();
     String getSignature();
     String getGenericSignature();
     boolean hasGenericSignature();

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/parsing/methods/impl/JavaMethodImpl.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/parsing/methods/impl/JavaMethodImpl.java
@@ -77,6 +77,17 @@ public class JavaMethodImpl implements JavaMethod {
     }
 
     @Override
+    public boolean isDeprecated() {
+        return Arrays.stream(
+            this
+                .getMethod()
+                .getAttributes())
+                .anyMatch(x ->
+                x.getClass()
+                        .isAssignableFrom(org.apache.bcel.classfile.Deprecated.class));
+    }
+
+    @Override
     public String getSignature() {
         return method.getSignature();
     }

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/parsing/methods/impl/ReifiedJavaMethodImpl.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/parsing/methods/impl/ReifiedJavaMethodImpl.java
@@ -97,6 +97,9 @@ public class ReifiedJavaMethodImpl implements ReifiedJavaMethod {
     }
 
     @Override
+    public boolean isDeprecated() { return javaMethod.isDeprecated(); }
+
+    @Override
     public String getSignature() {
         return javaMethod.getSignature();
     }

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/writing/MethodsWriter.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/writing/MethodsWriter.java
@@ -3,7 +3,7 @@ package org.nativescript.staticbindinggenerator.generating.writing;
 import org.nativescript.staticbindinggenerator.generating.parsing.methods.ReifiedJavaMethod;
 
 public interface MethodsWriter extends JavaCodeWriter {
-    void writeMethod(ReifiedJavaMethod method);
+    void writeMethod(ReifiedJavaMethod method, boolean isUserImplemented);
     void writeConstructor(String className, ReifiedJavaMethod method, boolean hasUserImplementedInitMethod);
     void writeGetInstanceMethod(String className);
     void writeInternalRuntimeEqualsMethod();

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/writing/impl/MethodsWriterImpl.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/writing/impl/MethodsWriterImpl.java
@@ -2,11 +2,13 @@ package org.nativescript.staticbindinggenerator.generating.writing.impl;
 
 import org.apache.bcel.generic.Type;
 import org.nativescript.staticbindinggenerator.DefaultValues;
+import org.nativescript.staticbindinggenerator.Generator;
 import org.nativescript.staticbindinggenerator.Writer;
 import org.nativescript.staticbindinggenerator.generating.parsing.methods.ReifiedJavaMethod;
 import org.nativescript.staticbindinggenerator.generating.writing.MethodsWriter;
 import org.nativescript.staticbindinggenerator.naming.BcelNamingUtil;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class MethodsWriterImpl implements MethodsWriter {
@@ -228,7 +230,25 @@ public class MethodsWriterImpl implements MethodsWriter {
         writer.write(CLOSING_ROUND_BRACKET_LITERAL);
     }
 
+    private boolean isMethodDeprecated(ReifiedJavaMethod method) {
+        return Arrays.stream(
+                method
+                    .getMethod()
+                    .getAttributes())
+                    .anyMatch(x ->
+                            x.getClass()
+                                    .isAssignableFrom(org.apache.bcel.classfile.Deprecated.class));
+    }
+
+    private void writeSuppressDeprecationsToWriter() {
+        writer.writeln("@SuppressWarnings( \"deprecation\" )");
+    }
+
     private void writeMethodSignature(ReifiedJavaMethod method) {
+        if(isMethodDeprecated(method)) {
+            writeSuppressDeprecationsToWriter();
+        }
+
         writer.write(getMethodVisibilityModifier(method));
         writer.write(SPACE_LITERAL);
         writer.write(method.getOwnGenericArgumentsDeclaration());


### PR DESCRIPTION
Related to #1396

When extending a class SBG generates methods for all methods in the parent class including the deprecated ones, so to avoid those warnings we are are adding `@SuppressWarnings("deprecation")` before the method declaration.

A new setting is added which will cause the build to fail if there are any warnings in the generated code (excluding the autogenerated abstract deprecated methods from the SBG). The setting will be helpful if you want to check whether you are using deprecated methods when extending a class. To enable it add the following in the **App_Resources/app.gradle** file:
```gradle
project.ext.failOnCompilationWarnings = true
```