### PR TITLE
refactoring message and stack trace reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@
 - [java.lang.NullPointerException in Metadata generator(#13795)](https://github.com/NativeScript/android-runtime/issues/1379)
 - [Buffer() is deprecated(#1392)](https://github.com/NativeScript/android-runtime/pull/1392)
 - [Warnings when building android(#1396)](https://github.com/NativeScript/android-runtime/issues/1396)
+- [No JS stack on discardedError and unhandledError(#1354)](https://github.com/NativeScript/android-runtime/issues/1354)
+
+## Breaking Changes
+
+- Exception information in onDiscarderError and onUnhandledError is changed so that `message` contains the exception message and `stackTrace` contains only the stackTrace. In the previous implementation `stackTrace` contained some additional details (including the exception message) and the `message` was something like:
+
+    ```
+    The application crashed because of an uncaught exception. You can look at "stackTrace" or "nativeException" for more detailed information about the exception.
+    ```
 
 5.4.0
 ==

--- a/test-app/app/src/main/assets/app/tests/discardedExceptionsTest.js
+++ b/test-app/app/src/main/assets/app/tests/discardedExceptionsTest.js
@@ -18,7 +18,8 @@ describe("Tests discarded exception ", function () {
         expect(reportedException).not.toBe(null);
         expect(reportedException.nativeException).not.toBe(null);
         expect(reportedException.nativeException.getMessage()).toBe('Exception to suppress');
-        expect(reportedException.stackTrace).toContain('Error on "main" thread for reportSupressedException');
+        expect(reportedException.message).toBe('Exception to suppress');
+        expect(reportedException.stackTrace).toContain('com.tns.tests.DiscardedExceptionTest.reportSupressedException');
     });
 
     afterEach(function() {

--- a/test-app/app/src/main/java/com/tns/NativeScriptUncaughtExceptionHandler.java
+++ b/test-app/app/src/main/java/com/tns/NativeScriptUncaughtExceptionHandler.java
@@ -1,7 +1,6 @@
 package com.tns;
 
 import java.lang.Thread.UncaughtExceptionHandler;
-
 import android.content.Context;
 
 public class NativeScriptUncaughtExceptionHandler implements UncaughtExceptionHandler {
@@ -19,18 +18,19 @@ public class NativeScriptUncaughtExceptionHandler implements UncaughtExceptionHa
 
     @Override
     public void uncaughtException(Thread thread, Throwable ex) {
-        String currentThreadMessage = "An uncaught Exception occurred on \"" + thread.getName() + "\" thread.\n";
-
-        String errorMessage = currentThreadMessage + Runtime.getStackTraceErrorMessage(ex);
+        String currentThreadMessage = String.format("An uncaught Exception occurred on \"%s\" thread.\n%s\n", thread.getName(), ex.getMessage());
+        String stackTraceErrorMessage = Runtime.getStackTraceErrorMessage(ex);
+        String errorMessage = currentThreadMessage + stackTraceErrorMessage;
 
         if (Runtime.isInitialized()) {
             try {
-                ex.printStackTrace();
+                // print this only in debug
+                System.err.println(errorMessage);
 
                 Runtime runtime = Runtime.getCurrentRuntime();
 
                 if (runtime != null) {
-                    runtime.passUncaughtExceptionToJs(ex, errorMessage);
+                    runtime.passUncaughtExceptionToJs(ex, ex.getMessage(), stackTraceErrorMessage);
                 }
             } catch (Throwable t) {
                 t.printStackTrace();

--- a/test-app/runtime/src/main/cpp/NativeScriptException.h
+++ b/test-app/runtime/src/main/cpp/NativeScriptException.h
@@ -21,6 +21,11 @@ class NativeScriptException {
         NativeScriptException(const std::string& message);
 
         /*
+         * Generates a NativeScriptException with given message and stackTrace
+         */
+        NativeScriptException(const std::string& message, const std::string& stackTrace);
+
+        /*
          * Generates a NativeScriptException with javascript error from TryCatch and a prepend message if any
          */
         NativeScriptException(v8::TryCatch& tc, const std::string& message = "");
@@ -64,7 +69,7 @@ class NativeScriptException {
         /*
          * Gets all the information from a js message and an js error object and puts it in a string
          */
-        static std::string GetErrorMessage(const v8::Local<v8::Message>& message, v8::Local<v8::Value>& error);
+        static std::string GetErrorMessage(const v8::Local<v8::Message>& message, v8::Local<v8::Value>& error, const std::string& prependMessage = "");
 
         /*
          * Generates string stack trace from js StackTrace
@@ -74,11 +79,13 @@ class NativeScriptException {
         /*
          *	Adds a prepend message to the normal message process
          */
-        std::string GetFullMessage(const v8::TryCatch& tc, bool isExceptionEmpty, bool isMessageEmpty, const std::string& prependMessage = "");
+        std::string GetFullMessage(const v8::TryCatch& tc, const std::string& jsExceptionMessage);
 
         v8::Persistent<v8::Value>* m_javascriptException;
         JniLocalRef m_javaException;
         std::string m_message;
+        std::string m_stackTrace;
+        std::string m_fullMessage;
 
         static jclass RUNTIME_CLASS;
         static jclass THROWABLE_CLASS;

--- a/test-app/runtime/src/main/cpp/Runtime.cpp
+++ b/test-app/runtime/src/main/cpp/Runtime.cpp
@@ -370,12 +370,10 @@ bool Runtime::TryCallGC() {
     return success;
 }
 
-void Runtime::PassExceptionToJsNative(JNIEnv* env, jobject obj, jthrowable exception, jstring stackTrace, jboolean isDiscarded) {
+void Runtime::PassExceptionToJsNative(JNIEnv* env, jobject obj, jthrowable exception, jstring message, jstring stackTrace, jboolean isDiscarded) {
     auto isolate = m_isolate;
 
-    //create error message
-    string errMsg = isDiscarded ? "An exception was caught and discarded. You can look at \"stackTrace\" or \"nativeException\" for more detailed information about the exception.":
-                    "The application crashed because of an uncaught exception. You can look at \"stackTrace\" or \"nativeException\" for more detailed information about the exception.";
+    string errMsg = ArgConverter::jstringToString(message);
 
     auto errObj = Exception::Error(ArgConverter::ConvertToV8String(isolate, errMsg)).As<Object>();
 
@@ -391,9 +389,6 @@ void Runtime::PassExceptionToJsNative(JNIEnv* env, jobject obj, jthrowable excep
             nativeExceptionObject = Object::New(isolate);
         }
     }
-
-    string stackTraceText = ArgConverter::jstringToString(stackTrace);
-    errMsg += "\n" + stackTraceText;
 
     //create a JS error object
     errObj->Set(V8StringConstants::GetNativeException(isolate), nativeExceptionObject);

--- a/test-app/runtime/src/main/cpp/Runtime.h
+++ b/test-app/runtime/src/main/cpp/Runtime.h
@@ -52,7 +52,7 @@ class Runtime {
         void AdjustAmountOfExternalAllocatedMemory();
         bool NotifyGC(JNIEnv* env, jobject obj);
         bool TryCallGC();
-        void PassExceptionToJsNative(JNIEnv* env, jobject obj, jthrowable exception, jstring stackTrace, jboolean isDiscarded);
+        void PassExceptionToJsNative(JNIEnv* env, jobject obj, jthrowable exception, jstring message, jstring stackTrace, jboolean isDiscarded);
         void PassUncaughtExceptionFromWorkerToMainHandler(v8::Local<v8::String> message, v8::Local<v8::String> stackTrace, v8::Local<v8::String> filename, int lineno);
         void ClearStartupData(JNIEnv* env, jobject obj);
         void DestroyRuntime();

--- a/test-app/runtime/src/main/cpp/com_tns_Runtime.cpp
+++ b/test-app/runtime/src/main/cpp/com_tns_Runtime.cpp
@@ -245,7 +245,7 @@ extern "C" JNIEXPORT void Java_com_tns_Runtime_unlock(JNIEnv* env, jobject obj, 
     }
 }
 
-extern "C" JNIEXPORT void Java_com_tns_Runtime_passExceptionToJsNative(JNIEnv* env, jobject obj, jint runtimeId, jthrowable exception, jstring stackTrace, jboolean isDiscarded) {
+extern "C" JNIEXPORT void Java_com_tns_Runtime_passExceptionToJsNative(JNIEnv* env, jobject obj, jint runtimeId, jthrowable exception, jstring message, jstring stackTrace, jboolean isDiscarded) {
     auto runtime = TryGetRuntime(runtimeId);
     if (runtime == nullptr) {
         return;
@@ -256,7 +256,7 @@ extern "C" JNIEXPORT void Java_com_tns_Runtime_passExceptionToJsNative(JNIEnv* e
     v8::HandleScope handleScope(isolate);
 
     try {
-        runtime->PassExceptionToJsNative(env, obj, exception, stackTrace, isDiscarded);
+        runtime->PassExceptionToJsNative(env, obj, exception, message, stackTrace, isDiscarded);
     } catch (NativeScriptException& e) {
         e.ReThrowToJava();
     } catch (std::exception e) {

--- a/test-app/runtime/src/main/java/com/tns/NativeScriptException.java
+++ b/test-app/runtime/src/main/java/com/tns/NativeScriptException.java
@@ -4,26 +4,37 @@ package com.tns;
 public class NativeScriptException extends RuntimeException {
     @SuppressWarnings("unused")
     private long jsValueAddress = 0;
+    private String incomingStackTrace;
 
     public NativeScriptException() {
         super();
     }
 
-    public NativeScriptException(String detailMessage) {
-        super(detailMessage);
+    public NativeScriptException(String message) {
+        super(message);
     }
 
     public NativeScriptException(Throwable throwable) {
         super(throwable);
     }
 
-    public NativeScriptException(String detailMessage, Throwable throwable) {
-        super(detailMessage, throwable);
+    public NativeScriptException(String message, Throwable throwable) {
+        super(message, throwable);
     }
 
-    public NativeScriptException(String detailMessage, long jsValueAddress) {
-        super(detailMessage);
+    public NativeScriptException(String message, String stackTrace, Throwable throwable) {
+        super(message, throwable);
+        this.incomingStackTrace = stackTrace;
+    }
+
+    public NativeScriptException(String message, String stackTrace, long jsValueAddress) {
+        super(message);
+        this.incomingStackTrace = stackTrace;
         this.jsValueAddress = jsValueAddress;
+    }
+
+    public String getIncomingStackTrace() {
+        return incomingStackTrace;
     }
 
     @RuntimeCallable


### PR DESCRIPTION
Related to #1354
`stackTrace` now report only the stack trace, and `message` reports the right message.