### PR TITLE
Add Kotlin extension functions support

### DIFF
--- a/test-app/app/src/main/assets/app/mainpage.js
+++ b/test-app/app/src/main/assets/app/mainpage.js
@@ -59,3 +59,4 @@ require("./tests/kotlin/properties/testPropertiesSupport");
 require("./tests/kotlin/delegation/testDelegationSupport");
 require("./tests/kotlin/objects/testObjectsSupport");
 require("./tests/kotlin/functions/testTopLevelFunctionsSupport");
+require("./tests/kotlin/extensions/testExtensionFunctionsSupport")

--- a/test-app/app/src/main/assets/app/tests/kotlin/extensions/testExtensionFunctionsSupport.js
+++ b/test-app/app/src/main/assets/app/tests/kotlin/extensions/testExtensionFunctionsSupport.js
@@ -1,0 +1,119 @@
+describe("Tests Kotlin extension functions support", function () {
+
+    it("Test Kotlin extension functions with no arguments and no return value should work", function () {
+        var obj = new java.lang.Object();
+        var hasException = false;
+
+        try {
+            obj.extensionFunctionWithNoArgumentsAndNoReturnValue();
+        } catch (error) {
+            hasException = true;
+        }
+
+        expect(hasException).toBe(false);
+    });
+
+    it("Test Kotlin extension functions with no arguments should work", function () {
+        var obj = new java.lang.Object();
+        var hasException = false;
+
+        try {
+            var res = obj.extensionFunctionWithNoArgumentsAndStringReturnValue();
+            expect(res).toBe("some data");
+        } catch (error) {
+            hasException = true;
+        }
+
+        expect(hasException).toBe(false);
+    });
+
+    it("Test Kotlin extension functions with one primitive argument and no return value should work", function () {
+        var obj = new java.lang.Object();
+        var hasException = false;
+
+        try {
+            obj.extensionFunctionWithOnePrimitiveArgumentAndNoReturnValue(42);
+        } catch (error) {
+            hasException = true;
+        }
+
+        expect(hasException).toBe(false);
+    });
+
+    it("Test Kotlin extension functions with one primitive argument should work", function () {
+        var obj = new java.lang.Object();
+        var hasException = false;
+
+        try {
+            var res = obj.extensionFunctionWithOnePrimitiveArgumentAndStringReturnValue(42);
+            expect(res).toBe("some data 42");
+        } catch (error) {
+            hasException = true;
+        }
+
+        expect(hasException).toBe(false);
+    });
+
+    it("Test Kotlin extension functions with one object type argument and no return value should work", function () {
+        var obj = new java.lang.Object();
+        var arg = new java.lang.Object();
+        var hasException = false;
+
+        try {
+            obj.extensionFunctionWithOneObjectTypeArgumentAndNoReturnValue(arg);
+        } catch (error) {
+            hasException = true;
+        }
+
+        expect(hasException).toBe(false);
+    });
+
+    it("Test Kotlin extension functions with one object type argument should work", function () {
+        var obj = new java.lang.Object();
+        var arg = new java.lang.Object();
+        var argAsString = arg.toString();
+        var hasException = false;
+
+        try {
+            var res = obj.extensionFunctionWithOneObjectTypeArgumentAndStringReturnValue(arg);
+            expect(res).toBe("some data " + argAsString);
+        } catch (error) {
+            hasException = true;
+        }
+
+        expect(hasException).toBe(false);
+    });
+
+    it("Test Kotlin extension functions with multiple object type arguments and no return value should work", function () {
+        var obj = new java.lang.Object();
+        var arg1 = new java.lang.Object();
+        var arg2 = "test";
+        var hasException = false;
+
+        try {
+            obj.extensionFunctionWithMultipleObjectTypeArgumentsAndNoReturnValue(arg1, arg2);
+        } catch (error) {
+            hasException = true;
+        }
+
+        expect(hasException).toBe(false);
+    });
+
+    it("Test Kotlin extension functions with multiple object type arguments should work", function () {
+        var obj = new java.lang.Object();
+        var arg1 = new java.lang.Object();
+        var arg1AsString = arg1.toString();
+        var arg2 = "test";
+        var hasException = false;
+
+        try {
+            var res = obj.extensionFunctionWithMultipleObjectTypeArgumentsAndStringReturnValue(arg1, arg2);
+            expect(res).toBe("some data " + arg1AsString + " test");
+        } catch (error) {
+            hasException = true;
+        }
+
+        expect(hasException).toBe(false);
+    });
+
+});

--- a/test-app/app/src/main/assets/app/tests/numericConversionTests.js
+++ b/test-app/app/src/main/assets/app/tests/numericConversionTests.js
@@ -3,248 +3,248 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 			var myCustomEquality = function(first, second) {
 				return first == second;
 			};
-			
+
 			beforeEach(function() {
 				jasmine.addCustomEqualityTester(myCustomEquality);
 			});
-			
+
 			it("TestCreateInstanceWithConstructorResolutionWithNumberLiteral", function () {
-				
+
 				__log("TEST: TestCreateInstanceWithConstructorResolutionWithNumberLiteral");
-				
+
 				var n = new com.tns.tests.NumericConversionTest(123);
-				
+
 				var s = n.getInit();
-		
+
 				expect(s).toBe("byte");
 			});
-		
+
 			it("TestCreateInstanceWithConstructorResolutionWithCastFunctions", function () {
-				
+
 				__log("TEST: TestCreateInstanceWithConstructorResolutionWithCastFunctions");
-				
+
 				var n1 = new com.tns.tests.NumericConversionTest(byte(123));
 				var s1 = n1.getInit();
 				expect(s1).toBe("byte");
-				
+
 				var n2 = new com.tns.tests.NumericConversionTest(short(123));
 				var s2 = n2.getInit();
 				expect(s2).toBe("byte");
-				
+
 				var n3 = new com.tns.tests.NumericConversionTest(long(123));
 				var s3 = n3.getInit();
 				expect(s3).toBe("byte");
 			});
-			
+
 			it("TestCreateInstanceWithConstructorResolutionWithValuesFromJavaCalls", function () {
-				
+
 				__log("TEST: TestCreateInstanceWithConstructorResolutionWithValuesFromJavaCalls");
-				
+
 				var b = java.lang.Byte.parseByte("123");
 				var n1 = new com.tns.tests.NumericConversionTest(b);
 				var s1 = n1.getInit();
 				expect(s1).toBe("byte");
-				
+
 				var i = java.lang.Integer.parseInt("12345");
 				var n2 = new com.tns.tests.NumericConversionTest(i);
 				var s2 = n2.getInit();
 				expect(s2).toBe("byte");
 			});
-			
+
 			it("TestCreateInstanceWithConstructorResolutionWithPromotingValueUp", function () {
-		
+
 				__log("TEST: TestCreateInstanceWithConstructorResolutionWithPromotingValueUp");
-				
+
 				var n = new com.tns.tests.NumericConversionTest(null, short(1));
 				var s = n.getInit();
 				expect(s).toBe("Object,int");
 			});
-			
+
 			it("TestCreateInstanceWithConstructorResolutionWithPromotingValueDown", function () {
-				
+
 				__log("TEST: TestCreateInstanceWithConstructorResolutionWithPromotingValueDown");
-				
+
 				var n = new com.tns.tests.NumericConversionTest(null, null, long(1));
 				var s = n.getInit();
 				expect(s).toBe("Object,Object,short");
 			});
-			
+
 			it("TestCallMethodWithResolutionWithPromotingValueUp", function () {
-				
+
 				__log("TEST: TestCallMethodWithResolutionWithPromotingValueUp");
-				
+
 				var n = new com.tns.tests.NumericConversionTest();
 				var s = n.method1(byte(1));
 				expect(s).toBe("short=1");
 			});
