### PR TITLE
Increase NodeJS heap size

### DIFF
--- a/test-app/build-tools/static-binding-generator/build.gradle
+++ b/test-app/build-tools/static-binding-generator/build.gradle
@@ -16,9 +16,11 @@ dependencies {
     compile group: 'org.json', name: 'json', version: '20090211'
     compile 'commons-io:commons-io:2.5'
     compile 'com.google.code.gson:gson:2.8.5'
-    testCompile 'com.google.code.gson:gson:2.8.5'
-    testCompile 'junit:junit:4.+'
     compile 'com.google.googlejavaformat:google-java-format:1.6'
+
+    testCompile 'com.google.code.gson:gson:2.8.5'
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.mockito:mockito-core:3.0.0'
 }
 
 compileJava {

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/Main.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/Main.java
@@ -4,10 +4,13 @@ import org.apache.commons.io.FileUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.nativescript.staticbindinggenerator.nodejs.NodeJSProcess;
+import org.nativescript.staticbindinggenerator.nodejs.impl.NodeJSProcessImpl;
+import org.nativescript.staticbindinggenerator.system.environment.impl.EnvironmentVariablesReaderImpl;
+import org.nativescript.staticbindinggenerator.system.process.impl.ProcessExecutorImpl;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InterruptedIOException;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
 import java.nio.file.Paths;
@@ -121,25 +124,13 @@ public class Main {
      * Run the javascript static analysis [js_parser] and generate an output file.
      * This output file should contain all the information needed to generate java counterparts to the traversed js classes.
      * */
-    private static void runJsParser() throws IOException {
+    private static void runJsParser() {
         String parserPath = Paths.get(System.getProperty("user.dir"), "jsparser", "js_parser.js").toString();
+        NodeJSProcess nodeJSProcess = new NodeJSProcessImpl(new ProcessExecutorImpl(), new EnvironmentVariablesReaderImpl());
+        int exitCode = nodeJSProcess.runScript(parserPath);
 
-        List<String> l = new ArrayList<String>();
-        l.add("node");
-        l.add(parserPath);
-
-        ProcessBuilder pb = new ProcessBuilder(l);
-        pb.redirectOutput(ProcessBuilder.Redirect.INHERIT);
-        pb.redirectError(ProcessBuilder.Redirect.INHERIT);
-        Process p = pb.start();
-        try {
-            p.waitFor();
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-            throw new InterruptedIOException("A problem occured while waiting for the jsparser to finish.");
-        }
-        if (p.exitValue() != 0) {
-            System.exit(p.exitValue());
+        if (exitCode != 0) {
+            System.exit(exitCode);
         }
     }
 

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/nodejs/NodeJSProcess.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/nodejs/NodeJSProcess.java
@@ -1,0 +1,11 @@
+package org.nativescript.staticbindinggenerator.nodejs;
+
+public interface NodeJSProcess {
+    /**
+     * Starts a Node process to execute a JS file
+     *
+     * @param scriptPath path to the JS file
+     * @return returns the Node process' exit code
+     */
+    int runScript(String scriptPath);
+}

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/nodejs/impl/NodeJSProcessImpl.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/nodejs/impl/NodeJSProcessImpl.java
@@ -1,0 +1,56 @@
+package org.nativescript.staticbindinggenerator.nodejs.impl;
+
+import org.nativescript.staticbindinggenerator.nodejs.NodeJSProcess;
+import org.nativescript.staticbindinggenerator.system.environment.EnvironmentVariablesReader;
+import org.nativescript.staticbindinggenerator.system.process.ProcessExecutor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class NodeJSProcessImpl implements NodeJSProcess {
+
+    private static final String NODE_PROCESS_NAME = "node";
+    private static final String NODE_OPTIONS_VARIABLE = "NODE_OPTIONS";
+    private static final String MAX_OLD_SPACE_SIZE_PROPERTY_NAME = "max-old-space-size";
+    private static final String MAX_OLD_SPACE_SIZE_PROPERTY_NAME_UNDERSCORED = "max_old_space_size";
+    private static final String MAX_OLD_SPACE_SIZE_DEFAULT_PROPERTY = "--" + MAX_OLD_SPACE_SIZE_PROPERTY_NAME + "=8192";
+    private static final String MAX_OLD_SPACE_SIZE_DEFAULT_PROPERTY_UNDERSCORED = "--" + MAX_OLD_SPACE_SIZE_PROPERTY_NAME_UNDERSCORED + "=8192";
+
+    private final ProcessExecutor processExecutor;
+    private final EnvironmentVariablesReader environmentVariablesReader;
+
+    public NodeJSProcessImpl(ProcessExecutor processExecutor, EnvironmentVariablesReader environmentVariablesReader) {
+        this.processExecutor = processExecutor;
+        this.environmentVariablesReader = environmentVariablesReader;
+    }
+
+    @Override
+    public int runScript(String scriptPath) {
+        List<String> parameters = createNodeJSParameters(scriptPath);
+        return processExecutor.executeProcess(NODE_PROCESS_NAME, parameters);
+    }
+
+    private List<String> createNodeJSParameters(String scriptPath) {
+        List<String> parameters = new ArrayList<>();
+
+        if (!hasUserProvidedV8HeapSizeProperty()) {
+            parameters.add(MAX_OLD_SPACE_SIZE_DEFAULT_PROPERTY);
+            parameters.add(MAX_OLD_SPACE_SIZE_DEFAULT_PROPERTY_UNDERSCORED);
+        }
+
+        parameters.add(scriptPath);
+
+        return parameters;
+    }
+
+    private boolean hasUserProvidedV8HeapSizeProperty() {
+        return environmentVariablesReader.readEnvironmentVariables()
+                .entrySet()
+                .stream()
+                .anyMatch(x -> x.getKey().equals(NODE_OPTIONS_VARIABLE)
+                        && (x.getValue().contains(MAX_OLD_SPACE_SIZE_PROPERTY_NAME)
+                            || x.getValue().contains(MAX_OLD_SPACE_SIZE_PROPERTY_NAME_UNDERSCORED)));
+    }
+
+
+}

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/system/environment/EnvironmentVariablesReader.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/system/environment/EnvironmentVariablesReader.java
@@ -1,0 +1,12 @@
+package org.nativescript.staticbindinggenerator.system.environment;
+
+import java.util.Map;
+
+public interface EnvironmentVariablesReader {
+    /**
+     * Reads the current process' environment variables
+     *
+     * @return the environment variables as name=value collection
+     */
+    Map<String, String> readEnvironmentVariables();
+}

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/system/environment/impl/EnvironmentVariablesReaderImpl.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/system/environment/impl/EnvironmentVariablesReaderImpl.java
@@ -1,0 +1,14 @@
+package org.nativescript.staticbindinggenerator.system.environment.impl;
+
+import org.nativescript.staticbindinggenerator.system.environment.EnvironmentVariablesReader;
+
+import java.util.Map;
+
+public class EnvironmentVariablesReaderImpl implements EnvironmentVariablesReader {
+
+    @Override
+    public Map<String, String> readEnvironmentVariables() {
+        return System.getenv();
+    }
+
+}

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/system/process/ProcessExecutionException.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/system/process/ProcessExecutionException.java
@@ -1,0 +1,18 @@
+package org.nativescript.staticbindinggenerator.system.process;
+
+public class ProcessExecutionException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public ProcessExecutionException(String message) {
+        super(message);
+    }
+
+    public ProcessExecutionException(String message, Throwable origin) {
+        super(message, origin);
+    }
+
+    public ProcessExecutionException(Throwable origin) {
+        super(origin);
+    }
+}

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/system/process/ProcessExecutor.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/system/process/ProcessExecutor.java
@@ -1,0 +1,16 @@
+package org.nativescript.staticbindinggenerator.system.process;
+
+import java.util.List;
+
+public interface ProcessExecutor {
+
+    /**
+     * Executes a process by a given name or path with specified arguments
+     *
+     * @param processNameOrPath process name or path
+     * @param arguments         arguments to pass to the process
+     * @return status code of the executed process
+     * @throws ProcessExecutionException if no process name/path given or InterruptedException/IOException occurs
+     */
+    int executeProcess(String processNameOrPath, List<String> arguments);
+}

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/system/process/impl/ProcessExecutorImpl.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/system/process/impl/ProcessExecutorImpl.java
@@ -1,0 +1,36 @@
+package org.nativescript.staticbindinggenerator.system.process.impl;
+
+import com.google.common.base.Strings;
+
+import org.nativescript.staticbindinggenerator.system.process.ProcessExecutionException;
+import org.nativescript.staticbindinggenerator.system.process.ProcessExecutor;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ProcessExecutorImpl implements ProcessExecutor {
+
+    @Override
+    public int executeProcess(String processNameOrPath, List<String> arguments) {
+        if (Strings.isNullOrEmpty(processNameOrPath)) {
+            throw new ProcessExecutionException("Missing process name!");
+        }
+
+        List<String> processBuilderArguments = new ArrayList<>();
+        processBuilderArguments.add(processNameOrPath);
+        processBuilderArguments.addAll(arguments);
+
+        ProcessBuilder processBuilder = new ProcessBuilder(processBuilderArguments);
+        processBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+        processBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
+
+        try {
+            Process p = processBuilder.start();
+            p.waitFor();
+            return p.exitValue();
+        } catch (InterruptedException | IOException e) {
+            throw new ProcessExecutionException(e);
+        }
+    }
+}

--- a/test-app/build-tools/static-binding-generator/src/test/java/org/nativescript/staticbindinggenerator/nodejs/impl/NodeJSProcessImplTest.java
+++ b/test-app/build-tools/static-binding-generator/src/test/java/org/nativescript/staticbindinggenerator/nodejs/impl/NodeJSProcessImplTest.java
@@ -1,0 +1,99 @@
+package org.nativescript.staticbindinggenerator.nodejs.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.nativescript.staticbindinggenerator.nodejs.NodeJSProcess;
+import org.nativescript.staticbindinggenerator.system.environment.EnvironmentVariablesReader;
+import org.nativescript.staticbindinggenerator.system.process.ProcessExecutor;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class NodeJSProcessImplTest {
+
+    private static final String NODE_PROCESS_NAME = "node";
+    private static final String TEST_SCRIPT_FILE_PATH = "testFile.js";
+    private static final String TEST_USER_PROVIDED_NODE_OPTIONS_UNDERSCORED = "--max_old_space_size=1234";
+    private static final String TEST_USER_PROVIDED_NODE_OPTIONS = "--max-old-space-size=1234";
+    private static final String DEFAULT_HEAP_SIZE_ARGUMENT_UNDERSCORED = "--max_old_space_size=8192";
+    private static final String DEFAULT_HEAP_SIZE_ARGUMENT = "--max-old-space-size=8192";
+    private static final int TEST_EXIT_CODE = 666;
+
+    @Mock
+    private ProcessExecutor processExecutor;
+
+    @Mock
+    private EnvironmentVariablesReader environmentVariablesReader;
+
+    private NodeJSProcess nodeJSProcess;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        nodeJSProcess = new NodeJSProcessImpl(processExecutor, environmentVariablesReader);
+    }
+
+    @Test
+    public void testProcessStartedWithoutDefaultHeapSizeIfUserProvidedNodeOptions() {
+        when(environmentVariablesReader.readEnvironmentVariables()).thenReturn(createTestNodeOptionsEnvironmentVariable(TEST_USER_PROVIDED_NODE_OPTIONS));
+        List<String> expectedProcessArguments = new ArrayList<>();
+        expectedProcessArguments.add(TEST_SCRIPT_FILE_PATH);
+
+        nodeJSProcess.runScript(TEST_SCRIPT_FILE_PATH);
+
+        verify(environmentVariablesReader).readEnvironmentVariables();
+        verify(processExecutor).executeProcess(NODE_PROCESS_NAME, expectedProcessArguments);
+    }
+
+    @Test
+    public void testProcessStartedWithoutDefaultHeapSizeIfUserProvidedUnderscoredNodeOptions() {
+        when(environmentVariablesReader.readEnvironmentVariables()).thenReturn(createTestNodeOptionsEnvironmentVariable(TEST_USER_PROVIDED_NODE_OPTIONS_UNDERSCORED));
+        List<String> expectedProcessArguments = new ArrayList<>();
+        expectedProcessArguments.add(TEST_SCRIPT_FILE_PATH);
+
+        nodeJSProcess.runScript(TEST_SCRIPT_FILE_PATH);
+
+        verify(environmentVariablesReader).readEnvironmentVariables();
+        verify(processExecutor).executeProcess(NODE_PROCESS_NAME, expectedProcessArguments);
+    }
+
+    private Map<String, String> createTestNodeOptionsEnvironmentVariable(String nodeOptionsValue) {
+        Map<String, String> mockedEnvironment = new HashMap<>();
+        mockedEnvironment.put("NODE_OPTIONS", nodeOptionsValue);
+        return mockedEnvironment;
+    }
+
+    @Test
+    public void testProcessStartedWithDefaultHeapSizeIfUserDidNotProvideNodeOptions() {
+        when(environmentVariablesReader.readEnvironmentVariables()).thenReturn(new HashMap<>());
+        List<String> expectedProcessArguments = new ArrayList<>();
+        expectedProcessArguments.add(DEFAULT_HEAP_SIZE_ARGUMENT);
+        expectedProcessArguments.add(DEFAULT_HEAP_SIZE_ARGUMENT_UNDERSCORED);
+        expectedProcessArguments.add(TEST_SCRIPT_FILE_PATH);
+
+        nodeJSProcess.runScript(TEST_SCRIPT_FILE_PATH);
+
+        verify(environmentVariablesReader).readEnvironmentVariables();
+        verify(processExecutor).executeProcess(NODE_PROCESS_NAME, expectedProcessArguments);
+    }
+
+    @Test
+    public void testProcessExitsWithCodeFromProcessExecutor() {
+        when(processExecutor.executeProcess(any(), any())).thenReturn(TEST_EXIT_CODE);
+
+        int actualExitCode = nodeJSProcess.runScript(TEST_SCRIPT_FILE_PATH);
+
+        assertEquals("Unexpected status code returned", TEST_EXIT_CODE, actualExitCode);
+    }
+
+
+}


### PR DESCRIPTION
Currently, the NodeJS process started by the SBG has the default heap size of V8 which in some rare cases may not be enough. For example, large `vendor.js` files may crash Node's V8 with an OOM exception.