### PR TITLE
feat: support snapshot libs out of the box

### DIFF
--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -266,7 +266,7 @@ android {
     }
 
     sourceSets.main {
-        jniLibs.srcDir "$projectDir/libs/jni"
+        jniLibs.srcDirs = ["$projectDir/libs/jni", "$projectDir/snapshot-build/build/ndk-build/libs"]
     }
 
     signingConfigs {


### PR DESCRIPTION
### Description

In this way, we avoid the manual step when a snapshot build with `useLibs` is generated.

> This should not affect the default builds as the additional folder does not exist.

### Does your commit message include the wording below to reference a specific issue in this repo?
Related to: https://github.com/NativeScript/nativescript-cli/issues/5049

### Does your pull request have [unit tests]
No, it does not contain any business logic.