-			
+
 			it("TestCallMethodWithResolutionWithPromotingValueDown", function () {
-				
+
 				__log("TEST: TestCallMethodWithResolutionWithPromotingValueDown");
-				
+
 				var n = new com.tns.tests.NumericConversionTest();
 				var s = n.method1(1);
 				expect(s).toBe("short=1");
-				
+
 				var n1 = new com.tns.tests.NumericConversionTest();
 				var s1 = n1.method1(long((1 << 16) + 2));
 				expect(s1).toBe("short=2");
 			});
-			
+
 			it("TestLongCastToFloatConversionWhenThereIsDoubleOverload", function () {
-				
+
 				__log("TEST: TestLongCastToFloatConversionWhenThereIsDoubleOverload");
-				
+
 				var n = new com.tns.tests.NumericConversionTest();
 				var s = n.method2(long(65536 + 2));
 				expect(s).toBe("float=65538.0");
 			});
-			
+
 			it("TestByteCastToFloatConversionWhenThereIsDoubleOverload", function () {
-				
+
 				__log("TEST: TestByteCastToFloatConversionWhenThereIsDoubleOverload");
-				
+
 				var n = new com.tns.tests.NumericConversionTest();
 				var s = n.method2(byte(65536 + 2));
 				expect(s).toBe("float=2.0");
 			});
-			
+
 			it("TestShortCastToFloatConversionWhenThereIsDoubleOverload", function () {
-				
+
 				__log("TEST: TestShortCastToFloatConversionWhenThereIsDoubleOverload");
-				
+
 				var n = new com.tns.tests.NumericConversionTest();
 				var s = n.method2(short(65536 + 2));
 				expect(s).toBe("float=2.0");
 			});
-			
+
 			it("TestDoubleCastWhenThereIsDoubleOverload", function () {
-				
+
 				__log("TEST: TestDoubleCastWhenThereIsDoubleOverload");
-				
+
 				var n = new com.tns.tests.NumericConversionTest();
 				var s = n.method2(double(65536 + 2));
 				expect(s).toBe("double=65538.0");
 			});
-			
+
 			it("TestNumberExpressionToFloatConversionWhenThereIsDoubleOverload", function () {
-				
+
 				__log("TEST: TestNumberExpressionToFloatConversionWhenThereIsDoubleOverload");
-				
+
 				var n = new com.tns.tests.NumericConversionTest();
 				var s = n.method2(65536 + 2);
 				expect(s).toBe("float=65538.0");
 				expect(true).toEqual(true);
 			});
-			
+
 			it("TestDoubleCastToLongConversionWhenThereIsShortOverload", function () {
-		
+
 				__log("TEST: TestDoubleCastToLongConversionWhenThereIsShortOverload");
-				
+
 				var n = new com.tns.tests.NumericConversionTest();
 				var s = n.method3(double(65536 + 2));
 				expect(s).toBe("long=65538");
 			});
-			
+
 			it("TestFloatCastToLongConversionWhenThereIsShortOverload", function () {
-				
+
 				__log("TEST: TestFloatCastToLongConversionWhenThereIsShortOverload");
-				
+
 				var n = new com.tns.tests.NumericConversionTest();
 				var s = n.method3(float(65536 + 2));
 				expect(s).toBe("long=65538");
 			});
-			
+
 			it("TestFloatCastToShortConversionWhenThereIsObjectOverload", function () {
-				
+
 				__log("TEST: TestFloatCastToShortConversionWhenThereIsObjectOverload");
-				
+
 				var n = new com.tns.tests.NumericConversionTest();
 				var s = n.method4(float(65536 + 2));
 				expect(s).toBe("short=2");
 			});
-			
+
 			it("TestByteCastToShortConversionWhenThereIsObjectOverload", function () {
-				
+
 				__log("TEST: TestByteCastToShortConversionWhenThereIsObjectOverload");
-				
+
 				var n = new com.tns.tests.NumericConversionTest();
 				var s = n.method4(byte(65536 + 2));
 				expect(s).toBe("short=2");
 			});
-			
+
 			it("TestResolveMethodWithByteCast", function () {
-				
+
 				__log("TEST: TestResolveMethodWithByteCast");
-				
+
 				var n = new com.tns.tests.NumericConversionTest();
 				var s = n.method5(byte(65536 + 123));
 				expect(s).toBe("byte=123");
 			});
-			
+
 			it("TestResolveMethodWithShortCast", function () {
-				
+
 				__log("TEST: TestResolveMethodWithShortCast");
-				
+
 				var n = new com.tns.tests.NumericConversionTest();
 				var s = n.method5(short(65536 + 1234));
 				expect(s).toBe("short=1234");
 			});
-			
+
 			it("TestResolveMethodWithoutCastFunction", function () {
-				
+
 				__log("TEST: TestResolveMethodWithoutCastFunction");
-				
+
 				var n = new com.tns.tests.NumericConversionTest();
 				var s = n.method5(123456);
 				expect(s).toBe("int=123456");
 			});
-			
+
 			it("TestResolveMethodWithLongCast", function () {
-				
+
 				__log("TEST: TestResolveMethodWithLongCast");
-				
+
 				var n = new com.tns.tests.NumericConversionTest();
 				var s = n.method5(long("123456789012"));
 				expect(s).toBe("long=123456789012");
 			});
-			
+
 			it("TestResolveMethodWithFloatCast", function () {
-				
+
 				__log("TEST: TestResolveMethodWithFloatCast");
-				
+
 				var n = new com.tns.tests.NumericConversionTest();
 				var s = n.method5(float(1.23));
 				expect(s).toBe("float=1.23");
 			});
-			
+
 			it("TestResolveMethodWithDoubleCast", function () {
-				
+
 				__log("TEST: TestResolveMethodWithDoubleCast");
-				
+
 				var n = new com.tns.tests.NumericConversionTest();
 				var s = n.method5(double(1));
 				expect(s).toBe("double=1.0");
 			});
-			
+
 			it("TestResolveIntMethodWithNumberObjectWithIntArgument", function () {
-				
+
 				__log("TEST: TestResolveIntMethodWithNumberObjectWithIntArgument");
-				
+
 				var n = new com.tns.tests.NumericConversionTest();
 				var s = n.method5(new Number(1));
 				expect(s).toBe("int=1");
 			});
-			
+
 			it("TestResolveIntMethodWithNumberObjectWithDoubleArgument", function () {
-				
+
 				__log("TEST: TestResolveIntMethodWithNumberObjectWithDoubleArgument");
-				
+
 				var n = new com.tns.tests.NumericConversionTest();
 				var s = n.method5(new Number(1.23));
 				expect(s).toBe("float=1.23"); // changed to float=1.23 because of new casting (double, and float not just double)
 			});
