### PR TITLE
Add super.onCreate() call in generated onCreate method

### DIFF
--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/writing/impl/MethodsWriterImpl.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/writing/impl/MethodsWriterImpl.java
@@ -389,6 +389,12 @@ public class MethodsWriterImpl implements MethodsWriter {
         writer.write(INTERNAL_SERVICES_ONCREATE_METHOD_SIGNATURE);
         writer.write(OPENING_CURLY_BRACKET_LITERAL);
 
+        writer.write(SUPER_METHOD_CALL_PREFIX);
+        writer.write(ON_CREATE_METHOD_NAME);
+        writer.write(OPENING_ROUND_BRACKET_LITERAL);
+        writer.write(CLOSING_ROUND_BRACKET_LITERAL);
+        writer.write(END_OF_STATEMENT_LITERAL);
+
         writeRuntimeInitializationForService();
 
         writer.write(CLOSING_CURLY_BRACKET_LITERAL);


### PR DESCRIPTION
Related to: https://github.com/NativeScript/nativescript-dev-webpack/issues/952

Currently, if the user hasn't provided an `onCreate` method implementation, the SBG generates the `onCreate` method for object initialization. This auto-generated method, however, doesn't have a call to the parent class' method and in some cases like extending an `IntentService` an exception occurs when Android creates an instance of the service. This commit adds a call to `super.onCreate()`