### PR TITLE
DO NOT MERGE: Multithreaded javascript

### DIFF
--- a/test-app/app/src/main/assets/app/mainpage.js
+++ b/test-app/app/src/main/assets/app/mainpage.js
@@ -21,6 +21,7 @@ shared.runWeakRefTests();
 shared.runRuntimeTests();
 shared.runWorkerTests();
 require("./tests/testWebAssembly");
+require("./tests/testMultithreadedJavascript");
 require("./tests/testInterfaceDefaultMethods");
 require("./tests/testInterfaceStaticMethods");
 require("./tests/testMetadata");

--- a/test-app/app/src/main/assets/app/tests/testMultithreadedJavascript.js
+++ b/test-app/app/src/main/assets/app/tests/testMultithreadedJavascript.js
@@ -1,0 +1,18 @@
+describe("Test multithreaded javascript ", () => {
+    it("Should execute callbacks on specified native thread", done => {
+        const currentThreadId = java.lang.Thread.currentThread().getId();
+        new java.lang.Thread(new java.lang.Runnable({
+            run() {
+                const threadId = java.lang.Thread.currentThread().getId();
+                expect(threadId).not.toEqual(currentThreadId);
+
+                const mainHandler = new android.os.Handler(android.os.Looper.getMainLooper());
+                // done() must called on the main thread to ensure that jasmine tests
+                // continue executing there
+                mainHandler.post(new java.lang.Runnable({
+                    run: done
+                }));
+            }
+        })).start();
+    });
+});