-			
+
 			// long cast
 			it("TestIfNeedsToReturnLongItAlwaysReturnsLong", function() {
 
@@ -258,7 +258,7 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 
 				var instance = new N();
 
-				var exceptionCaught = false, 
+				var exceptionCaught = false,
 					exceptionThrown = true;
 				try {
 					var value = com.tns.tests.NumericConversions.callHasToReturnLong(instance, 1234);
@@ -272,7 +272,7 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 				expect(exceptionCaught).toBe(false);
 				expect(value).toBe(1234);
 			});
-			
+
 			it("TestIfNeedsToReturnLongItAlwaysReturnsLong1", function() {
 
 				__log("TEST: TestIfNeedsToReturnLongItAlwaysReturnsLong1");
@@ -285,7 +285,7 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 
 				var instance = new N();
 
-				var exceptionCaught = false, 
+				var exceptionCaught = false,
 					exceptionThrown = true;
 				try {
 					var value = com.tns.tests.NumericConversions.callHasToReturnLong(instance, 3147483647);
@@ -312,7 +312,7 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 
 				var instance = new N();
 
-				var exceptionCaught = false, 
+				var exceptionCaught = false,
 					exceptionThrown = true;
 				try {
 					var value = com.tns.tests.NumericConversions.callHasToReturnLong(instance, long(3147483647));
@@ -326,7 +326,7 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 				expect(exceptionCaught).toBe(false);
 				expect(value).toBe(3147483647);
 			});
-			
+
 			it("TestIfNeedsToReturnLongItAlwaysReturnsLong3", function() {
 
 				__log("TEST: TestIfNeedsToReturnLongItAlwaysReturnsLong3");
@@ -339,7 +339,7 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 
 				var instance = new N();
 
-				var exceptionCaught = false, 
+				var exceptionCaught = false,
 					exceptionThrown = true;
 				try {
 					var value = com.tns.tests.NumericConversions.callHasToReturnLong(instance, long(1234));
@@ -367,7 +367,7 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 
 						var instance = new N();
 
-						var exceptionCaught = false, 
+						var exceptionCaught = false,
 							exceptionThrown = true;
 						try {
 							var value = com.tns.tests.NumericConversions.callHasToReturnInt(instance, 1234);
@@ -381,7 +381,7 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 						expect(exceptionCaught).toBe(false);
 						expect(value).toBe(1234);
 			});
-			
+
 			it("TestIfNeedsToReturnIntAndWePassLongExceptionShouldBeThrown", function() {
 
 				__log("TEST: TestIfNeedsToReturnIntAndWePassLongExceptionShouldBeThrown");
@@ -394,7 +394,7 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 
 				var instance = new N();
 
-				var exceptionCaught = false, 
+				var exceptionCaught = false,
 					exceptionThrown = true;
 				try {
 					var value = com.tns.tests.NumericConversions.callHasToReturnInt(instance, long(3147483647));
@@ -407,7 +407,7 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 				expect(exceptionThrown).toBe(true);
 				expect(exceptionCaught).toBe(true);
 			});
-			
+
 			// double cast
 			it("TestIfNeedsToReturnDoubleItAlwaysReturnsDouble", function() {
 
@@ -421,7 +421,7 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 
 				var instance = new N();
 
-				var exceptionCaught = false, 
+				var exceptionCaught = false,
 					exceptionThrown = true;
 				try {
 					var value = com.tns.tests.NumericConversions.callHasToReturnDouble(instance, 1234.1234); //float
@@ -430,12 +430,12 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 					exceptionCaught = true;
 					__log("Error: " + e);
 				}
-				
+
 				var isReturnValueCorrect = false;
-				
+
 				var difference = Math.abs(value - 1234.1234);
 				var e = 0.001;
-				
+
 				if(difference <= e) {
 					isReturnValueCorrect = true;
 				}
@@ -457,7 +457,7 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 
 				var instance = new N();
 
-				var exceptionCaught = false, 
+				var exceptionCaught = false,
 					exceptionThrown = true;
 				try {
 					var value = com.tns.tests.NumericConversions.callHasToReturnDouble(instance, double(1234.1234));
@@ -471,7 +471,7 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 				expect(exceptionCaught).toBe(false);
 				expect(value).toBe(1234.1234);
 			});
-			
+
 			it("TestIfNeedsToReturnDoubleItAlwaysReturnsDouble2", function() {
 
 				__log("TEST: TestIfNeedsToReturnDoubleItAlwaysReturnsDouble2");
@@ -496,19 +496,19 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 				}
 
 				var isReturnValueCorrect = false;
-				
+
 				var difference = Math.abs(value - doubleVal);
 				var e = 0.000000000000000000000000000000000000001;
-				
+
 				if(difference <= e) {
 					isReturnValueCorrect = true;
 				}
-				
+
 				expect(exceptionThrown).toBe(false);
 				expect(exceptionCaught).toBe(false);
 				expect(isReturnValueCorrect).toBe(true);
 			});
-			
+
 			it("TestIfNeedsToReturnDoubleItAlwaysReturnsDouble3", function() {
 
 				__log("TEST: TestIfNeedsToReturnDoubleItAlwaysReturnsDouble3");
@@ -531,12 +531,12 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 					exceptionCaught = true;
 					__log("Error: " + e);
 				}
-				
+
 				expect(exceptionThrown).toBe(false);
 				expect(exceptionCaught).toBe(false);
 				expect(value).toBe(doubleVal);
 			});
-			
+
 			it("TestIfNeedsToReturnDoubleItAlwaysReturnsDouble4", function() {
 
 				__log("TEST: TestIfNeedsToReturnDoubleItAlwaysReturnsDouble4");
@@ -549,7 +549,7 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 
 				var instance = new N();
 
-				var exceptionCaught = false, 
+				var exceptionCaught = false,
 					exceptionThrown = true;
 				try {
 					var value = com.tns.tests.NumericConversions.callHasToReturnDouble(instance, float(1234.1234));
@@ -560,19 +560,19 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 				}
 
 				var isReturnValueCorrect = false;
-				
+
 				var difference = Math.abs(value - 1234.1234);
 				var e = 0.001;
-				
+
 				if(difference <= e) {
 					isReturnValueCorrect = true;
 				}
-				
+
 				expect(exceptionThrown).toBe(false);
 				expect(exceptionCaught).toBe(false);
 				expect(isReturnValueCorrect).toBe(true);
 			});
-			
+
 			// float cast
 			it("TestIfNeedsToReturnFloatItAlwaysReturnsFloat", function() {
 
@@ -586,7 +586,7 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 
 				var instance = new N();
 
-				var exceptionCaught = false, 
+				var exceptionCaught = false,
 					exceptionThrown = true;
 				try {
 					var testFloat = 1234.1234;
@@ -596,12 +596,12 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 					exceptionCaught = true;
 					__log("Error: " + e);
 				}
-				
+
 				var isReturnValueCorrect = false;
-				
+
 				var difference = Math.abs(value - 1234.1234);
 				var e = 0.001;
-				
+
 				if(difference <= e) {
 					isReturnValueCorrect = true;
 				}
@@ -610,7 +610,7 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 				expect(exceptionCaught).toBe(false);
 				expect(isReturnValueCorrect).toBe(true);
 			});
-			
+
 			it("TestIfNeedsToReturnFloatItAlwaysReturnsFloat1", function() {
 
 				__log("TEST: TestIfNeedsToReturnFloatItAlwaysReturnsFloat1");
@@ -623,7 +623,7 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 
 				var instance = new N();
 
-				var exceptionCaught = false, 
+				var exceptionCaught = false,
 					exceptionThrown = true;
 				try {
 					var value = com.tns.tests.NumericConversions.callHasToReturnFloat(instance, float(1234.1234));
@@ -632,12 +632,12 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 					exceptionCaught = true;
 					__log("Error: " + e);
 				}
-				
+
 				var isReturnValueCorrect = false;
-				
+
 				var difference = Math.abs(value - 1234.1234);
 				var e = 0.001;
-				
+
 				if(difference <= e) {
 					isReturnValueCorrect = true;
 				}
@@ -646,20 +646,20 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 				expect(exceptionCaught).toBe(false);
 				expect(isReturnValueCorrect).toBe(true);
 			});
-	
+
 			it("TestIfNeedsToReturnFloatAndWePassDoubleExceptionShouldBeThrown", function() {
-		
+
 				__log("TEST: TestIfNeedsToReturnFloatAndWePassDoubleExceptionShouldBeThrown");
-		
+
 				var N = com.tns.tests.NumericConversions.extend({
 					hasToReturnFloat : function(val) {
 						return val;
 					}
 				});
-		
+
 				var instance = new N();
-		
-				var exceptionCaught = false, 
+
+				var exceptionCaught = false,
 					exceptionThrown = true;
 				try {
 					var doubleVal = 1e-40;
@@ -669,24 +669,24 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 					exceptionCaught = true;
 					__log("Error: " + e);
 				}
-		
+
 				expect(exceptionThrown).toBe(true);
 				expect(exceptionCaught).toBe(true);
 			});
-			
+
 			it("TestIfNeedsToReturnFloatAndWePassDoubleExceptionShouldBeThrown1", function() {
-				
+
 				__log("TEST: TestIfNeedsToReturnFloatAndWePassDoubleExceptionShouldBeThrown1");
-		
+
 				var N = com.tns.tests.NumericConversions.extend({
 					hasToReturnFloat : function(val) {
 						return val;
 					}
 				});
-		
+
 				var instance = new N();
-		
-				var exceptionCaught = false, 
+
+				var exceptionCaught = false,
 					exceptionThrown = true;
 				try {
 					var doubleVal = 1e-40;
@@ -696,7 +696,7 @@ describe("Tests numeric conversions and constructor/method resolutions", functio
 					exceptionCaught = true;
 					__log("Error: " + e);
 				}
-		
+
 				expect(exceptionThrown).toBe(true);
 				expect(exceptionCaught).toBe(true);
 			});

--- a/test-app/app/src/main/java/com/tns/tests/kotlin/extensions/ExtensionFunctions.kt
+++ b/test-app/app/src/main/java/com/tns/tests/kotlin/extensions/ExtensionFunctions.kt
@@ -1,0 +1,17 @@
+package com.tns.tests.kotlin.extensions
+
+fun Any.extensionFunctionWithNoArgumentsAndNoReturnValue(){}
+
+fun Any.extensionFunctionWithNoArgumentsAndStringReturnValue() = "some data"
+
+fun Any.extensionFunctionWithOnePrimitiveArgumentAndNoReturnValue(arg: Int){}
+
+fun Any.extensionFunctionWithOnePrimitiveArgumentAndStringReturnValue(arg: Int) = "some data $arg"
+
+fun Any.extensionFunctionWithOneObjectTypeArgumentAndNoReturnValue(arg: Any){}
+
+fun Any.extensionFunctionWithOneObjectTypeArgumentAndStringReturnValue(arg: Any) = "some data $arg"
+
+fun Any.extensionFunctionWithMultipleObjectTypeArgumentsAndNoReturnValue(arg1: Any, arg2: Any){}
+
+fun Any.extensionFunctionWithMultipleObjectTypeArgumentsAndStringReturnValue(arg1: Any, arg2: Any) = "some data $arg1 $arg2"

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/Builder.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/Builder.java
@@ -12,12 +12,19 @@ import com.telerik.metadata.desc.TypeDescriptor;
 import com.telerik.metadata.dx.DexFile;
 import com.telerik.metadata.kotlin.classes.KotlinClassMetadataParser;
 import com.telerik.metadata.kotlin.classes.impl.KotlinClassMetadataParserImpl;
+import com.telerik.metadata.kotlin.functions.ClassNameAndExtensionFunctionPair;
+import com.telerik.metadata.kotlin.functions.ExtensionFunctionsCollector;
+import com.telerik.metadata.kotlin.functions.ExtensionFunctionsStorage;
+import com.telerik.metadata.kotlin.functions.impl.ExtensionFunctionsCollectorImpl;
+import com.telerik.metadata.kotlin.functions.impl.ExtensionFunctionsStorageImpl;
+import com.telerik.metadata.nodes.cache.NodesCacheImpl;
 import com.telerik.metadata.parsing.ClassParser;
 
 import java.io.File;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -57,6 +64,22 @@ public class Builder {
         TreeNode root = TreeNode.getRoot();
 
         String[] classNames = ClassRepo.getClassNames();
+
+        for (String className : classNames) {
+            try {
+                ClassDescriptor clazz = ClassRepo.findClass(className);
+                if (clazz == null) {
+                    throw new ClassNotFoundException("Class " + className + " not found in the input android libraries.");
+                } else {
+                    tryCollectKotlinExtensionFunctions(clazz);
+                }
+            } catch (Throwable e) {
+                System.out.println("Skip " + className);
+                System.out.println("\tError: " + e.toString());
+                //e.printStackTrace();
+            }
+        }
+
         for (String className : classNames) {
             try {
                 // possible exceptions here are:
@@ -80,7 +103,18 @@ public class Builder {
             }
         }
 
+
         return root;
+    }
+
+    private static void tryCollectKotlinExtensionFunctions(ClassDescriptor classDescriptor) {
+        ExtensionFunctionsCollector extensionFunctionsCollector = new ExtensionFunctionsCollectorImpl(new KotlinClassMetadataParserImpl());
+        Collection<ClassNameAndExtensionFunctionPair> extensionFunctions = extensionFunctionsCollector.collectExtensionFunctions(classDescriptor);
+
+        if (!extensionFunctions.isEmpty()) {
+            ExtensionFunctionsStorage extensionFunctionsStorage = ExtensionFunctionsStorageImpl.getInstance();
+            extensionFunctionsStorage.storeExtensionFunctions(extensionFunctions);
+        }
     }
 
     private static Boolean isClassPublic(ClassDescriptor clazz) {
@@ -128,19 +162,35 @@ public class Builder {
     private static void setNodeMembers(ClassDescriptor clazz, TreeNode node, TreeNode root, boolean hasClassMetadataInfo) throws Exception {
         node.setWentThroughSettingMembers(true);
 
-        Map<String, MethodInfo> existingMethods = new HashMap<String, MethodInfo>();
+        Map<String, MethodInfo> existingMethods = new HashMap<>();
         for (MethodInfo mi : node.instanceMethods) {
             existingMethods.put(mi.name + mi.sig, mi);
         }
+        MethodDescriptor[] extensionFunctions = ExtensionFunctionsStorageImpl.getInstance().retrieveExtensionFunctions(clazz.getClassName()).toArray(new MethodDescriptor[0]);
+        MethodDescriptor[] nonExtensionFunctionMethods = ClassUtil.getAllMethods(clazz);
+        MethodDescriptor[] allMethods = concatenate(extensionFunctions, nonExtensionFunctionMethods);
 
-        MethodDescriptor[] allMethods = ClassUtil.getAllMethods(clazz);
         MethodDescriptor[] classImplementedMethods = clazz.getMethods();
         MethodDescriptor[] interfaceImplementedMethods = clazz.isClass() ? getDefaultMethodsFromImplementedInterfaces(clazz, classImplementedMethods) : new MethodDescriptor[0];
-        MethodDescriptor[] methods = concatenate(classImplementedMethods, interfaceImplementedMethods);
-
+        MethodDescriptor[] methods = concatenate(classImplementedMethods, interfaceImplementedMethods, extensionFunctions);
         Arrays.sort(methods, methodNameComparator);
 
-        for (MethodDescriptor m : methods) {
+        setMethodsInfo(root, node, clazz, methods, allMethods, existingMethods, hasClassMetadataInfo);
+
+        FieldDescriptor[] fields = clazz.getFields();
+
+        setFieldInfo(clazz, node, root, fields, null);
+
+        setPropertiesInfo(root, node, clazz.getProperties());
+
+        // adds static fields from interface to implementing class because java can call them from implementing class... no problem.
+        getFieldsFromImplementedInterfaces(clazz, node, root, fields);
+    }
+
+    private static void setMethodsInfo(TreeNode root, TreeNode node, ClassDescriptor clazz, MethodDescriptor[] ownMethodDescriptors, MethodDescriptor[] ownAndParentMethodDescriptors, Map<String, MethodInfo> existingNodeMethods, boolean hasClassMetadataInfo) throws Exception {
+
+
+        for (MethodDescriptor m : ownMethodDescriptors) {
             if (m.isSynthetic()) {
                 continue;
             }
@@ -157,7 +207,7 @@ public class Builder {
 
                 MethodInfo mi = new MethodInfo(m);
                 int countUnique = 0;
-                for (MethodDescriptor m1 : allMethods) {
+                for (MethodDescriptor m1 : ownAndParentMethodDescriptors) {
                     boolean m1IsStatic = m1.isStatic();
                     if (!m1.isSynthetic()
                             && (m1.isPublic() || m1.isProtected())
@@ -172,33 +222,38 @@ public class Builder {
                 }
                 mi.isResolved = countUnique == 1;
 
+
                 TypeDescriptor[] params = m.getArgumentTypes();
                 mi.signature = getMethodSignature(root, m.getReturnType(),
                         params);
 
                 if (mi.signature != null) {
                     if (isStatic) {
-                        mi.declaringType = getOrCreateNode(root, clazz, null);
-                        node.staticMethods.add(mi);
+                        if (!mi.isExtensionFunction) {
+                            mi.declaringType = getOrCreateNode(root, clazz, null);
+                            node.staticMethods.add(mi);
+                        } else {
+                            if(mi.name.contains("testIntExtension") || mi.name.contains("testArrayExtension")){
+                                System.out.println("asd");
+                            }
+                            mi.declaringType = getOrCreateNode(root, m.getDeclaringClass(), null);
+                            node.addExtensionFunction(mi);
+                        }
                     } else {
                         String sig = m.getName() + m.getSignature();
-                        if (existingMethods.containsKey(sig)) {
+                        if (existingNodeMethods.containsKey(sig)) {
                             continue;
                         }
                         node.instanceMethods.add(mi);
                     }
                 }
+
+                if (mi.isResolved) {
+                    node.resolvedMethods.add(mi);
+                }
             }
         }
 
-        FieldDescriptor[] fields = clazz.getFields();
-
-        setFieldInfo(clazz, node, root, fields, null);
-
-        setPropertiesInfo(root, node, clazz.getProperties());
-
-        // adds static fields from interface to implementing class because java can call them from implementing class... no problem.
-        getFieldsFromImplementedInterfaces(clazz, node, root, fields);
     }
 
     private static void setPropertiesInfo(TreeNode root, TreeNode node, PropertyDescriptor[] propertyDescriptors) throws Exception {
@@ -411,6 +466,7 @@ public class Builder {
             }
         }
 
+        NodesCacheImpl.getInstance().addNode(clazz.getClassName(), node);
         return node;
     }
 
@@ -493,10 +549,25 @@ public class Builder {
         int bLen = b.length;
 
         @SuppressWarnings("unchecked")
-        T[] c = (T[]) Array.newInstance(a.getClass().getComponentType(), aLen + bLen);
-        System.arraycopy(a, 0, c, 0, aLen);
-        System.arraycopy(b, 0, c, aLen, bLen);
+        T[] d = (T[]) Array.newInstance(a.getClass().getComponentType(), aLen + bLen);
+        System.arraycopy(a, 0, d, 0, aLen);
+        System.arraycopy(b, 0, d, aLen, bLen);
 
-        return c;
+        return d;
+    }
+
+    private static <T> T[] concatenate(T[] a, T[] b, T[] c) {
+        int aLen = a.length;
+        int bLen = b.length;
+        int cLen = c.length;
+        int abLen = aLen + bLen;
+
+        @SuppressWarnings("unchecked")
+        T[] d = (T[]) Array.newInstance(a.getClass().getComponentType(), abLen + cLen);
+        System.arraycopy(a, 0, d, 0, aLen);
+        System.arraycopy(b, 0, d, aLen, bLen);
+        System.arraycopy(c, 0, d, abLen, cLen);
+
+        return d;
     }
 }

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/ClassUtil.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/ClassUtil.java
@@ -81,7 +81,7 @@ public class ClassUtil {
             }
             currentClass = getSuperclass(currentClass);
         }
-        return methods.toArray(new MethodDescriptor[methods.size()]);
+        return methods.toArray(new MethodDescriptor[0]);
     }
 
     public static String getCanonicalName(String className) {

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/TreeNode.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/TreeNode.java
@@ -1,6 +1,7 @@
 package com.telerik.metadata;
 
 import com.telerik.metadata.desc.ClassDescriptor;
+import com.telerik.metadata.desc.ExtensionFunctionDescriptor;
 import com.telerik.metadata.desc.MethodDescriptor;
 import com.telerik.metadata.desc.TypeDescriptor;
 
@@ -14,9 +15,12 @@ public class TreeNode {
             this.name = m.getName();
             this.sig = m.getSignature();
             this.isResolved = false;
-            signature = new ArrayList<TreeNode>();
+            this.isExtensionFunction = m instanceof ExtensionFunctionDescriptor;
+
+            signature = new ArrayList<>();
         }
 
+        public boolean isExtensionFunction;
         public String name;
         public String sig;
         public ArrayList<TreeNode> signature;
@@ -85,13 +89,15 @@ public class TreeNode {
     public static final byte Final = 1;
 
     public TreeNode() {
-        children = new ArrayList<TreeNode>();
+        children = new ArrayList<>();
 
-        instanceMethods = new ArrayList<TreeNode.MethodInfo>();
-        staticMethods = new ArrayList<TreeNode.MethodInfo>();
-        instanceFields = new ArrayList<TreeNode.FieldInfo>();
-        staticFields = new ArrayList<TreeNode.FieldInfo>();
-        properties = new ArrayList<PropertyInfo>();
+        instanceMethods = new ArrayList<>();
+        staticMethods = new ArrayList<>();
+        instanceFields = new ArrayList<>();
+        staticFields = new ArrayList<>();
+        properties = new ArrayList<>();
+        extensionFunctions = new ArrayList<>();
+        resolvedMethods = new ArrayList<>();
     }
 
     public static final TreeNode BYTE = getPrimitive("B", (byte) 1);
@@ -219,16 +225,34 @@ public class TreeNode {
     public ArrayList<FieldInfo> instanceFields;
     public ArrayList<FieldInfo> staticFields;
     ArrayList<PropertyInfo> properties;
+    ArrayList<MethodInfo> extensionFunctions;
+    ArrayList<MethodInfo> resolvedMethods;
     public TreeNode baseClassNode;
     TreeNode parentNode;
     //
 
-    void addProperty(PropertyInfo propertyInfo){
+    void addProperty(PropertyInfo propertyInfo) {
         properties.add(propertyInfo);
     }
 
-    List<PropertyInfo> getProperties(){
+    void addExtensionFunction(MethodInfo methodInfo) {
+        extensionFunctions.add(methodInfo);
+    }
+
+    List<PropertyInfo> getProperties() {
         return properties;
+    }
+
+    List<MethodInfo> getExtensionFunctions() {
+        return extensionFunctions;
+    }
+
+    void addResolvedMethod(MethodInfo resolvedMethod) {
+        resolvedMethods.add(resolvedMethod);
+    }
+
+    List<MethodInfo> getResolvedMethods() {
+        return resolvedMethods;
     }
 
     private boolean wentThroughSettingMembers = false;

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/bcl/ClassInfo.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/bcl/ClassInfo.java
@@ -9,6 +9,10 @@ import com.telerik.metadata.desc.MethodDescriptor;
 import com.telerik.metadata.desc.PropertyDescriptor;
 import com.telerik.metadata.kotlin.classes.KotlinClassMetadataParser;
 import com.telerik.metadata.kotlin.classes.impl.KotlinClassMetadataParserImpl;
+import com.telerik.metadata.kotlin.functions.ExtensionFunctionsCollector;
+import com.telerik.metadata.kotlin.functions.ExtensionFunctionsStorage;
+import com.telerik.metadata.kotlin.functions.impl.ExtensionFunctionsCollectorImpl;
+import com.telerik.metadata.kotlin.functions.impl.ExtensionFunctionsStorageImpl;
 
 import org.apache.bcel.classfile.AnnotationEntry;
 import org.apache.bcel.classfile.Attribute;
@@ -22,19 +26,22 @@ import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
+import kotlinx.metadata.KmFunction;
 import kotlinx.metadata.KmProperty;
 import kotlinx.metadata.jvm.JvmExtensionsKt;
 import kotlinx.metadata.jvm.JvmMethodSignature;
 
 public class ClassInfo implements ClassDescriptor {
     private final JavaClass clazz;
+    private final ExtensionFunctionsStorage extensionFunctionsStorage;
 
     public ClassInfo(JavaClass clazz) {
         this.clazz = clazz;
+        this.extensionFunctionsStorage = ExtensionFunctionsStorageImpl.getInstance();
         init();
     }
 
@@ -126,7 +133,7 @@ public class ClassInfo implements ClassDescriptor {
         Method[] ms = clazz.getMethods();
         MethodDescriptor[] methods = new MethodDescriptor[ms.length];
         for (int i = 0; i < methods.length; i++) {
-            methods[i] = new MethodInfo(ms[i]);
+            methods[i] = new MethodInfo(ms[i], this);
         }
         return methods;
     }
@@ -164,7 +171,7 @@ public class ClassInfo implements ClassDescriptor {
             String methodName = method.getName();
 
             if (methodSignature.equals(signature) && methodName.equals(name)) {
-                return new MethodInfo(method);
+                return new MethodInfo(method, this);
             }
         }
 

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/bcl/ExtensionFunctionInfo.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/bcl/ExtensionFunctionInfo.java
@@ -1,20 +1,16 @@
 package com.telerik.metadata.bcl;
 
 import com.telerik.metadata.desc.ClassDescriptor;
+import com.telerik.metadata.desc.ExtensionFunctionDescriptor;
 import com.telerik.metadata.desc.MetadataInfoAnnotationDescriptor;
 import com.telerik.metadata.desc.MethodDescriptor;
 import com.telerik.metadata.desc.TypeDescriptor;
-import org.apache.bcel.classfile.Method;
-import org.apache.bcel.generic.Type;
 
-public class MethodInfo implements MethodDescriptor {
+public class ExtensionFunctionInfo implements ExtensionFunctionDescriptor {
+    private final MethodDescriptor m;
 
-    private final Method m;
-    private final ClassDescriptor classDescriptor;
-
-    public MethodInfo(Method m, ClassDescriptor classDescriptor) {
+    public ExtensionFunctionInfo(MethodDescriptor m) {
         this.m = m;
-        this.classDescriptor = classDescriptor;
     }
 
     @Override
@@ -44,7 +40,7 @@ public class MethodInfo implements MethodDescriptor {
 
     @Override
     public ClassDescriptor getDeclaringClass() {
-        return classDescriptor;
+        return m.getDeclaringClass();
     }
 
     @Override
@@ -59,17 +55,12 @@ public class MethodInfo implements MethodDescriptor {
 
     @Override
     public TypeDescriptor[] getArgumentTypes() {
-        Type[] ts = m.getArgumentTypes();
-        TypeDescriptor[] argTypes = new TypeDescriptor[ts.length];
-        for (int i=0; i<argTypes.length; i++) {
-            argTypes[i] = new TypeInfo(ts[i]);
-        }
-        return argTypes;
+        return m.getArgumentTypes();
     }
 
     @Override
     public TypeDescriptor getReturnType() {
-        return new TypeInfo(m.getReturnType());
+        return m.getReturnType();
     }
 
     @Override
@@ -82,7 +73,7 @@ public class MethodInfo implements MethodDescriptor {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        MethodInfo that = (MethodInfo) o;
+        ExtensionFunctionInfo that = (ExtensionFunctionInfo) o;
 
         return m.equals(that.m);
     }

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/bcl/JarFile.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/bcl/JarFile.java
@@ -20,7 +20,7 @@ public class JarFile implements ClassMapProvider {
 
     private JarFile(String path) {
         this.path = path;
-        this.classMap = new HashMap<String, ClassDescriptor>();
+        this.classMap = new HashMap<>();
     }
 
     public String getPath() {

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/desc/ClassDescriptor.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/desc/ClassDescriptor.java
@@ -4,11 +4,15 @@ import java.util.Optional;
 
 public interface ClassDescriptor {
     boolean isClass();
+
     boolean isInterface();
+
     boolean isEnum();
 
     boolean isStatic();
+
     boolean isPublic();
+
     boolean isProtected();
 
     MethodDescriptor[] getMethods();
@@ -24,6 +28,8 @@ public interface ClassDescriptor {
     String[] getInterfaceNames();
 
     String getPackageName();
+
     String getClassName();
+
     String getSuperclassName();
 }

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/desc/ExtensionFunctionDescriptor.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/desc/ExtensionFunctionDescriptor.java
@@ -1,0 +1,4 @@
+package com.telerik.metadata.desc;
+
+public interface ExtensionFunctionDescriptor extends MethodDescriptor {
+}

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/desc/MethodDescriptor.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/desc/MethodDescriptor.java
@@ -7,6 +7,8 @@ public interface MethodDescriptor {
     boolean isStatic();
     boolean isAbstract();
 
+    ClassDescriptor getDeclaringClass();
+
     String getName();
     String getSignature();
 

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/dx/MethodInfo.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/dx/MethodInfo.java
@@ -7,6 +7,7 @@ import com.android.dex.Dex;
 import com.android.dex.MethodId;
 import com.android.dex.ProtoId;
 import com.android.dx.rop.code.AccessFlags;
+import com.telerik.metadata.desc.ClassDescriptor;
 import com.telerik.metadata.desc.MetadataInfoAnnotationDescriptor;
 import com.telerik.metadata.desc.MethodDescriptor;
 import com.telerik.metadata.desc.TypeDescriptor;
@@ -46,6 +47,11 @@ public class MethodInfo implements MethodDescriptor {
     @Override
     public boolean isAbstract() {
         return AccessFlags.isAbstract(method.getAccessFlags());
+    }
+
+    @Override
+    public ClassDescriptor getDeclaringClass() {
+        return null;
     }
 
     @Override

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/kotlin/classes/KotlinClassMetadataParser.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/kotlin/classes/KotlinClassMetadataParser.java
@@ -4,9 +4,11 @@ import com.telerik.metadata.desc.ClassDescriptor;
 
 import java.util.List;
 
+import kotlinx.metadata.KmFunction;
 import kotlinx.metadata.KmProperty;
 
 public interface KotlinClassMetadataParser {
     boolean wasKotlinCompanionObject(ClassDescriptor clazz, ClassDescriptor possibleCompanion);
     List<KmProperty> getKotlinProperties(ClassDescriptor clazz);
+    List<KmFunction> getKotlinExtensionFunctions(ClassDescriptor clazz);
 }

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/kotlin/classes/impl/KotlinClassMetadataParserImpl.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/kotlin/classes/impl/KotlinClassMetadataParserImpl.java
@@ -4,13 +4,22 @@ import com.telerik.metadata.desc.ClassDescriptor;
 import com.telerik.metadata.desc.KotlinClassMetadataAnnotation;
 import com.telerik.metadata.kotlin.classes.KotlinClassMetadataParser;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 import java.lang.reflect.Modifier;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import kotlinx.metadata.Flag;
 import kotlinx.metadata.KmClass;
+import kotlinx.metadata.KmExtensionType;
+import kotlinx.metadata.KmFunction;
+import kotlinx.metadata.KmFunctionExtensionVisitor;
+import kotlinx.metadata.KmFunctionVisitor;
+import kotlinx.metadata.KmPackage;
 import kotlinx.metadata.KmProperty;
 import kotlinx.metadata.jvm.KotlinClassHeader;
 import kotlinx.metadata.jvm.KotlinClassMetadata;
@@ -74,5 +83,48 @@ public class KotlinClassMetadataParserImpl implements KotlinClassMetadataParser 
         }
 
         return Collections.emptyList();
+    }
+
+    @Override
+    public List<KmFunction> getKotlinExtensionFunctions(ClassDescriptor clazz) {
+        Optional<KotlinClassMetadataAnnotation> kotlinClassMetadataAnnotationOptional = clazz.getKotlinClassMetadataAnnotation();
+        if (!kotlinClassMetadataAnnotationOptional.isPresent()) {
+            return Collections.emptyList();
+        }
+
+        KotlinClassMetadataAnnotation kotlinClassMetadataAnnotation = kotlinClassMetadataAnnotationOptional.get();
+        KotlinClassMetadata kotlinClassMetadata = buildKotlinClassMetadata(kotlinClassMetadataAnnotation);
+
+        if (kotlinClassMetadata instanceof KotlinClassMetadata.Class) {
+            KotlinClassMetadata.Class regularKotlinClassMetadata = (KotlinClassMetadata.Class) kotlinClassMetadata;
+            KmClass kmClass = regularKotlinClassMetadata.toKmClass();
+
+            return kmClass.getFunctions()
+                    .stream()
+                    .filter(KotlinClassMetadataParserImpl::isVisibleExtensionFunction)
+                    .collect(Collectors.toList());
+        } else if (kotlinClassMetadata instanceof KotlinClassMetadata.FileFacade) {
+            KotlinClassMetadata.FileFacade fileFacadeMetadata = (KotlinClassMetadata.FileFacade) kotlinClassMetadata;
+            KmPackage kmClass = fileFacadeMetadata.toKmPackage();
+
+            return kmClass.getFunctions()
+                    .stream()
+                    .filter(KotlinClassMetadataParserImpl::isVisibleExtensionFunction)
+                    .collect(Collectors.toList());
+        }
+
+        return Collections.emptyList();
+    }
+
+    class KotlinClassVisitor extends KmFunctionVisitor{
+        @Nullable
+        @Override
+        public KmFunctionExtensionVisitor visitExtensions(@NotNull KmExtensionType type) {
+            return super.visitExtensions(type);
+        }
+    }
+
+    private static boolean isVisibleExtensionFunction(KmFunction function) {
+        return function.getReceiverParameterType() != null;
     }
 }

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/kotlin/functions/ClassNameAndExtensionFunctionPair.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/kotlin/functions/ClassNameAndExtensionFunctionPair.java
@@ -1,0 +1,21 @@
+package com.telerik.metadata.kotlin.functions;
+
+import com.telerik.metadata.desc.ExtensionFunctionDescriptor;
+
+public final class ClassNameAndExtensionFunctionPair {
+    private final String className;
+    private final ExtensionFunctionDescriptor extensionFunction;
+
+    public ClassNameAndExtensionFunctionPair(String className, ExtensionFunctionDescriptor extensionFunction) {
+        this.className = className;
+        this.extensionFunction = extensionFunction;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public ExtensionFunctionDescriptor getExtensionFunction() {
+        return extensionFunction;
+    }
+}

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/kotlin/functions/ExtensionFunctionsCollector.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/kotlin/functions/ExtensionFunctionsCollector.java
@@ -1,0 +1,8 @@
+package com.telerik.metadata.kotlin.functions;
+
+import com.telerik.metadata.desc.ClassDescriptor;
+import java.util.Collection;
+
+public interface ExtensionFunctionsCollector {
+    Collection<ClassNameAndExtensionFunctionPair> collectExtensionFunctions(ClassDescriptor classDescriptor);
+}

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/kotlin/functions/ExtensionFunctionsStorage.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/kotlin/functions/ExtensionFunctionsStorage.java
@@ -1,0 +1,11 @@
+package com.telerik.metadata.kotlin.functions;
+
+import com.telerik.metadata.desc.ExtensionFunctionDescriptor;
+
+import java.util.Collection;
+
+public interface ExtensionFunctionsStorage {
+    void storeExtensionFunctions(Collection<ClassNameAndExtensionFunctionPair> extensionFunctions);
+
+    Collection<ExtensionFunctionDescriptor> retrieveExtensionFunctions(String className);
+}

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/kotlin/functions/impl/ExtensionFunctionsCollectorImpl.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/kotlin/functions/impl/ExtensionFunctionsCollectorImpl.java
@@ -1,0 +1,56 @@
+package com.telerik.metadata.kotlin.functions.impl;
+
+import com.telerik.metadata.ClassUtil;
+import com.telerik.metadata.bcl.ExtensionFunctionInfo;
+import com.telerik.metadata.desc.ClassDescriptor;
+import com.telerik.metadata.desc.MethodDescriptor;
+import com.telerik.metadata.desc.TypeDescriptor;
+import com.telerik.metadata.kotlin.classes.KotlinClassMetadataParser;
+import com.telerik.metadata.kotlin.functions.ClassNameAndExtensionFunctionPair;
+import com.telerik.metadata.kotlin.functions.ExtensionFunctionsCollector;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import kotlinx.metadata.KmFunction;
+import kotlinx.metadata.jvm.JvmExtensionsKt;
+import kotlinx.metadata.jvm.JvmMethodSignature;
+
+public class ExtensionFunctionsCollectorImpl implements ExtensionFunctionsCollector {
+
+    private final KotlinClassMetadataParser kotlinClassMetadataParser;
+
+    public ExtensionFunctionsCollectorImpl(KotlinClassMetadataParser kotlinClassMetadataParser) {
+        this.kotlinClassMetadataParser = kotlinClassMetadataParser;
+    }
+
+    @Override
+    public Collection<ClassNameAndExtensionFunctionPair> collectExtensionFunctions(ClassDescriptor classDescriptor) {
+        Collection<ClassNameAndExtensionFunctionPair> extensionFunctionsDescriptors = new ArrayList<>();
+
+        List<KmFunction> extensionFunctions = kotlinClassMetadataParser.getKotlinExtensionFunctions(classDescriptor);
+
+        for (KmFunction extensionFunction : extensionFunctions) {
+            JvmMethodSignature signature = JvmExtensionsKt.getSignature(extensionFunction);
+
+            String functionName = signature.getName();
+            String functionSignature = signature.getDesc();
+
+            MethodDescriptor extensionFunctionDescriptor = Arrays
+                    .stream(classDescriptor.getMethods())
+                    .filter(x -> x.getName().equals(functionName) && x.getSignature().equals(functionSignature))
+                    .findFirst()
+                    .get();
+
+            if (extensionFunctionDescriptor.isStatic()) {
+                TypeDescriptor receiverType = extensionFunctionDescriptor.getArgumentTypes()[0]; // kotlin extension functions' first argument is the receiver type
+                String receiverClassName = ClassUtil.getCanonicalName(receiverType.getSignature());
+                extensionFunctionsDescriptors.add(new ClassNameAndExtensionFunctionPair(receiverClassName, new ExtensionFunctionInfo(extensionFunctionDescriptor)));
+            }
+        }
+
+        return extensionFunctionsDescriptors;
+    }
+}

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/kotlin/functions/impl/ExtensionFunctionsStorageImpl.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/kotlin/functions/impl/ExtensionFunctionsStorageImpl.java
@@ -1,0 +1,60 @@
+package com.telerik.metadata.kotlin.functions.impl;
+
+import com.telerik.metadata.desc.ExtensionFunctionDescriptor;
+import com.telerik.metadata.kotlin.functions.ClassNameAndExtensionFunctionPair;
+import com.telerik.metadata.kotlin.functions.ExtensionFunctionsStorage;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ExtensionFunctionsStorageImpl implements ExtensionFunctionsStorage {
+
+    private static final ExtensionFunctionsStorageImpl ourInstance = new ExtensionFunctionsStorageImpl();
+
+    public static ExtensionFunctionsStorage getInstance() {
+        return ourInstance;
+    }
+
+    private final Map<String, Collection<ExtensionFunctionDescriptor>> extensionFunctions;
+
+    private ExtensionFunctionsStorageImpl() {
+        this.extensionFunctions = new HashMap<>();
+    }
+
+    @Override
+    public void storeExtensionFunctions(Collection<ClassNameAndExtensionFunctionPair> extensionFunctions) {
+        Map<String, List<ExtensionFunctionDescriptor>> classConcreteExtensionFunctions = extensionFunctions
+                .stream()
+                .collect(Collectors
+                        .groupingBy(ClassNameAndExtensionFunctionPair::getClassName,
+                                Collectors.mapping(ClassNameAndExtensionFunctionPair::getExtensionFunction,
+                                        Collectors.toList())));
+
+        for (Map.Entry<String, List<ExtensionFunctionDescriptor>> classConcreteExtensionFunction : classConcreteExtensionFunctions.entrySet()) {
+            String className = classConcreteExtensionFunction.getKey();
+
+            if (this.extensionFunctions.containsKey(className)) {
+                Collection<ExtensionFunctionDescriptor> existingExtensionFunctions = this.extensionFunctions.get(className);
+                existingExtensionFunctions.addAll(classConcreteExtensionFunction.getValue());
+            } else {
+                this.extensionFunctions.put(className, classConcreteExtensionFunction.getValue());
+            }
+        }
+    }
+
+    @Override
+    public Collection<ExtensionFunctionDescriptor> retrieveExtensionFunctions(String className) {
+        Collection<ExtensionFunctionDescriptor> classConcreteExtensionFunctions = extensionFunctions.get(className);
+
+        if (classConcreteExtensionFunctions != null) {
+            return classConcreteExtensionFunctions;
+        }
+
+        return Collections.emptyList();
+    }
+
+}

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/nodes/cache/NodesCache.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/nodes/cache/NodesCache.java
@@ -1,0 +1,11 @@
+package com.telerik.metadata.nodes.cache;
+
+import com.telerik.metadata.TreeNode;
+
+public interface NodesCache {
+
+    public void addNode(String className, TreeNode node);
+
+    public TreeNode getNode(String className);
+
+}

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/nodes/cache/NodesCacheImpl.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/nodes/cache/NodesCacheImpl.java
@@ -1,0 +1,28 @@
+package com.telerik.metadata.nodes.cache;
+
+import com.telerik.metadata.TreeNode;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class NodesCacheImpl implements NodesCache {
+    private static final NodesCacheImpl ourInstance = new NodesCacheImpl();
+
+    private final Map<String, TreeNode> nodesCache;
+
+    public static NodesCache getInstance() {
+        return ourInstance;
+    }
+
+    private NodesCacheImpl() {
+        this.nodesCache = new HashMap<>();
+    }
+
+    public void addNode(String className, TreeNode node) {
+        nodesCache.put(className, node);
+    }
+
+    public TreeNode getNode(String className) {
+        return nodesCache.get(className);
+    }
+}

--- a/test-app/gradle.properties
+++ b/test-app/gradle.properties
@@ -14,6 +14,7 @@ org.gradle.jvmargs=-Xmx1536m
 android.enableJetifier=true
 android.useAndroidX=true
 useKotlin=true
+gatherAnalyticsData=true
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/test-app/runtime/src/main/cpp/ArgConverter.h
+++ b/test-app/runtime/src/main/cpp/ArgConverter.h
@@ -14,6 +14,7 @@
 #include <map>
 
 namespace tns {
+
 class ArgConverter {
     public:
         static void Init(v8::Isolate* isolate);

--- a/test-app/runtime/src/main/cpp/JsArgConverter.cpp
+++ b/test-app/runtime/src/main/cpp/JsArgConverter.cpp
@@ -14,6 +14,41 @@ using namespace v8;
 using namespace std;
 using namespace tns;
 
+//JsArgConverter::JsArgConverter(){}
+
+JsArgConverter::JsArgConverter(const Local<Object>& caller, const v8::FunctionCallbackInfo<Value>& args, const string& methodSignature, MetadataEntry* entry)
+        : m_isolate(args.GetIsolate()), m_env(JEnv()), m_methodSignature(methodSignature), m_isValid(true), m_error(Error()) {
+    int v8ProvidedArgumentsLength = args.Length();
+    m_argsLen = 1 + v8ProvidedArgumentsLength;
+
+    if (m_argsLen > 0) {
+        if ((entry != nullptr) && (entry->isResolved)) {
+            if (entry->parsedSig.empty()) {
+                JniSignatureParser parser(m_methodSignature);
+                entry->parsedSig = parser.Parse();
+            }
+            m_tokens = entry->parsedSig;
+        } else {
+            JniSignatureParser parser(m_methodSignature);
+            m_tokens = parser.Parse();
+        }
+
+        m_isValid = ConvertArg(caller, 0);
+
+        if (!m_isValid) {
+            throw NativeScriptException("Error while converting argument!");
+        }
+
+        for (int i = 0; i < v8ProvidedArgumentsLength; i++) {
+            m_isValid = ConvertArg(args[i], i + 1);
+
+            if (!m_isValid) {
+                break;
+            }
+        }
+    }
+}
+
 JsArgConverter::JsArgConverter(const v8::FunctionCallbackInfo<Value>& args, bool hasImplementationObject, const string& methodSignature, MetadataEntry* entry)
     : m_isolate(args.GetIsolate()), m_env(JEnv()), m_methodSignature(methodSignature), m_isValid(true), m_error(Error()) {
     m_argsLen = !hasImplementationObject ? args.Length() : args.Length() - 1;

--- a/test-app/runtime/src/main/cpp/JsArgConverter.h
+++ b/test-app/runtime/src/main/cpp/JsArgConverter.h
@@ -10,6 +10,10 @@
 namespace tns {
 class JsArgConverter {
     public:
+//        JsArgConverter();
+
+        JsArgConverter(const v8::Local<v8::Object>& caller, const v8::FunctionCallbackInfo<v8::Value>& args, const std::string& methodSignature, MetadataEntry* entry);
+
         JsArgConverter(const v8::FunctionCallbackInfo<v8::Value>& args, bool hasImplementationObject, const std::string& methodSignature, MetadataEntry* entry);
 
         JsArgConverter(const v8::FunctionCallbackInfo<v8::Value>& args, const std::string& methodSignature);

--- a/test-app/runtime/src/main/cpp/MetadataEntry.h
+++ b/test-app/runtime/src/main/cpp/MetadataEntry.h
@@ -35,7 +35,7 @@ struct MetadataEntry {
         :
         isTypeMember(false), name(std::string()), treeNode(nullptr), sig(std::string()), returnType(std::string()), retType(MethodReturnType::Unknown), paramCount(0),
         isStatic(false), isFinal(false), declaringType(std::string()),
-        isResolved(false), memberId(nullptr), clazz(nullptr) {
+        isResolved(false), isExtensionFunction(false), memberId(nullptr), clazz(nullptr) {
     }
     MetadataTreeNode* treeNode;
     NodeType type;
@@ -49,6 +49,7 @@ struct MetadataEntry {
     bool isFinal;
     bool isTypeMember;
     bool isResolved;
+    bool isExtensionFunction;
     void* memberId;
     jclass clazz;
     std::vector<std::string> parsedSig;

--- a/test-app/runtime/src/main/cpp/MetadataReader.cpp
+++ b/test-app/runtime/src/main/cpp/MetadataReader.cpp
@@ -199,6 +199,20 @@ MetadataEntry MetadataReader::ReadStaticMethodEntry(uint8_t** data) {
     return entry;
 }
 
+MetadataEntry MetadataReader::ReadExtensionFunctionEntry(uint8_t** data) {
+    MetadataEntry entry;
+    MethodInfo smip(*data, this); //static method info pointer
+
+    FillEntryWithMethodInfo(smip, entry);
+    entry.isStatic = true;
+    entry.declaringType = smip.GetDeclaringType();
+    entry.isExtensionFunction = true;
+
+    *data += smip.GetSizeOfReadMethodInfo();
+
+    return entry;
+}
+
 string MetadataReader::ReadInterfaceImplementationTypeName(MetadataTreeNode* treeNode, bool& isPrefix) {
     uint8_t* data = m_valueData + treeNode->offsetValue + sizeof(uint8_t) + sizeof(uint16_t);
 

--- a/test-app/runtime/src/main/cpp/MetadataReader.h
+++ b/test-app/runtime/src/main/cpp/MetadataReader.h
@@ -21,6 +21,8 @@ class MetadataReader {
 
         MetadataEntry ReadStaticMethodEntry(uint8_t** data);
 
+        MetadataEntry ReadExtensionFunctionEntry(uint8_t** data);
+
         MetadataEntry ReadInstanceFieldEntry(uint8_t** data);
 
         MetadataEntry ReadStaticFieldEntry(uint8_t** data);


### PR DESCRIPTION
Currently, the only way to use Kotlin extension functions through JS/TS is by invoking the Kotlin compiler-generated utility functions. 
This PR enables calling extension functions of Object types as if they were instance methods of the type.