### PR TITLE
Fix cyclic dependency and throw error if missing metadata folder

### DIFF
--- a/test-app/runtime/src/main/cpp/MetadataNode.cpp
+++ b/test-app/runtime/src/main/cpp/MetadataNode.cpp
@@ -11,6 +11,7 @@
 #include "Runtime.h"
 #include <sstream>
 #include <cctype>
+#include <dirent.h>
 #include "ManualInstrumentation.h"
 
 #include "v8.h"
@@ -1698,6 +1699,12 @@ void MetadataNode::BuildMetadata(const string& filesPath) {
 
     string baseDir = filesPath;
     baseDir.append("/metadata");
+
+    DIR* dir = opendir(baseDir.c_str());
+    if(dir == nullptr){
+        throw NativeScriptException(string("metadata folder couldn't be opened!"));
+    }
+
     string nodesFile = baseDir + "/treeNodeStream.dat";
     string namesFile = baseDir + "/treeStringsStream.dat";
     string valuesFile = baseDir + "/treeValueStream.dat";

--- a/test-app/runtime/src/main/cpp/NativeScriptException.cpp
+++ b/test-app/runtime/src/main/cpp/NativeScriptException.cpp
@@ -71,9 +71,10 @@ void NativeScriptException::ReThrowToJava() {
     JEnv env;
 
     auto isolate = Isolate::GetCurrent();
-    auto objectManager = Runtime::GetObjectManager(isolate);
+
 
     if (!m_javaException.IsNull()) {
+        auto objectManager = Runtime::GetObjectManager(isolate);
         auto excClassName = objectManager->GetClassName((jobject) m_javaException);
         if (excClassName == "com/tns/NativeScriptException") {
             ex = m_javaException;
@@ -101,6 +102,7 @@ void NativeScriptException::ReThrowToJava() {
         if (ex == nullptr) {
             ex = static_cast<jthrowable>(env.NewObject(NATIVESCRIPTEXCEPTION_CLASS, NATIVESCRIPTEXCEPTION_JSVALUE_CTOR_ID, (jstring) msg, (jstring)stackTrace, reinterpret_cast<jlong>(m_javascriptException)));
         } else {
+            auto objectManager = Runtime::GetObjectManager(isolate);
             auto excClassName = objectManager->GetClassName(ex);
             if (excClassName != "com/tns/NativeScriptException") {
                 ex = static_cast<jthrowable>(env.NewObject(NATIVESCRIPTEXCEPTION_CLASS, NATIVESCRIPTEXCEPTION_THROWABLE_CTOR_ID, (jstring) msg, (jstring)stackTrace, ex));


### PR DESCRIPTION
Related to: https://github.com/NativeScript/android-runtime/issues/1471

Currently, if the `metadata` folder is missing there is no exception thrown. When checking the behavior around the metadata files reading, a cyclic dependency was found if a `NativeScriptException` is thrown early in the runtime initialization phase. The dependency occurs when trying to get an `ObjectManager` instance and if no object manager is found an exception is thrown. This results in a cycle of crashes. There is a workaround as the object manager is not needed in every case of throwing an exception but only when the `NativeScriptException` contains a nested JS or Java exception.

After this fix, an exception was added in case the metadata folder is missing.