### PR TITLE
Add analytics during build and track kotlin usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -299,6 +299,10 @@ task copyFilesToProjectTemeplate {
             into "$DIST_FRAMEWORK_PATH/app/gradle-helpers"
         }
         copy {
+            from "$TEST_APP_PATH/app/gradle-helpers/AnalyticsCollector.gradle"
+            into "$DIST_FRAMEWORK_PATH/app/gradle-helpers"
+        }
+        copy {
             from "$TEST_APP_PATH/app/gradle-helpers/BuildToolTask.gradle"
             into "$DIST_FRAMEWORK_PATH/app/gradle-helpers"
         }

--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -33,6 +33,7 @@ import static org.gradle.internal.logging.text.StyledTextOutput.Style
 apply plugin: "com.android.application"
 apply from: "gradle-helpers/BuildToolTask.gradle"
 apply from: "gradle-helpers/CustomExecutionLogger.gradle"
+apply from: "gradle-helpers/AnalyticsCollector.gradle"
 
 def enableKotlin = (project.hasProperty("useKotlin") && project.useKotlin == "true")
 
@@ -80,6 +81,14 @@ def computeCompileSdkVersion = { -> project.hasProperty("compileSdk") ? compileS
 def computeTargetSdkVersion = { -> project.hasProperty("targetSdk") ? targetSdk : 29 }
 def computeBuildToolsVersion = { ->
     project.hasProperty("buildToolsVersion") ? buildToolsVersion : "29.0.2"
+}
+
+def enableAnalytics = (project.hasProperty("gatherAnalyticsData") && project.useKotlin == "true")
+def analyticsFilePath = "$rootDir/analytics/build-statistics.json"
+def analyticsCollector = project.ext.AnalyticsCollector.withOutputPath(analyticsFilePath)
+if (enableKotlin && enableAnalytics) {
+    analyticsCollector.markHasUseKotlinPropertyInApp()
+    analyticsCollector.writeAnalyticsFile()
 }
 
 project.ext.selectedBuildType = project.hasProperty("release") ? "release" : "debug"
@@ -800,7 +809,14 @@ task buildMetadata(type: BuildToolTask) {
 
         setOutputs outLogger
 
-        args "android-metadata-generator.jar"
+        def paramz = new ArrayList<String>()
+        paramz.add("android-metadata-generator.jar")
+
+        if(enableAnalytics){
+            paramz.add("analyticsFilePath=$analyticsFilePath")
+        }
+
+        args paramz.toArray()
     }
 }
 

--- a/test-app/app/gradle-helpers/AnalyticsCollector.gradle
+++ b/test-app/app/gradle-helpers/AnalyticsCollector.gradle
@@ -1,0 +1,48 @@
+import groovy.json.JsonBuilder
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.nio.file.Path
+
+class AnalyticsCollector{
+
+    private final String analyticsFilePath
+    private boolean hasUseKotlinPropertyInApp = false
+    private boolean hasKotlinRuntimeClasses = false
+
+    private AnalyticsCollector(String analyticsFilePath){
+        this.analyticsFilePath = analyticsFilePath
+    }
+
+    static AnalyticsCollector withOutputPath(String analyticsFilePath){
+        return new AnalyticsCollector(analyticsFilePath)
+    }
+
+    void markHasUseKotlinPropertyInApp() {
+        hasUseKotlinPropertyInApp = true
+    }
+
+    void writeAnalyticsFile() {
+        def jsonBuilder = new JsonBuilder()
+        def kotlinUsageData = new Object()
+        kotlinUsageData.metaClass.hasUseKotlinPropertyInApp = hasUseKotlinPropertyInApp
+        kotlinUsageData.metaClass.hasKotlinRuntimeClasses = hasKotlinRuntimeClasses
+        jsonBuilder(kotlinUsage: kotlinUsageData)
+        def prettyJson = jsonBuilder.toPrettyString()
+
+
+
+        Path statisticsFilePath = Paths.get(analyticsFilePath)
+
+        if (Files.notExists(statisticsFilePath)) {
+            Files.createDirectories(statisticsFilePath.getParent())
+            Files.createFile(statisticsFilePath)
+        }
+
+        Files.write(statisticsFilePath, prettyJson.getBytes(StandardCharsets.UTF_8))
+
+    }
+}
+
+ext.AnalyticsCollector = AnalyticsCollector

