### PR TITLE
Fix Kotlin enum accessing issue

### DIFF
--- a/test-app/app/src/main/assets/app/mainpage.js
+++ b/test-app/app/src/main/assets/app/mainpage.js
@@ -61,4 +61,5 @@ require("./tests/kotlin/delegation/testDelegationSupport");
 require("./tests/kotlin/objects/testObjectsSupport");
 require("./tests/kotlin/functions/testTopLevelFunctionsSupport");
 require("./tests/kotlin/extensions/testExtensionFunctionsSupport");
+require("./tests/kotlin/enums/testEnumsSupport");
 require("./tests/kotlin/access/testInternalLanguageFeaturesSupport");

--- a/test-app/app/src/main/assets/app/tests/kotlin/enums/testEnumsSupport.js
+++ b/test-app/app/src/main/assets/app/tests/kotlin/enums/testEnumsSupport.js
@@ -1,0 +1,10 @@
+describe("Tests Kotlin extension functions support", function () {
+
+    it("Test Kotlin enum entries are accessible", function () {
+        var enumEntry = com.tns.tests.kotlin.enums.KotlinEnum.TEST_ENTRY;
+
+        expect(enumEntry).not.toBe(undefined);
+        expect(enumEntry).not.toBe(null);
+    });
+
+});

--- a/test-app/app/src/main/java/com/tns/tests/kotlin/enums/KotlinEnum.kt
+++ b/test-app/app/src/main/java/com/tns/tests/kotlin/enums/KotlinEnum.kt
@@ -1,0 +1,5 @@
+package com.tns.tests.kotlin.enums
+
+enum class KotlinEnum {
+    TEST_ENTRY
+}

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/parsing/kotlin/fields/KotlinEnumFieldDescriptor.kt
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/parsing/kotlin/fields/KotlinEnumFieldDescriptor.kt
@@ -1,0 +1,9 @@
+package com.telerik.metadata.parsing.kotlin.fields
+
+import com.telerik.metadata.parsing.bytecode.fields.NativeFieldBytecodeDescriptor
+import org.apache.bcel.classfile.Field
+
+class KotlinEnumFieldDescriptor(field: Field,
+                                override val isPublic: Boolean,
+                                override val isInternal: Boolean,
+                                override val isProtected: Boolean) : NativeFieldBytecodeDescriptor(field)


### PR DESCRIPTION
Due to a bug in the MDG, Kotlin enum entries couldn't be accessed through JS. This PR fixes this behavior and additional tests for the Kotlin support.