### PR TITLE
Update sdk and build tools version to 29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ env:
   - EMULATOR_API_LEVEL=21
   - ANDROID_ABI=armeabi-v7a
   - EMULATOR_NAME=runtime-emu
-  - BUILD_TOOLS=28.0.3
-  - ANDROID_API=28
+  - BUILD_TOOLS=29.0.2
+  - ANDROID_API=29
 
 matrix:
   include:

--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -64,10 +64,10 @@ def METADATA_OUT_PATH = "$projectDir/src/main/assets/metadata"
 def pluginsJarLibraries = new LinkedList<String>()
 def allJarLibraries = new LinkedList<String>()
 
-def computeCompileSdkVersion = { -> project.hasProperty("compileSdk") ? compileSdk : 28 }
-def computeTargetSdkVersion = { -> project.hasProperty("targetSdk") ? targetSdk : 28 }
+def computeCompileSdkVersion = { -> project.hasProperty("compileSdk") ? compileSdk : 29 }
+def computeTargetSdkVersion = { -> project.hasProperty("targetSdk") ? targetSdk : 29 }
 def computeBuildToolsVersion = { ->
-    project.hasProperty("buildToolsVersion") ? buildToolsVersion : "28.0.3"
+    project.hasProperty("buildToolsVersion") ? buildToolsVersion : "29.0.2"
 }
 
 project.ext.selectedBuildType = project.hasProperty("release") ? "release" : "debug"

--- a/test-app/runtime/build.gradle
+++ b/test-app/runtime/build.gradle
@@ -20,7 +20,7 @@ if (useCCache) {
     println "Use CCache build triggered."
 }
 
-project.ext._buildToolsVersion = "28.0.3"
+project.ext._buildToolsVersion = "29.0.2"
 
 android {
     sourceSets {
@@ -32,12 +32,12 @@ android {
             java.srcDirs = [bindingGeneratorSourcePath, defaultSrcPath]
         }
     }
-    compileSdkVersion 28
+    compileSdkVersion 29
     buildToolsVersion project.ext._buildToolsVersion
 
     defaultConfig {
         minSdkVersion 17
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
Related to: https://github.com/NativeScript/android-runtime/issues/1452

Updated targetSdk, compileSdk and build tools version to 29 as it is now in the stable android channel. 