### PR TITLE
Handle android worker classes

### DIFF
--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/Generator.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/Generator.java
@@ -404,9 +404,10 @@ public class Generator {
     private void writeConstructorsToWriter(Writer writer, JavaClass clazz, DataRow dataRow, String generatedClassName, GenericHierarchyView genericHierarchyView) {
         boolean isApplicationClass = androidClassChecker.isApplicationClass(clazz);
         boolean isServiceClass = androidClassChecker.isServiceClass(clazz);
+        boolean isAndroidWorkerClass = androidClassChecker.isAndroidWorkerClass(clazz);
 
         MethodSignatureReifier methodSignatureReifier = new MethodSignatureReifier(genericHierarchyView);
-        MethodsWriter methodsWriter = new MethodsWriterImpl(writer, suppressCallJSMethodExceptions, isApplicationClass, isServiceClass);
+        MethodsWriter methodsWriter = new MethodsWriterImpl(writer, suppressCallJSMethodExceptions, isApplicationClass, isServiceClass, isAndroidWorkerClass);
         ImplementationObjectChecker implementationObjectChecker = new ImplementationObjectCheckerImpl();
 
         List<String> implObjectMethods = Arrays.asList(dataRow.getMethods());
@@ -425,8 +426,9 @@ public class Generator {
     private void writeMethodsToWriter(Writer writer, GenericHierarchyView genericHierarchyView, Map<JavaClass, GenericHierarchyView> interfaceGenericHierarchyViews, JavaClass clazz, List<String> userImplementedMethods, List<JavaClass> userImplementedInterfaces, String packageName) {
         boolean isApplicationClass = androidClassChecker.isApplicationClass(clazz);
         boolean isServiceClass = androidClassChecker.isServiceClass(clazz);
+        boolean isAndroidWorkerClass = androidClassChecker.isAndroidWorkerClass(clazz);
 
-        MethodsWriter methodsWriter = new MethodsWriterImpl(writer, suppressCallJSMethodExceptions, isApplicationClass, isServiceClass);
+        MethodsWriter methodsWriter = new MethodsWriterImpl(writer, suppressCallJSMethodExceptions, isApplicationClass, isServiceClass, isAndroidWorkerClass);
 
         InheritedMethodsCollector inheritedMethodsCollector = new InheritedMethodsCollectorImpl.Builder()
                 .forJavaClass(clazz)

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/parsing/checkers/AndroidClassChecker.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/parsing/checkers/AndroidClassChecker.java
@@ -6,4 +6,5 @@ public interface AndroidClassChecker {
     boolean isActivityClass(JavaClass clazz);
     boolean isApplicationClass(JavaClass clazz);
     boolean isServiceClass(JavaClass javaClass);
+    boolean isAndroidWorkerClass(JavaClass javaClass);
 }

--- a/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/parsing/checkers/impl/AndroidClassCheckerImpl.java
+++ b/test-app/build-tools/static-binding-generator/src/main/java/org/nativescript/staticbindinggenerator/generating/parsing/checkers/impl/AndroidClassCheckerImpl.java
@@ -14,6 +14,7 @@ public class AndroidClassCheckerImpl implements AndroidClassChecker {
 
     private static final String APPLICATION_CLASS_NAME = "android.app.Application";
     private static final String SERVICE_CLASS_NAME = "android.app.Service";
+    private static final String ANDROID_WORKER_CLASS_NAME = "androidx.work.ListenableWorker";
     private static final List<String> ACTIVITY_TYPES = Arrays.asList("android.app.Activity","android.support.v7.app.AppCompatActivity","androidx.appcompat.app.AppCompatActivity");
 
     private final ClassHierarchyParser classHierarchyParser;
@@ -57,5 +58,15 @@ public class AndroidClassCheckerImpl implements AndroidClassChecker {
 
         HierarchyView hierarchyView = classHierarchyParser.getClassHierarchy(javaClass);
         return hierarchyView.getAllParentClassesNames().contains(SERVICE_CLASS_NAME);
+    }
+
+    @Override
+    public boolean isAndroidWorkerClass(JavaClass javaClass) {
+        if(javaClass.getClass().equals(ANDROID_WORKER_CLASS_NAME)){
+            return true;
+        }
+
+        HierarchyView hierarchyView = classHierarchyParser.getClassHierarchy(javaClass);
+        return hierarchyView.getAllParentClassesNames().contains(ANDROID_WORKER_CLASS_NAME);
     }
 }


### PR DESCRIPTION
Currently, extending an Android Worker class fails as when it is started it's on another thread. This commit changes the behavior of extended Android Worker classes to execute them on the main thread. 
This is probably not the best solution but due to the current threading situation in the runtime, it's the most viable fix. 