### PR TITLE
set "stack" property of error to js stack trace

### DIFF
--- a/test-app/app/src/main/java/com/tns/NativeScriptUncaughtExceptionHandler.java
+++ b/test-app/app/src/main/java/com/tns/NativeScriptUncaughtExceptionHandler.java
@@ -31,7 +31,7 @@ public class NativeScriptUncaughtExceptionHandler implements UncaughtExceptionHa
                 Runtime runtime = Runtime.getCurrentRuntime();
 
                 if (runtime != null) {
-                    runtime.passUncaughtExceptionToJs(ex, ex.getMessage(), stackTraceErrorMessage);
+                    runtime.passUncaughtExceptionToJs(ex, ex.getMessage(), Runtime.getJSStackTrace(ex), stackTraceErrorMessage);
                 }
             } catch (Throwable t) {
                 if (Util.isDebuggableApp(context)) {

--- a/test-app/runtime/src/main/cpp/Runtime.cpp
+++ b/test-app/runtime/src/main/cpp/Runtime.cpp
@@ -368,7 +368,7 @@ bool Runtime::TryCallGC() {
     return success;
 }
 
-void Runtime::PassExceptionToJsNative(JNIEnv* env, jobject obj, jthrowable exception, jstring message, jstring stackTrace, jboolean isDiscarded) {
+void Runtime::PassExceptionToJsNative(JNIEnv* env, jobject obj, jthrowable exception, jstring message, jstring fullStackTrace, jstring jsStackTrace, jboolean isDiscarded) {
     auto isolate = m_isolate;
 
     string errMsg = ArgConverter::jstringToString(message);
@@ -391,7 +391,10 @@ void Runtime::PassExceptionToJsNative(JNIEnv* env, jobject obj, jthrowable excep
     //create a JS error object
     auto context = isolate->GetCurrentContext();
     errObj->Set(context, V8StringConstants::GetNativeException(isolate), nativeExceptionObject);
-    errObj->Set(context, V8StringConstants::GetStackTrace(isolate), ArgConverter::jstringToV8String(isolate, stackTrace));
+    errObj->Set(context, V8StringConstants::GetStackTrace(isolate), ArgConverter::jstringToV8String(isolate, fullStackTrace));
+    if (jsStackTrace != NULL) {
+        errObj->Set(context, V8StringConstants::GetStack(isolate), ArgConverter::jstringToV8String(isolate, jsStackTrace));
+    }
 
     //pass err to JS
     NativeScriptException::CallJsFuncWithErr(errObj, isDiscarded);

--- a/test-app/runtime/src/main/cpp/Runtime.h
+++ b/test-app/runtime/src/main/cpp/Runtime.h
@@ -52,7 +52,7 @@ class Runtime {
         void AdjustAmountOfExternalAllocatedMemory();
         bool NotifyGC(JNIEnv* env, jobject obj);
         bool TryCallGC();
-        void PassExceptionToJsNative(JNIEnv* env, jobject obj, jthrowable exception, jstring message, jstring stackTrace, jboolean isDiscarded);
+        void PassExceptionToJsNative(JNIEnv* env, jobject obj, jthrowable exception, jstring message, jstring fullStackTrace, jstring jsStackTrace, jboolean isDiscarded);
         void PassUncaughtExceptionFromWorkerToMainHandler(v8::Local<v8::String> message, v8::Local<v8::String> stackTrace, v8::Local<v8::String> filename, int lineno);
         void ClearStartupData(JNIEnv* env, jobject obj);
         void DestroyRuntime();

--- a/test-app/runtime/src/main/cpp/V8StringConstants.cpp
+++ b/test-app/runtime/src/main/cpp/V8StringConstants.cpp
@@ -51,6 +51,12 @@ Local<String> V8StringConstants::GetNativeException(Isolate* isolate) {
     return Local<String>::New(isolate, *consts->NATIVE_EXCEPTION_PERSISTENT);
 }
 
+Local<String> V8StringConstants::GetStack(Isolate* isolate) {
+    auto consts = GetConstantsForIsolate(isolate);
+
+    return Local<String>::New(isolate, *consts->STACK_PERSISTENT);
+}
+
 Local<String> V8StringConstants::GetStackTrace(Isolate* isolate) {
     auto consts = GetConstantsForIsolate(isolate);
 
@@ -130,6 +136,7 @@ const string V8StringConstants::NULL_NODE_NAME = "nullNode";
 const string V8StringConstants::IS_PROTOTYPE_IMPLEMENTATION_OBJECT = "__isPrototypeImplementationObject";
 const string V8StringConstants::NATIVE_EXCEPTION = "nativeException";
 const string V8StringConstants::STACK_TRACE = "stackTrace";
+const string V8StringConstants::STACK = "stack";
 const string V8StringConstants::LONG_NUMBER = "NativeScriptLongNumber";
 const string V8StringConstants::PROTOTYPE = "prototype";
 const string V8StringConstants::SUPER = "super";

--- a/test-app/runtime/src/main/cpp/V8StringConstants.h
+++ b/test-app/runtime/src/main/cpp/V8StringConstants.h
@@ -21,6 +21,8 @@ class V8StringConstants {
 
         static v8::Local<v8::String> GetNativeException(v8::Isolate* isolate);
 
+        static v8::Local<v8::String> GetStack(v8::Isolate* isolate);
+
         static v8::Local<v8::String> GetStackTrace(v8::Isolate* isolate);
 
         static v8::Local<v8::String> GetLongNumber(v8::Isolate* isolate);
@@ -52,6 +54,7 @@ class V8StringConstants {
         static const std::string NULL_NODE_NAME;
         static const std::string IS_PROTOTYPE_IMPLEMENTATION_OBJECT;
         static const std::string NATIVE_EXCEPTION;
+        static const std::string STACK;
         static const std::string STACK_TRACE;
         static const std::string LONG_NUMBER;
         static const std::string PROTOTYPE;
@@ -96,6 +99,8 @@ class V8StringConstants {
                 str = String::NewFromUtf8(isolate, NATIVE_EXCEPTION.c_str()).ToLocalChecked();
                 NATIVE_EXCEPTION_PERSISTENT = new Persistent<String>(isolate, str);
 
+                str = String::NewFromUtf8(isolate, STACK.c_str()).ToLocalChecked();
+                STACK_PERSISTENT = new Persistent<String>(isolate, str);
 
                 str = String::NewFromUtf8(isolate, STACK_TRACE.c_str()).ToLocalChecked();
                 STACK_TRACE_PERSISTENT = new Persistent<String>(isolate, str);
@@ -151,6 +156,7 @@ class V8StringConstants {
                 NULL_NODE_NAME_PERSISTENT->Reset();
                 IS_PROTOTYPE_IMPLEMENTATION_OBJECT_PERSISTENT->Reset();
                 NATIVE_EXCEPTION_PERSISTENT->Reset();
+                STACK_PERSISTENT->Reset();
                 STACK_TRACE_PERSISTENT->Reset();
                 LONG_NUMBER_PERSISTENT->Reset();
                 PROTOTYPE_PERSISTENT->Reset();
@@ -171,6 +177,7 @@ class V8StringConstants {
             v8::Persistent<v8::String>* NULL_NODE_NAME_PERSISTENT;
             v8::Persistent<v8::String>* IS_PROTOTYPE_IMPLEMENTATION_OBJECT_PERSISTENT;
             v8::Persistent<v8::String>* NATIVE_EXCEPTION_PERSISTENT;
+            v8::Persistent<v8::String>* STACK_PERSISTENT;
             v8::Persistent<v8::String>* STACK_TRACE_PERSISTENT;
             v8::Persistent<v8::String>* LONG_NUMBER_PERSISTENT;
             v8::Persistent<v8::String>* PROTOTYPE_PERSISTENT;

--- a/test-app/runtime/src/main/cpp/com_tns_Runtime.cpp
+++ b/test-app/runtime/src/main/cpp/com_tns_Runtime.cpp
@@ -245,7 +245,7 @@ extern "C" JNIEXPORT void Java_com_tns_Runtime_unlock(JNIEnv* env, jobject obj, 
     }
 }
 
-extern "C" JNIEXPORT void Java_com_tns_Runtime_passExceptionToJsNative(JNIEnv* env, jobject obj, jint runtimeId, jthrowable exception, jstring message, jstring stackTrace, jboolean isDiscarded) {
+extern "C" JNIEXPORT void Java_com_tns_Runtime_passExceptionToJsNative(JNIEnv* env, jobject obj, jint runtimeId, jthrowable exception, jstring message, jstring fullStackTrace, jstring jsStackTrace, jboolean isDiscarded) {
     auto runtime = TryGetRuntime(runtimeId);
     if (runtime == nullptr) {
         return;
@@ -256,7 +256,7 @@ extern "C" JNIEXPORT void Java_com_tns_Runtime_passExceptionToJsNative(JNIEnv* e
     v8::HandleScope handleScope(isolate);
 
     try {
-        runtime->PassExceptionToJsNative(env, obj, exception, message, stackTrace, isDiscarded);
+        runtime->PassExceptionToJsNative(env, obj, exception, message, fullStackTrace, jsStackTrace, isDiscarded);
     } catch (NativeScriptException& e) {
         e.ReThrowToJava();
     } catch (std::exception e) {


### PR DESCRIPTION
Related to #1445

Set the thrown javascript exception's "stack" property to the JS only stack trace as this is a JS error and works in the same way in iOS. The full stack trace (JS + Native) can be found in the "stackTrace" property