### PR TITLE
chore: Bump package version to 6.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tns-android",
   "description": "NativeScript Runtime for Android",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/NativeScript/android-runtime.git"


### PR DESCRIPTION
This ensures the correct functioning of CLI 6.0.0 with subsequent runtime RC versions