--- a/test-app/app/src/main/java/com/tns/RuntimeHelper.java
+++ b/test-app/app/src/main/java/com/tns/RuntimeHelper.java
@@ -74,6 +74,7 @@ public final class RuntimeHelper {
 
             Logger logger = new LogcatLogger(context);
 
+            Runtime.nativeLibraryLoaded = true;
             Runtime runtime = null;
             boolean showErrorIntent = hasErrorIntent(context);
             if (!showErrorIntent) {

--- a/test-app/runtime/src/main/cpp/ArgConverter.cpp
+++ b/test-app/runtime/src/main/cpp/ArgConverter.cpp
@@ -13,9 +13,9 @@ using namespace v8;
 using namespace std;
 using namespace tns;
 
-void ArgConverter::Init(Isolate* isolate) {
+void ArgConverter::Init(Local<Context> context) {
+    Isolate* isolate = context->GetIsolate();
     auto cache = GetTypeLongCache(isolate);
-    auto context = isolate->GetCurrentContext();
 
     auto ft = FunctionTemplate::New(isolate, ArgConverter::NativeScriptLongFunctionCallback);
     ft->SetClassName(V8StringConstants::GetLongNumber(isolate));
@@ -93,10 +93,11 @@ jstring ArgConverter::ObjectToString(jobject object) {
     return (jstring) object;
 }
 
-Local<Array> ArgConverter::ConvertJavaArgsToJsArgs(Isolate* isolate, jobjectArray args) {
+Local<Array> ArgConverter::ConvertJavaArgsToJsArgs(Local<Context> context, jobjectArray args) {
     JEnv env;
 
     int argc = env.GetArrayLength(args) / 3;
+    auto isolate = context->GetIsolate();
     Local<Array> arr(Array::New(isolate, argc));
 
     auto runtime = Runtime::GetRuntime(isolate);
@@ -155,7 +156,6 @@ Local<Array> ArgConverter::ConvertJavaArgsToJsArgs(Isolate* isolate, jobjectArra
             break;
         }
 
-        auto context = isolate->GetCurrentContext();
         arr->Set(context, i, jsArg);
     }
 

--- a/test-app/runtime/src/main/cpp/ArgConverter.h
+++ b/test-app/runtime/src/main/cpp/ArgConverter.h
@@ -17,9 +17,9 @@ namespace tns {
 
 class ArgConverter {
     public:
-        static void Init(v8::Isolate* isolate);
+        static void Init(v8::Local<v8::Context> context);
 
-        static v8::Local<v8::Array> ConvertJavaArgsToJsArgs(v8::Isolate* isolate, jobjectArray args);
+        static v8::Local<v8::Array> ConvertJavaArgsToJsArgs(v8::Local<v8::Context> context, jobjectArray args);
 
         static v8::Local<v8::Value> ConvertFromJavaLong(v8::Isolate* isolate, jlong value);
 

--- a/test-app/runtime/src/main/cpp/ArrayBufferHelper.cpp
+++ b/test-app/runtime/src/main/cpp/ArrayBufferHelper.cpp
@@ -12,14 +12,13 @@ ArrayBufferHelper::ArrayBufferHelper()
           m_remainingMethodID(nullptr), m_getMethodID(nullptr) {
 }
 
-void ArrayBufferHelper::CreateConvertFunctions(Isolate* isolate, const Local<Object>& global, ObjectManager* objectManager) {
+void ArrayBufferHelper::CreateConvertFunctions(Local<Context> context, const Local<Object>& global, ObjectManager* objectManager) {
     m_objectManager = objectManager;
+    Isolate* isolate = context->GetIsolate();
     auto extData = External::New(isolate, this);
-    auto context = isolate->GetCurrentContext();
     auto fromFunc = FunctionTemplate::New(isolate, CreateFromCallbackStatic, extData)->GetFunction(context).ToLocalChecked();
-    auto ctx = isolate->GetCurrentContext();
     auto arrBufferCtorFunc = global->Get(context, ArgConverter::ConvertToV8String(isolate, "ArrayBuffer")).ToLocalChecked().As<Function>();
-    arrBufferCtorFunc->Set(ctx, ArgConverter::ConvertToV8String(isolate, "from"), fromFunc);
+    arrBufferCtorFunc->Set(context, ArgConverter::ConvertToV8String(isolate, "from"), fromFunc);
 }
 
 void ArrayBufferHelper::CreateFromCallbackStatic(const FunctionCallbackInfo<Value>& info) {

--- a/test-app/runtime/src/main/cpp/ArrayBufferHelper.h
+++ b/test-app/runtime/src/main/cpp/ArrayBufferHelper.h
@@ -9,7 +9,7 @@ namespace tns {
         public:
             ArrayBufferHelper();
 
-            void CreateConvertFunctions(v8::Isolate* isolate, const v8::Local<v8::Object>& global, ObjectManager* objectManager);
+            void CreateConvertFunctions(v8::Local<v8::Context> context, const v8::Local<v8::Object>& global, ObjectManager* objectManager);
 
         private:
 

--- a/test-app/runtime/src/main/cpp/ArrayElementAccessor.cpp
+++ b/test-app/runtime/src/main/cpp/ArrayElementAccessor.cpp
@@ -9,9 +9,10 @@ using namespace v8;
 using namespace std;
 using namespace tns;
 
-Local<Value> ArrayElementAccessor::GetArrayElement(Isolate* isolate, const Local<Object>& array, uint32_t index, const string& arraySignature) {
+Local<Value> ArrayElementAccessor::GetArrayElement(Local<Context> context, const Local<Object>& array, uint32_t index, const string& arraySignature) {
     JEnv env;
 
+    Isolate* isolate = context->GetIsolate();
     EscapableHandleScope handleScope(isolate);
     auto runtime = Runtime::GetRuntime(isolate);
     auto objectManager = runtime->GetObjectManager();
@@ -79,13 +80,13 @@ Local<Value> ArrayElementAccessor::GetArrayElement(Isolate* isolate, const Local
     return handleScope.Escape(value);
 }
 
-void ArrayElementAccessor::SetArrayElement(Isolate* isolate, const Local<Object>& array, uint32_t index, const string& arraySignature, Local<Value>& value) {
+void ArrayElementAccessor::SetArrayElement(Local<Context> context, const Local<Object>& array, uint32_t index, const string& arraySignature, Local<Value>& value) {
     JEnv env;
 
+    Isolate* isolate = context->GetIsolate();
     HandleScope handleScope(isolate);
     auto runtime = Runtime::GetRuntime(isolate);
     auto objectManager = runtime->GetObjectManager();
-    auto context = isolate->GetCurrentContext();
 
     tns::JniLocalRef arr = objectManager->GetJavaObjectByJsObject(array);
 
@@ -140,7 +141,7 @@ void ArrayElementAccessor::SetArrayElement(Isolate* isolate, const Local<Object>
         if (isReferenceType) {
             auto object = value.As<Object>();
 
-            JsArgToArrayConverter argConverter(isolate, value, false, (int) Type::Null);
+            JsArgToArrayConverter argConverter(context, value, false, (int) Type::Null);
             if (argConverter.IsValid()) {
                 jobjectArray objArr = static_cast<jobjectArray>(arr);
                 jobject objectElementValue = argConverter.GetConvertedArg();

--- a/test-app/runtime/src/main/cpp/ArrayElementAccessor.h
+++ b/test-app/runtime/src/main/cpp/ArrayElementAccessor.h
@@ -9,9 +9,9 @@
 namespace tns {
 class ArrayElementAccessor {
     public:
-        v8::Local<v8::Value> GetArrayElement(v8::Isolate* isolate, const v8::Local<v8::Object>& array, uint32_t index, const std::string& arraySignature);
+        v8::Local<v8::Value> GetArrayElement(v8::Local<v8::Context> context, const v8::Local<v8::Object>& array, uint32_t index, const std::string& arraySignature);
 
-        void SetArrayElement(v8::Isolate* isolate, const v8::Local<v8::Object>& array, uint32_t index, const std::string& arraySignature, v8::Local<v8::Value>& value);
+        void SetArrayElement(v8::Local<v8::Context> context, const v8::Local<v8::Object>& array, uint32_t index, const std::string& arraySignature, v8::Local<v8::Value>& value);
 
     private:
         v8::Local<v8::Value> ConvertToJsValue(v8::Isolate* isolate, ObjectManager* objectManager, JEnv& env, const std::string& elementSignature, const void* value);

--- a/test-app/runtime/src/main/cpp/CallbackHandlers.h
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.h
@@ -47,11 +47,11 @@ namespace tns {
         static std::string ResolveClassName(v8::Isolate *isolate, jclass &clazz);
 
         static v8::Local<v8::Value>
-        GetArrayElement(v8::Isolate *isolate, const v8::Local<v8::Object> &array, uint32_t index,
+        GetArrayElement(v8::Local<v8::Context> context, const v8::Local<v8::Object> &array, uint32_t index,
                         const std::string &arraySignature);
 
         static void
-        SetArrayElement(v8::Isolate *isolate, const v8::Local<v8::Object> &array, uint32_t index,
+        SetArrayElement(v8::Local<v8::Context> context, const v8::Local<v8::Object> &array, uint32_t index,
                         const std::string &arraySignature, v8::Local<v8::Value> &value);
 
         static int GetArrayLength(v8::Isolate *isolate, const v8::Local<v8::Object> &arr);

--- a/test-app/runtime/src/main/cpp/JsArgConverter.cpp
+++ b/test-app/runtime/src/main/cpp/JsArgConverter.cpp
@@ -15,7 +15,7 @@ using namespace std;
 using namespace tns;
 
 JsArgConverter::JsArgConverter(const Local<Object>& caller, const v8::FunctionCallbackInfo<Value>& args, const string& methodSignature, MetadataEntry* entry)
-        : m_isolate(args.GetIsolate()), m_env(JEnv()), m_methodSignature(methodSignature), m_isValid(true), m_error(Error()) {
+        : m_isolate(args.GetIsolate()), m_methodSignature(methodSignature), m_isValid(true), m_error(Error()) {
     int v8ProvidedArgumentsLength = args.Length();
     m_argsLen = 1 + v8ProvidedArgumentsLength;
 
@@ -48,7 +48,7 @@ JsArgConverter::JsArgConverter(const Local<Object>& caller, const v8::FunctionCa
 }
 
 JsArgConverter::JsArgConverter(const v8::FunctionCallbackInfo<Value>& args, bool hasImplementationObject, const string& methodSignature, MetadataEntry* entry)
-    : m_isolate(args.GetIsolate()), m_env(JEnv()), m_methodSignature(methodSignature), m_isValid(true), m_error(Error()) {
+    : m_isolate(args.GetIsolate()), m_methodSignature(methodSignature), m_isValid(true), m_error(Error()) {
     m_argsLen = !hasImplementationObject ? args.Length() : args.Length() - 1;
 
     if (m_argsLen > 0) {
@@ -74,7 +74,7 @@ JsArgConverter::JsArgConverter(const v8::FunctionCallbackInfo<Value>& args, bool
 }
 
 JsArgConverter::JsArgConverter(const v8::FunctionCallbackInfo<Value>& args, const string& methodSignature)
-    : m_isolate(args.GetIsolate()), m_env(JEnv()), m_methodSignature(methodSignature), m_isValid(true), m_error(Error()) {
+    : m_isolate(args.GetIsolate()), m_methodSignature(methodSignature), m_isValid(true), m_error(Error()) {
     m_argsLen = args.Length();
 
     JniSignatureParser parser(m_methodSignature);
@@ -366,76 +366,77 @@ bool JsArgConverter::ConvertJavaScriptArray(const Local<Array>& jsArr, int index
     jclass elementClass;
     string strippedClassName;
 
+    JEnv env;
     switch (elementTypePrefix) {
     case 'Z':
-        arr = m_env.NewBooleanArray(arrLength);
+        arr = env.NewBooleanArray(arrLength);
         for (jsize i = 0; i < arrLength; i++) {
             jboolean value = jsArr->Get(context, i).ToLocalChecked()->BooleanValue(m_isolate);
-            m_env.SetBooleanArrayRegion((jbooleanArray) arr, i, 1, &value);
+            env.SetBooleanArrayRegion((jbooleanArray) arr, i, 1, &value);
         }
         break;
     case 'B':
-        arr = m_env.NewByteArray(arrLength);
+        arr = env.NewByteArray(arrLength);
         for (jsize i = 0; i < arrLength; i++) {
             jbyte value = jsArr->Get(context, i).ToLocalChecked()->Int32Value(context).ToChecked();
-            m_env.SetByteArrayRegion((jbyteArray) arr, i, 1, &value);
+            env.SetByteArrayRegion((jbyteArray) arr, i, 1, &value);
         }
         break;
     case 'C':
-        arr = m_env.NewCharArray(arrLength);
+        arr = env.NewCharArray(arrLength);
         for (jsize i = 0; i < arrLength; i++) {
             String::Utf8Value utf8(m_isolate, jsArr->Get(context, i).ToLocalChecked()->ToString(context).ToLocalChecked());
-            JniLocalRef s(m_env.NewString((jchar*) *utf8, 1));
-            const char* singleChar = m_env.GetStringUTFChars(s, nullptr);
+            JniLocalRef s(env.NewString((jchar*) *utf8, 1));
+            const char* singleChar = env.GetStringUTFChars(s, nullptr);
             jchar value = *singleChar;
-            m_env.ReleaseStringUTFChars(s, singleChar);
-            m_env.SetCharArrayRegion((jcharArray) arr, i, 1, &value);
+            env.ReleaseStringUTFChars(s, singleChar);
+            env.SetCharArrayRegion((jcharArray) arr, i, 1, &value);
         }
         break;
     case 'S':
-        arr = m_env.NewShortArray(arrLength);
+        arr = env.NewShortArray(arrLength);
         for (jsize i = 0; i < arrLength; i++) {
             jshort value = jsArr->Get(context, i).ToLocalChecked()->Int32Value(context).ToChecked();
-            m_env.SetShortArrayRegion((jshortArray) arr, i, 1, &value);
+            env.SetShortArrayRegion((jshortArray) arr, i, 1, &value);
         }
         break;
     case 'I':
-        arr = m_env.NewIntArray(arrLength);
+        arr = env.NewIntArray(arrLength);
         for (jsize i = 0; i < arrLength; i++) {
             jint value = jsArr->Get(context, i).ToLocalChecked()->Int32Value(context).ToChecked();
-            m_env.SetIntArrayRegion((jintArray) arr, i, 1, &value);
+            env.SetIntArrayRegion((jintArray) arr, i, 1, &value);
         }
         break;
     case 'J':
-        arr = m_env.NewLongArray(arrLength);
+        arr = env.NewLongArray(arrLength);
         for (jsize i = 0; i < arrLength; i++) {
             jlong value = jsArr->Get(context, i).ToLocalChecked()->NumberValue(context).ToChecked();
-            m_env.SetLongArrayRegion((jlongArray) arr, i, 1, &value);
+            env.SetLongArrayRegion((jlongArray) arr, i, 1, &value);
         }
         break;
     case 'F':
-        arr = m_env.NewFloatArray(arrLength);
+        arr = env.NewFloatArray(arrLength);
         for (jsize i = 0; i < arrLength; i++) {
             jfloat value = jsArr->Get(context, i).ToLocalChecked()->NumberValue(context).ToChecked();
-            m_env.SetFloatArrayRegion((jfloatArray) arr, i, 1, &value);
+            env.SetFloatArrayRegion((jfloatArray) arr, i, 1, &value);
         }
         break;
     case 'D':
-        arr = m_env.NewDoubleArray(arrLength);
+        arr = env.NewDoubleArray(arrLength);
         for (jsize i = 0; i < arrLength; i++) {
             jdouble value = jsArr->Get(context, i).ToLocalChecked()->NumberValue(context).ToChecked();
-            m_env.SetDoubleArrayRegion((jdoubleArray) arr, i, 1, &value);
+            env.SetDoubleArrayRegion((jdoubleArray) arr, i, 1, &value);
         }
         break;
     case 'L':
         strippedClassName = elementType.substr(1, elementType.length() - 2);
-        elementClass = m_env.FindClass(strippedClassName);
-        arr = m_env.NewObjectArray(arrLength, elementClass, nullptr);
+        elementClass = env.FindClass(strippedClassName);
+        arr = env.NewObjectArray(arrLength, elementClass, nullptr);
         for (int i = 0; i < arrLength; i++) {
             auto v = jsArr->Get(context, i).ToLocalChecked();
             JsArgToArrayConverter c(context, v, false, (int) Type::Null);
             jobject o = c.GetConvertedArg();
-            m_env.SetObjectArrayElement((jobjectArray) arr, i, o);
+            env.SetObjectArrayElement((jobjectArray) arr, i, o);
         }
         break;
     default:
@@ -515,10 +516,11 @@ JsArgConverter::Error JsArgConverter::GetError() const {
 
 JsArgConverter::~JsArgConverter() {
     if (m_argsLen > 0) {
+        JEnv env;
         int length = m_storedObjects.size();
         for (int i = 0; i < length; i++) {
             int index = m_storedObjects[i];
-            m_env.DeleteLocalRef(m_args[index].l);
+            env.DeleteLocalRef(m_args[index].l);
         }
     }
 }

--- a/test-app/runtime/src/main/cpp/JsArgConverter.cpp
+++ b/test-app/runtime/src/main/cpp/JsArgConverter.cpp
@@ -433,7 +433,7 @@ bool JsArgConverter::ConvertJavaScriptArray(const Local<Array>& jsArr, int index
         arr = m_env.NewObjectArray(arrLength, elementClass, nullptr);
         for (int i = 0; i < arrLength; i++) {
             auto v = jsArr->Get(context, i).ToLocalChecked();
-            JsArgToArrayConverter c(m_isolate, v, false, (int) Type::Null);
+            JsArgToArrayConverter c(context, v, false, (int) Type::Null);
             jobject o = c.GetConvertedArg();
             m_env.SetObjectArrayElement((jobjectArray) arr, i, o);
         }

--- a/test-app/runtime/src/main/cpp/JsArgConverter.h
+++ b/test-app/runtime/src/main/cpp/JsArgConverter.h
@@ -55,8 +55,6 @@ class JsArgConverter {
         template<typename T>
         bool ConvertFromCastFunctionObject(T value, int index);
 
-        JEnv m_env;
-
         v8::Isolate* m_isolate;
 
         int m_argsLen;

--- a/test-app/runtime/src/main/cpp/JsArgToArrayConverter.h
+++ b/test-app/runtime/src/main/cpp/JsArgToArrayConverter.h
@@ -12,7 +12,7 @@ class JsArgToArrayConverter {
     public:
         JsArgToArrayConverter(const v8::FunctionCallbackInfo<v8::Value>& args, bool hasImplementationObject);
 
-        JsArgToArrayConverter(v8::Isolate* isolate, const v8::Local<v8::Value>& arg, bool isImplementationObject, int classReturnType);
+        JsArgToArrayConverter(v8::Local<v8::Context> context, const v8::Local<v8::Value>& arg, bool isImplementationObject, int classReturnType);
 
         ~JsArgToArrayConverter();
 
@@ -38,11 +38,9 @@ class JsArgToArrayConverter {
         };
 
     private:
-        bool ConvertArg(const v8::Local<v8::Value>& arg, int index);
+        bool ConvertArg(v8::Local<v8::Context> context, const v8::Local<v8::Value>& arg, int index);
 
         void SetConvertedObject(JEnv& env, int index, jobject obj, bool isGlobal = false);
-
-        v8::Isolate* m_isolate;
 
         int m_argsLen;
 

--- a/test-app/runtime/src/main/cpp/JsV8InspectorClient.cpp
+++ b/test-app/runtime/src/main/cpp/JsV8InspectorClient.cpp
@@ -60,6 +60,7 @@ void JsV8InspectorClient::disconnect() {
         return;
     }
 
+    v8::Locker locker(isolate_);
     Isolate::Scope isolate_scope(isolate_);
     v8::HandleScope handleScope(isolate_);
 
@@ -76,9 +77,11 @@ void JsV8InspectorClient::disconnect() {
 
 
 void JsV8InspectorClient::dispatchMessage(const std::string& message) {
+    v8::Locker locker(isolate_);
     Isolate::Scope isolate_scope(isolate_);
     v8::HandleScope handleScope(isolate_);
-    Context::Scope context_scope(isolate_->GetCurrentContext());
+    auto context = Runtime::GetRuntime(isolate_)->GetContext();
+    Context::Scope context_scope(context);
 
     this->doDispatchMessage(isolate_, message);
 }
@@ -177,9 +180,10 @@ void JsV8InspectorClient::init() {
         return;
     }
 
+    v8::Locker locker(isolate_);
+    v8::Isolate::Scope isolate_scope(isolate_);
     v8::HandleScope handle_scope(isolate_);
-
-    v8::Local<Context> context = isolate_->GetCurrentContext();
+    v8::Local<Context> context = Runtime::GetRuntime(isolate_)->GetContext();
 
     inspector_ = V8Inspector::create(isolate_, this);
 

--- a/test-app/runtime/src/main/cpp/MessageLoopTimer.cpp
+++ b/test-app/runtime/src/main/cpp/MessageLoopTimer.cpp
@@ -124,6 +124,7 @@ int MessageLoopTimer::PumpMessageLoopCallback(int fd, int events, void* data) {
     read(fd, &msg, sizeof(uint8_t));
 
     auto isolate = static_cast<Isolate*>(data);
+    v8::Locker locker(isolate);
     v8::Isolate::Scope isolate_scope(isolate);
     v8::HandleScope handleScope(isolate);
 

--- a/test-app/runtime/src/main/cpp/MetadataNode.cpp
+++ b/test-app/runtime/src/main/cpp/MetadataNode.cpp
@@ -72,7 +72,7 @@ Local<Object> MetadataNode::CreateExtendedJSWrapper(Isolate* isolate, ObjectMana
         extInstance = objectManager->GetEmptyObject(isolate);
         extInstance->SetInternalField(static_cast<int>(ObjectManager::MetadataNodeKeys::CallSuper), True(isolate));
         auto extdCtorFunc = Local<Function>::New(isolate, *cacheData.extendedCtorFunction);
-        auto context = isolate->GetCurrentContext();
+        auto context = Runtime::GetRuntime(isolate)->GetContext();
         extInstance->SetPrototype(context, extdCtorFunc->Get(context, V8StringConstants::GetPrototype(isolate)).ToLocalChecked());
         extInstance->Set(context, ArgConverter::ConvertToV8String(isolate, "constructor"), extdCtorFunc);
 
@@ -1232,10 +1232,11 @@ void MetadataNode::ArrayIndexedPropertyGetterCallback(uint32_t index, const Prop
     try {
         auto thiz = info.This();
         auto isolate = info.GetIsolate();
+        auto context = isolate->GetCurrentContext();
 
         auto node = GetNodeFromHandle(thiz);
 
-        auto element = CallbackHandlers::GetArrayElement(isolate, thiz, index, node->m_name);
+        auto element = CallbackHandlers::GetArrayElement(context, thiz, index, node->m_name);
 
         info.GetReturnValue().Set(element);
     } catch (NativeScriptException& e) {
@@ -1255,10 +1256,11 @@ void MetadataNode::ArrayIndexedPropertySetterCallback(uint32_t index, Local<Valu
     try {
         auto thiz = info.This();
         auto isolate = info.GetIsolate();
+        auto context = isolate->GetCurrentContext();
 
         auto node = GetNodeFromHandle(thiz);
 
-        CallbackHandlers::SetArrayElement(isolate, thiz, index, node->m_name, value);
+        CallbackHandlers::SetArrayElement(context, thiz, index, node->m_name, value);
 
         info.GetReturnValue().Set(value);
     } catch (NativeScriptException& e) {

--- a/test-app/runtime/src/main/cpp/ModuleInternal.cpp
+++ b/test-app/runtime/src/main/cpp/ModuleInternal.cpp
@@ -198,22 +198,21 @@ void ModuleInternal::RequireNativeCallback(const v8::FunctionCallbackInfo<v8::Va
     funcPtr(args);
 }
 
-void ModuleInternal::Load(const string& path) {
+void ModuleInternal::Load(Local<Context> context, const string& path) {
     TNSPERF();
     auto isolate = m_isolate;
-    auto context = isolate->GetCurrentContext();
     auto globalObject = context->Global();
     auto require = globalObject->Get(context, ArgConverter::ConvertToV8String(isolate, "require")).ToLocalChecked().As<Function>();
     Local<Value> args[] = { ArgConverter::ConvertToV8String(isolate, path) };
     require->Call(context, globalObject, 1, args);
 }
 
-void ModuleInternal::LoadWorker(const string& path) {
+void ModuleInternal::LoadWorker(Local<Context> context, const string& path) {
     TNSPERF();
     auto isolate = m_isolate;
     TryCatch tc(isolate);
 
-    Load(path);
+    Load(context, path);
 
     if (tc.HasCaught()) {
         // This will handle any errors that occur when first loading a script (new worker)

--- a/test-app/runtime/src/main/cpp/ModuleInternal.h
+++ b/test-app/runtime/src/main/cpp/ModuleInternal.h
@@ -23,13 +23,13 @@ class ModuleInternal {
 
         void Init(v8::Isolate* isolate, const std::string& baseDir = "");
 
-        void Load(const std::string& path);
+        void Load(v8::Local<v8::Context> context, const std::string& path);
 
         /*
          * Reuses `Load` logic and adds TryCatch exception handling to push any unhandled exceptions
          * during script's initial load through the worker scope's `onerror` handler (if implemented before the exception was thrown)
          */
-        void LoadWorker(const std::string& path);
+        void LoadWorker(v8::Local<v8::Context> context, const std::string& path);
 
         /*
          * Checks if target script exists, will throw if negative

--- a/test-app/runtime/src/main/cpp/ObjectManager.cpp
+++ b/test-app/runtime/src/main/cpp/ObjectManager.cpp
@@ -876,7 +876,8 @@ void ObjectManager::DeleteWeakGlobalRefCallback(const jweak &object, void *state
 
 Local<Object> ObjectManager::GetEmptyObject(Isolate *isolate) {
     auto emptyObjCtorFunc = Local<Function>::New(isolate, *m_poJsWrapperFunc);
-    auto val = emptyObjCtorFunc->CallAsConstructor(isolate->GetCurrentContext(), 0, nullptr);
+    auto context = Runtime::GetRuntime(isolate)->GetContext();
+    auto val = emptyObjCtorFunc->CallAsConstructor(context, 0, nullptr);
     if (val.IsEmpty()) {
         return Local<Object>();
     }

--- a/test-app/runtime/src/main/cpp/ObjectManager.h
+++ b/test-app/runtime/src/main/cpp/ObjectManager.h
@@ -199,8 +199,6 @@ class ObjectManager {
 
         int m_numberOfGC;
 
-        JEnv m_env;
-
         v8::Isolate* m_isolate;
 
         std::stack<GarbageCollectionInfo> m_markedForGC;

--- a/test-app/runtime/src/main/cpp/Runtime.h
+++ b/test-app/runtime/src/main/cpp/Runtime.h
@@ -13,8 +13,6 @@
 #include "File.h"
 #include <mutex>
 
-jobject ConvertJsValueToJavaObject(tns::JEnv& env, const v8::Local<v8::Value>& value, int classReturnType);
-
 namespace tns {
 class Runtime {
     public:
@@ -38,7 +36,7 @@ class Runtime {
 
         static void SetManualInstrumentationMode(jstring mode);
 
-        void Init(jstring filesPath, jstring nativeLibsDir, bool verboseLoggingEnabled, bool isDebuggable, jstring packageName, jobjectArray args, jstring callingDir, int maxLogcatObjectSize, bool forceLog);
+        void Init(JNIEnv* env, jstring filesPath, jstring nativeLibsDir, bool verboseLoggingEnabled, bool isDebuggable, jstring packageName, jobjectArray args, jstring callingDir, int maxLogcatObjectSize, bool forceLog);
 
         v8::Isolate* GetIsolate() const;
 
@@ -63,6 +61,8 @@ class Runtime {
         void Lock();
         void Unlock();
 
+        int GetId();
+
         v8::Local<v8::Context> GetContext();
 
         static v8::Platform* platform;
@@ -72,7 +72,6 @@ class Runtime {
     private:
         Runtime(JNIEnv* env, jobject runtime, int id);
 
-        JEnv m_env;
         int m_id;
         jobject m_runtime;
         v8::Isolate* m_isolate;

--- a/test-app/runtime/src/main/cpp/Runtime.h
+++ b/test-app/runtime/src/main/cpp/Runtime.h
@@ -63,6 +63,8 @@ class Runtime {
         void Lock();
         void Unlock();
 
+        v8::Local<v8::Context> GetContext();
+
         static v8::Platform* platform;
 
         std::string ReadFileText(const std::string& filePath);
@@ -94,6 +96,8 @@ class Runtime {
 
         v8::Persistent<v8::Function>* m_gcFunc;
         volatile bool m_runGC;
+
+        v8::Persistent<v8::Context>* m_context;
 
         v8::Isolate* PrepareV8Runtime(const std::string& filesPath, const std::string& nativeLibsDir, const std::string& packageName, bool isDebuggable, const std::string& callingDir, const std::string& profilerOutputDir, const int maxLogcatObjectSize, const bool forceLog);
         jobject ConvertJsValueToJavaObject(JEnv& env, const v8::Local<v8::Value>& value, int classReturnType);

--- a/test-app/runtime/src/main/cpp/com_tns_Runtime.cpp
+++ b/test-app/runtime/src/main/cpp/com_tns_Runtime.cpp
@@ -75,8 +75,11 @@ extern "C" JNIEXPORT void Java_com_tns_Runtime_runModule(JNIEnv* _env, jobject o
     }
 
     auto isolate = runtime->GetIsolate();
+    v8::Locker locker(isolate);
     v8::Isolate::Scope isolate_scope(isolate);
     v8::HandleScope handleScope(isolate);
+    auto context = runtime->GetContext();
+    v8::Context::Scope context_scope(context);
 
     try {
         runtime->RunModule(_env, obj, scriptFile);
@@ -100,8 +103,11 @@ extern "C" JNIEXPORT void Java_com_tns_Runtime_runWorker(JNIEnv* _env, jobject o
     }
 
     auto isolate = runtime->GetIsolate();
+    v8::Locker locker(isolate);
     v8::Isolate::Scope isolate_scope(isolate);
     v8::HandleScope handleScope(isolate);
+    auto context = runtime->GetContext();
+    v8::Context::Scope context_scope(context);
 
     try {
         runtime->RunWorker(scriptFile);
@@ -127,8 +133,11 @@ extern "C" JNIEXPORT jobject Java_com_tns_Runtime_runScript(JNIEnv* _env, jobjec
     }
 
     auto isolate = runtime->GetIsolate();
+    v8::Locker locker(isolate);
     v8::Isolate::Scope isolate_scope(isolate);
     v8::HandleScope handleScope(isolate);
+    auto context = runtime->GetContext();
+    v8::Context::Scope context_scope(context);
 
     try {
         result = runtime->RunScript(_env, obj, scriptFile);
@@ -155,8 +164,11 @@ extern "C" JNIEXPORT jobject Java_com_tns_Runtime_callJSMethodNative(JNIEnv* _en
     }
 
     auto isolate = runtime->GetIsolate();
+    v8::Locker locker(isolate);
     v8::Isolate::Scope isolate_scope(isolate);
     v8::HandleScope handleScope(isolate);
+    auto context = runtime->GetContext();
+    v8::Context::Scope context_scope(context);
 
     try {
         result = runtime->CallJSMethodNative(_env, obj, javaObjectID, methodName, retType, isConstructor, packagedArgs);
@@ -181,8 +193,11 @@ extern "C" JNIEXPORT void Java_com_tns_Runtime_createJSInstanceNative(JNIEnv* _e
     }
 
     auto isolate = runtime->GetIsolate();
+    v8::Locker locker(isolate);
     v8::Isolate::Scope isolate_scope(isolate);
     v8::HandleScope handleScope(isolate);
+    auto context = runtime->GetContext();
+    v8::Context::Scope context_scope(context);
 
     try {
         runtime->CreateJSInstanceNative(_env, obj, javaObject, javaObjectID, className);
@@ -252,8 +267,11 @@ extern "C" JNIEXPORT void Java_com_tns_Runtime_passExceptionToJsNative(JNIEnv* e
     }
 
     auto isolate = runtime->GetIsolate();
+    v8::Locker locker(isolate);
     v8::Isolate::Scope isolate_scope(isolate);
     v8::HandleScope handleScope(isolate);
+    auto context = runtime->GetContext();
+    v8::Context::Scope context_scope(context);
 
     try {
         runtime->PassExceptionToJsNative(env, obj, exception, message, fullStackTrace, jsStackTrace, isDiscarded);
@@ -292,8 +310,11 @@ extern "C" JNIEXPORT void Java_com_tns_Runtime_WorkerGlobalOnMessageCallback(JNI
 
     auto isolate = runtime->GetIsolate();
 
+    v8::Locker locker(isolate);
     v8::Isolate::Scope isolate_scope(isolate);
     v8::HandleScope handleScope(isolate);
+    auto context = runtime->GetContext();
+    v8::Context::Scope context_scope(context);
 
     CallbackHandlers::WorkerGlobalOnMessageCallback(isolate, msg);
 }
@@ -307,8 +328,11 @@ extern "C" JNIEXPORT void Java_com_tns_Runtime_WorkerObjectOnMessageCallback(JNI
 
     auto isolate = runtime->GetIsolate();
 
+    v8::Locker locker(isolate);
     v8::Isolate::Scope isolate_scope(isolate);
     v8::HandleScope handleScope(isolate);
+    auto context = runtime->GetContext();
+    v8::Context::Scope context_scope(context);
 
     CallbackHandlers::WorkerObjectOnMessageCallback(isolate, workerId, msg);
 }
@@ -323,6 +347,7 @@ extern "C" JNIEXPORT void Java_com_tns_Runtime_TerminateWorkerCallback(JNIEnv* e
     auto isolate = runtime->GetIsolate();
 
     {
+        v8::Locker locker(isolate);
         v8::Isolate::Scope isolate_scope(isolate);
         v8::HandleScope handleScope(isolate);
 
@@ -345,8 +370,11 @@ extern "C" JNIEXPORT void Java_com_tns_Runtime_ClearWorkerPersistent(JNIEnv* env
 
     auto isolate = runtime->GetIsolate();
 
+    v8::Locker locker(isolate);
     v8::Isolate::Scope isolate_scope(isolate);
     v8::HandleScope handleScope(isolate);
+    auto context = runtime->GetContext();
+    v8::Context::Scope context_scope(context);
 
     CallbackHandlers::ClearWorkerPersistent(workerId);
 }
@@ -359,8 +387,11 @@ extern "C" JNIEXPORT void Java_com_tns_Runtime_CallWorkerObjectOnErrorHandleMain
     }
 
     auto isolate = runtime->GetIsolate();
+    v8::Locker locker(isolate);
     v8::Isolate::Scope isolate_scope(isolate);
     v8::HandleScope handleScope(isolate);
+    auto context = runtime->GetContext();
+    v8::Context::Scope context_scope(context);
 
     try {
         CallbackHandlers::CallWorkerObjectOnErrorHandle(isolate, workerId, message, stackTrace, filename, lineno, threadName);

--- a/test-app/runtime/src/main/cpp/com_tns_Runtime.cpp
+++ b/test-app/runtime/src/main/cpp/com_tns_Runtime.cpp
@@ -301,6 +301,17 @@ extern "C" JNIEXPORT jint Java_com_tns_Runtime_getPointerSize(JNIEnv* env, jobje
     return sizeof(void*);
 }
 
+extern "C" JNIEXPORT jint Java_com_tns_Runtime_getCurrentRuntimeId(JNIEnv* _env, jobject obj) {
+    Isolate* isolate = Isolate::GetCurrent();
+    if (isolate == nullptr) {
+        return -1;
+    }
+
+    Runtime* runtime = Runtime::GetRuntime(isolate);
+    int id = runtime->GetId();
+    return id;
+}
+
 extern "C" JNIEXPORT void Java_com_tns_Runtime_WorkerGlobalOnMessageCallback(JNIEnv* env, jobject obj, jint runtimeId, jstring msg) {
     // Worker Thread runtime
     auto runtime = TryGetRuntime(runtimeId);

--- a/test-app/runtime/src/main/java/com/tns/AppConfig.java
+++ b/test-app/runtime/src/main/java/com/tns/AppConfig.java
@@ -21,7 +21,8 @@ class AppConfig {
         MaxLogcatObjectSize("maxLogcatObjectSize", 1024),
         ForceLog("forceLog", false),
         DiscardUncaughtJsExceptions("discardUncaughtJsExceptions", false),
-        EnableLineBreakpoins("enableLineBreakpoints", false);
+        EnableLineBreakpoins("enableLineBreakpoints", false),
+        EnableMultithreadedJavascript("enableMultithreadedJavascript", true);
 
         private final String name;
         private final Object defaultValue;
@@ -122,6 +123,9 @@ class AppConfig {
                     if (androidObject.has(KnownKeys.EnableLineBreakpoins.getName())) {
                         values[KnownKeys.EnableLineBreakpoins.ordinal()] = androidObject.getBoolean(KnownKeys.EnableLineBreakpoins.getName());
                     }
+                    if (androidObject.has(KnownKeys.EnableMultithreadedJavascript.getName())) {
+                        values[KnownKeys.EnableMultithreadedJavascript.ordinal()] = androidObject.getBoolean(KnownKeys.EnableMultithreadedJavascript.getName());
+                    }
                 }
             }
         } catch (Exception e) {
@@ -181,5 +185,9 @@ class AppConfig {
 
     public boolean getDiscardUncaughtJsExceptions() {
         return (boolean)values[KnownKeys.DiscardUncaughtJsExceptions.ordinal()];
+    }
+
+    public boolean getEnableMultithreadedJavascript() {
+        return (boolean)values[KnownKeys.EnableMultithreadedJavascript.ordinal()];
     }
 }

--- a/test-app/runtime/src/main/java/com/tns/Runtime.java
+++ b/test-app/runtime/src/main/java/com/tns/Runtime.java
@@ -62,6 +62,8 @@ public class Runtime {
 
     private native void clearStartupData(int runtimeId);
 
+    private static native int getCurrentRuntimeId();
+
     public static native int getPointerSize();
 
     public static native void SetManualInstrumentationMode(String mode);
@@ -175,6 +177,7 @@ public class Runtime {
     private final static ThreadLocal<Runtime> currentRuntime = new ThreadLocal<Runtime>();
     private final static Map<Integer, Runtime> runtimeCache = new ConcurrentHashMap<>();
     public static Map<Integer, ConcurrentLinkedQueue<Message>> pendingWorkerMessages = new ConcurrentHashMap<>();
+    public static boolean nativeLibraryLoaded;
 
     /*
         Holds reference to all Worker Threads' handlers
@@ -233,6 +236,13 @@ public class Runtime {
 
     public static Runtime getCurrentRuntime() {
         Runtime runtime = currentRuntime.get();
+
+        if (runtime == null && nativeLibraryLoaded) {
+            // Attempt to retrieve the runtime id from the currently
+            // entered V8 isolate
+            int runtimeId = getCurrentRuntimeId();
+            runtime = runtimeCache.get(runtimeId);
+        }
 
         return runtime;
     }

--- a/test-app/runtime/src/main/java/com/tns/Runtime.java
+++ b/test-app/runtime/src/main/java/com/tns/Runtime.java
@@ -1279,8 +1279,9 @@ public class Runtime {
 
         final Object[] tmpArgs = extendConstructorArgs(methodName, isConstructor, args);
         final boolean discardUncaughtJsExceptions = this.config.appConfig.getDiscardUncaughtJsExceptions();
+        boolean enableMultithreadedJavascript = this.config.appConfig.getEnableMultithreadedJavascript();
 
-        if (isWorkThread) {
+        if (enableMultithreadedJavascript || isWorkThread) {
             Object[] packagedArgs = packageArgs(tmpArgs);
             try {
                 ret = callJSMethodNative(getRuntimeId(), javaObjectID, methodName, returnType, isConstructor, packagedArgs);


### PR DESCRIPTION
In this PR we are introducing the `enableMultithreadedJavascript` feature flag which allows to execute javascript code from arbitrary threads.

Consider the following example:

```javascript
new java.lang.Thread(new java.lang.Runnable({
    run() {
        const mainLooper = android.os.Looper.getMainLooper();
        const currentLooper = android.os.Looper.myLooper();
        const isMainThread = currentLooper === mainLooper;
        console.log(isMainThread); // should print false
    }
})).start();
```

We have identified 3 tasks to implement the feature:

- [x] Introduce `v8::Locker` objects to ensure re-entrancy of the V8 isolates
- [x] Thread-safe JNI
- [x] `Runtime.currentRuntime` should not rely on `ThreadLocal` storage only. When running on a background thread it should retrieve the runtime from the currently entered V8 isolate.

