### PR TITLE
Improve error message in SBG class parsing

### DIFF
--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/parsing/classes/hierarchy/generics/impl/GenericsAwareClassHierarchyParserImpl.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/parsing/classes/hierarchy/generics/impl/GenericsAwareClassHierarchyParserImpl.java
@@ -317,7 +317,7 @@ public class GenericsAwareClassHierarchyParserImpl implements GenericsAwareClass
         JavaClass javaClass = classesCache.get(BcelNamingUtil.resolveClassName(className));
 
         if (javaClass == null) {
-            throw new RuntimeException("Class not found!");
+            throw new RuntimeException("Class \"" + className + "\" not found!");
         }
 
         return javaClass;


### PR DESCRIPTION
Related to: https://github.com/NativeScript/android-runtime/issues/1406
Add the class/interface name in the exception message if it's not found.