### PR TITLE
feat: expose the NDK revision used to build the V8  and the Runtime

### DIFF
--- a/build-artifacts/project-template-gradle/settings.json
+++ b/build-artifacts/project-template-gradle/settings.json
@@ -1,4 +1,5 @@
 {
     "v8Version": "7.7.299.11",
+    "ndkRevision": "20.0.5594570",
     "mksnapshotParams": "--profile_deserialization --turbo_instruction_scheduling --target_os=android --no-native-code-counters"
 }


### PR DESCRIPTION
### Description
The version will be used by the V8 Snapshot Webpack plugin in order to build the V8 Snapshot using the same Android NDK version. 

> The revision could be found in the `source.properties` file from the root NDK folder.

### Does your commit message include the wording below to reference a specific issue in this repo?
Related to: https://github.com/NativeScript/nativescript-cli/issues/5049

### Does your pull request have [unit tests]
No, it does not contain any business logic.