--- a/test-app/build-tools/android-metadata-generator/build.gradle
+++ b/test-app/build-tools/android-metadata-generator/build.gradle
@@ -43,6 +43,7 @@ repositories {
 
 dependencies {
     compile 'org.apache.bcel:bcel:6.2'
+    compile 'com.google.code.gson:gson:2.8.5'
     compile group: 'org.jetbrains.kotlinx', name: 'kotlinx-metadata-jvm', version: '0.1.0'
     compile files("./src/libs/dx.jar")
 }

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/Generator.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/Generator.java
@@ -1,5 +1,7 @@
 package com.telerik.metadata;
 
+import com.telerik.metadata.analytics.AnalyticsConfiguration;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -8,18 +10,20 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.security.InvalidParameterException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public class Generator {
 
-    public static final String MDG_OUTPUT_DIR = "mdg-output-dir.txt";
-    public static final String MDG_JAVA_DEPENDENCIES = "mdg-java-dependencies.txt";
+    private static final String ANALYTICS_ARGUMENT_BEGINNING = "analyticsFilePath=";
+    private static final String MDG_OUTPUT_DIR = "mdg-output-dir.txt";
+    private static final String MDG_JAVA_DEPENDENCIES = "mdg-java-dependencies.txt";
 
     /**
      * @param args
      */
     public static void main(String[] args) {
+        enableAnalyticsBasedOnArgs(args);
+
         try {
             String metadataOutputDir;
             List<String> params;
@@ -51,6 +55,15 @@ public class Generator {
             System.err.println(String.format("Error executing Metadata Generator: %s", ex.getMessage()));
             ex.printStackTrace(System.out);
             System.exit(1);
+        }
+    }
+
+    private static void enableAnalyticsBasedOnArgs(String[] args){
+        for (String arg : args) {
+            if (arg.startsWith(ANALYTICS_ARGUMENT_BEGINNING)) {
+                String filePath = arg.replace(ANALYTICS_ARGUMENT_BEGINNING, "");
+                AnalyticsConfiguration.enableAnalytics(filePath);
+            }
         }
     }
 

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/analytics/AnalyticsCollector.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/analytics/AnalyticsCollector.java
@@ -1,0 +1,6 @@
+package com.telerik.metadata.analytics;
+
+public interface AnalyticsCollector {
+
+    void markHasKotlinRuntimeClassesIfNotMarkedAlready();
+}

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/analytics/AnalyticsCollectorProvider.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/analytics/AnalyticsCollectorProvider.java
@@ -1,0 +1,24 @@
+package com.telerik.metadata.analytics;
+
+import com.telerik.metadata.analytics.impl.EnabledAnalyticsCollectorImpl;
+import com.telerik.metadata.analytics.impl.NoOpAnalyticsCollector;
+
+public class AnalyticsCollectorProvider {
+    private static final AnalyticsCollectorProvider ourInstance = new AnalyticsCollectorProvider();
+
+    public static AnalyticsCollectorProvider getInstance() {
+        return ourInstance;
+    }
+
+    private AnalyticsCollectorProvider() {
+    }
+
+    public AnalyticsCollector provideAnalyticsCollector() {
+        if (AnalyticsConfiguration.areAnalyticsEnabled()) {
+            String analyticsFilePath = AnalyticsConfiguration.getAnalyticsFilePath();
+            return new EnabledAnalyticsCollectorImpl(analyticsFilePath);
+        } else {
+            return new NoOpAnalyticsCollector();
+        }
+    }
+}

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/analytics/AnalyticsConfiguration.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/analytics/AnalyticsConfiguration.java
@@ -1,0 +1,21 @@
+package com.telerik.metadata.analytics;
+
+public final class AnalyticsConfiguration {
+    private static String analyticsFilePath;
+    private static boolean areAnalyticsEnabled;
+
+    private AnalyticsConfiguration(){}
+
+    public static void enableAnalytics(String analyticsJsonFilePath){
+        analyticsFilePath = analyticsJsonFilePath;
+        areAnalyticsEnabled = true;
+    }
+
+    static boolean areAnalyticsEnabled(){
+        return areAnalyticsEnabled;
+    }
+
+    static String getAnalyticsFilePath(){
+        return analyticsFilePath;
+    }
+}

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/analytics/impl/EnabledAnalyticsCollectorImpl.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/analytics/impl/EnabledAnalyticsCollectorImpl.java
@@ -1,0 +1,91 @@
+package com.telerik.metadata.analytics.impl;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.telerik.metadata.analytics.AnalyticsCollector;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public final class EnabledAnalyticsCollectorImpl implements AnalyticsCollector {
+
+    private static final String HAS_KOTLIN_RUNTIME_CLASSES_JSON_PROPERTY_NAME = "hasKotlinRuntimeClasses";
+    private static final String HAS_USE_KOTLIN_PROPERTY_IN_APP_JSON_PROPERTY_NAME = "hasUseKotlinPropertyInApp";
+    private static final String KOTLIN_USAGE_JSON_PROPERTY_NAME = "kotlinUsage";
+
+
+    private final String analyticsFilePath;
+    private final Gson gson;
+    private boolean hasMarked;
+
+    public static void main(String... args) {
+        EnabledAnalyticsCollectorImpl a = new EnabledAnalyticsCollectorImpl("/Users/vmutafov/work/android_runtime_release/android-runtime/test-app/analytics/build-statistics.json");
+        a.markHasKotlinRuntimeClassesIfNotMarkedAlready();
+    }
+
+    public EnabledAnalyticsCollectorImpl(String analyticsFilePath) {
+        this.analyticsFilePath = analyticsFilePath;
+        this.gson = new GsonBuilder().setPrettyPrinting().create();
+        this.hasMarked = false;
+    }
+
+    @Override
+    public void markHasKotlinRuntimeClassesIfNotMarkedAlready() {
+        if (!hasMarked) {
+
+            try {
+                Path statisticsFilePath = Paths.get(analyticsFilePath);
+                String json;
+
+                if (Files.notExists(statisticsFilePath)) {
+                    Files.createDirectories(statisticsFilePath.getParent());
+                    Files.createFile(statisticsFilePath);
+
+                    JsonObject kotlinUsageObject = createNewKotlinUsageJsonObject(true);
+                    json = gson.toJson(kotlinUsageObject);
+                } else {
+                    byte[] fileContent = Files.readAllBytes(statisticsFilePath);
+                    String statisticsJson = new String(fileContent, StandardCharsets.UTF_8);
+                    JsonElement modifiedStatisticsJson = modifyExistingAnalyticsJsonObject(statisticsJson, true);
+                    json = gson.toJson(modifiedStatisticsJson);
+                }
+
+                Files.write(statisticsFilePath, json.getBytes(StandardCharsets.UTF_8));
+                hasMarked = true;
+            } catch (Exception e) {
+                System.out.println(e.getMessage()); // do not fail the build if analytics collection fails
+            }
+        }
+    }
+
+    private JsonObject createNewKotlinUsageJsonObject(boolean hasKotlinRuntimeClasses) {
+        JsonObject jsonObject = new JsonObject();
+
+        JsonObject kotlinUsageObject = new JsonObject();
+        kotlinUsageObject.addProperty(HAS_KOTLIN_RUNTIME_CLASSES_JSON_PROPERTY_NAME, hasKotlinRuntimeClasses);
+
+        jsonObject.add(KOTLIN_USAGE_JSON_PROPERTY_NAME, kotlinUsageObject);
+
+        return jsonObject;
+    }
+
+    private JsonElement modifyExistingAnalyticsJsonObject(String json, boolean hasKotlinRuntimeClasses) {
+        JsonElement jsonElement = new Gson().fromJson(json, JsonElement.class);
+        JsonObject jsonObject = jsonElement.getAsJsonObject();
+
+        if (jsonObject.has(KOTLIN_USAGE_JSON_PROPERTY_NAME)) {
+            JsonObject kotlinUsageObject = jsonObject.getAsJsonObject(KOTLIN_USAGE_JSON_PROPERTY_NAME);
+            kotlinUsageObject.addProperty(HAS_KOTLIN_RUNTIME_CLASSES_JSON_PROPERTY_NAME, hasKotlinRuntimeClasses);
+
+            if(!kotlinUsageObject.has(HAS_USE_KOTLIN_PROPERTY_IN_APP_JSON_PROPERTY_NAME)){
+                kotlinUsageObject.addProperty(HAS_USE_KOTLIN_PROPERTY_IN_APP_JSON_PROPERTY_NAME, false);
+            }
+        }
+
+        return jsonElement;
+    }
+}

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/analytics/impl/NoOpAnalyticsCollector.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/analytics/impl/NoOpAnalyticsCollector.java
@@ -1,0 +1,11 @@
+package com.telerik.metadata.analytics.impl;
+
+import com.telerik.metadata.analytics.AnalyticsCollector;
+
+public final class NoOpAnalyticsCollector implements AnalyticsCollector {
+
+    @Override
+    public void markHasKotlinRuntimeClassesIfNotMarkedAlready() {
+        // used when analytics are disabled
+    }
+}

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/bcl/JarFile.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/bcl/JarFile.java
@@ -1,7 +1,14 @@
 package com.telerik.metadata.bcl;
 
 import com.telerik.metadata.ClassMapProvider;
+import com.telerik.metadata.analytics.AnalyticsCollector;
+import com.telerik.metadata.analytics.AnalyticsCollectorProvider;
 import com.telerik.metadata.desc.ClassDescriptor;
+import com.telerik.metadata.kotlin.classes.KotlinClassMetadataParser;
+import com.telerik.metadata.kotlin.classes.impl.KotlinClassMetadataParserImpl;
+
+import org.apache.bcel.classfile.ClassFormatException;
+import org.apache.bcel.classfile.ClassParser;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -10,17 +17,16 @@ import java.util.Map;
 import java.util.jar.JarInputStream;
 import java.util.zip.ZipEntry;
 
-import org.apache.bcel.classfile.ClassFormatException;
-import org.apache.bcel.classfile.ClassParser;
-
 public class JarFile implements ClassMapProvider {
     private final String path;
     private final Map<String, ClassDescriptor> classMap;
+    private static final KotlinClassMetadataParser kotlinClassMetadataParser = new KotlinClassMetadataParserImpl();
+    private static final AnalyticsCollector analyticsCollector = AnalyticsCollectorProvider.getInstance().provideAnalyticsCollector();
     private static final String CLASS_EXT = ".class";
 
     private JarFile(String path) {
         this.path = path;
-        this.classMap = new HashMap<String, ClassDescriptor>();
+        this.classMap = new HashMap<>();
     }
 
     public String getPath() {
@@ -32,7 +38,7 @@ public class JarFile implements ClassMapProvider {
     }
 
     public static JarFile readJar(String path) throws ClassFormatException,
-        IOException {
+            IOException {
         JarFile jar;
         JarInputStream jis = null;
         try {
@@ -45,10 +51,11 @@ public class JarFile implements ClassMapProvider {
                 String name = ze.getName();
                 if (name.endsWith(CLASS_EXT)) {
                     name = name
-                           .substring(0, name.length() - CLASS_EXT.length())
-                           .replace('/', '.');
+                            .substring(0, name.length() - CLASS_EXT.length())
+                            .replace('/', '.');
                     ClassParser cp = new ClassParser(jis, name);
                     ClassDescriptor clazz = new ClassInfo(cp.parse());
+                    markIfKotlinClass(clazz);
                     jar.classMap.put(name, clazz);
                 }
             }
@@ -58,5 +65,11 @@ public class JarFile implements ClassMapProvider {
             }
         }
         return jar;
+    }
+
+    private static void markIfKotlinClass(ClassDescriptor classDescriptor) {
+        if (kotlinClassMetadataParser.wasKotlinClass(classDescriptor)) {
+            analyticsCollector.markHasKotlinRuntimeClassesIfNotMarkedAlready();
+        }
     }
 }

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/kotlin/classes/KotlinClassMetadataParser.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/kotlin/classes/KotlinClassMetadataParser.java
@@ -7,6 +7,7 @@ import java.util.List;
 import kotlinx.metadata.KmProperty;
 
 public interface KotlinClassMetadataParser {
+    boolean wasKotlinClass(ClassDescriptor clazz);
     boolean wasKotlinCompanionObject(ClassDescriptor clazz, ClassDescriptor possibleCompanion);
     List<KmProperty> getKotlinProperties(ClassDescriptor clazz);
 }

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/kotlin/classes/impl/KotlinClassMetadataParserImpl.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/kotlin/classes/impl/KotlinClassMetadataParserImpl.java
@@ -18,6 +18,11 @@ import kotlinx.metadata.jvm.KotlinClassMetadata;
 public class KotlinClassMetadataParserImpl implements KotlinClassMetadataParser {
 
     @Override
+    public boolean wasKotlinClass(ClassDescriptor clazz) {
+        return clazz.getKotlinClassMetadataAnnotation().isPresent();
+    }
+
+    @Override
     public boolean wasKotlinCompanionObject(ClassDescriptor clazz, ClassDescriptor possibleCompanion) {
         Optional<KotlinClassMetadataAnnotation> kotlinClassMetadataAnnotationOptional = clazz.getKotlinClassMetadataAnnotation();
         if (!kotlinClassMetadataAnnotationOptional.isPresent()) {


### PR DESCRIPTION
Related to: https://github.com/NativeScript/android-runtime/issues/1501

Add gradle build and MDG analytics if the gradle property `gatherAnalyticsData` is `true`. 

Currently, collected analytics are about Kotlin usage in apps.