### PR TITLE
Fix Kotlin Object issue

### DIFF
--- a/test-app/app/src/main/assets/app/tests/kotlin/objects/testObjectsSupport.js
+++ b/test-app/app/src/main/assets/app/tests/kotlin/objects/testObjectsSupport.js
@@ -2,6 +2,12 @@ describe("Tests Kotlin objects support", function () {
     it("Test Kotlin object instances should be the same reference", function () {
     	var kotlinClass = com.tns.tests.kotlin.objects.KotlinSingleton.INSTANCE;
     	var kotlinClass2 = com.tns.tests.kotlin.objects.KotlinSingleton.INSTANCE;
+
+    	expect(kotlinClass).not.toBe(null);
+    	expect(kotlinClass).not.toBe(undefined);
+    	expect(kotlinClass2).not.toBe(null);
+    	expect(kotlinClass2).not.toBe(undefined);
+
     	expect(com.tns.EqualityComparator.areReferencesEqual(kotlinClass, kotlinClass2)).toBe(true);
     });
 });

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/parsing/kotlin/fields/KotlinObjectInstanceFieldDescriptor.kt
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/parsing/kotlin/fields/KotlinObjectInstanceFieldDescriptor.kt
@@ -1,0 +1,11 @@
+package com.telerik.metadata.parsing.kotlin.fields
+
+import com.telerik.metadata.parsing.bytecode.fields.NativeFieldBytecodeDescriptor
+import com.telerik.metadata.parsing.kotlin.classes.KotlinClassDescriptor
+import org.apache.bcel.classfile.Field
+
+class KotlinObjectInstanceFieldDescriptor(field: Field, companion: KotlinClassDescriptor) : NativeFieldBytecodeDescriptor(field) {
+    override val isPublic = companion.isPublic
+    override val isInternal = companion.isInternal
+    override val isProtected = companion.isProtected
+}


### PR DESCRIPTION
Related to: https://github.com/NativeScript/android-runtime/issues/1563

Currently, due to an incorrect test, we had regressed the support of Kotlin in the runtime. 

Kotlin `object`s are compiled to a regular class at bytecode level and the special thing about them is a compiler-generated `INSTANCE` field of the same type as the class. 
In a commit included in 6.3.0 we have stripped the `INSTANCE` field and broken the Kotlin `object` support. 

This PR fixes the issue by gathering the `INSTANCE` field checking by name and type. There seems to be no way to get information if the currently parsed class is a Kotlin `object` from the Kotlin metadata.