### PR TITLE
Clean up allocations from finalized object links

### DIFF
--- a/test-app/runtime/src/main/cpp/ObjectManager.cpp
+++ b/test-app/runtime/src/main/cpp/ObjectManager.cpp
@@ -341,8 +341,7 @@ void ObjectManager::JSObjectFinalizer(Isolate *isolate, ObjectWeakCallbackState 
         auto jsInfoIdx = static_cast<int>(MetadataNodeKeys::JsInfo);
         po->Get(m_isolate)->SetInternalField(jsInfoIdx, Undefined(m_isolate));
         po->Reset();
-        auto it = m_idToObject.find(javaObjectID);
-        m_idToObject.erase(it);
+        m_idToObject.erase(javaObjectID);
         delete po;
         delete callbackState;
     }

--- a/test-app/runtime/src/main/cpp/ObjectManager.cpp
+++ b/test-app/runtime/src/main/cpp/ObjectManager.cpp
@@ -343,6 +343,8 @@ void ObjectManager::JSObjectFinalizer(Isolate *isolate, ObjectWeakCallbackState 
         po->Reset();
         auto it = m_idToObject.find(javaObjectID);
         m_idToObject.erase(it);
+        delete po;
+        delete callbackState;
     }
 }
 

--- a/test-app/runtime/src/main/cpp/ObjectManager.cpp
+++ b/test-app/runtime/src/main/cpp/ObjectManager.cpp
@@ -325,6 +325,8 @@ void ObjectManager::JSObjectFinalizer(Isolate *isolate, ObjectWeakCallbackState 
 
     if (jsInstanceInfo == nullptr) {
         po->Reset();
+        delete po;
+        delete callbackState;
         return;
     }
 

--- a/test-app/runtime/src/main/cpp/ObjectManager.cpp
+++ b/test-app/runtime/src/main/cpp/ObjectManager.cpp
@@ -341,6 +341,8 @@ void ObjectManager::JSObjectFinalizer(Isolate *isolate, ObjectWeakCallbackState 
         auto jsInfoIdx = static_cast<int>(MetadataNodeKeys::JsInfo);
         po->Get(m_isolate)->SetInternalField(jsInfoIdx, Undefined(m_isolate));
         po->Reset();
+        auto it = m_idToObject.find(javaObjectID);
+        m_idToObject.erase(it);
     }
 }
 


### PR DESCRIPTION
### Description
This PR is for fixing a memory leak which is caused by passing java objects to the javascript runtime. This memory leak is small, but with a lot of objects passed, it is certainly measurable. From our measurements. Every java object passed to javascript adds about 85bytes to the native memory which never gets cleaned up even if the object is garbage collected on both sides.
We found the native objects causing this leak and deleted them on finalization. 


### Does your commit message include the wording below to reference a specific issue in this repo?
No there is no issue for it in the repo currently

### Related Pull Requests
None

### Does your pull request have [unit tests]
No, this kind of memory leak is not unit-testable from java or javascript as far as I can tell. 
Setting up a cpp unit test suite for this would be overkill.
