### PR TITLE
Make buildMetadata aware of whitelist/blacklist files

### DIFF
--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -767,6 +767,9 @@ task buildMetadata(type: BuildToolTask) {
     description "builds metadata with provided jar dependencies"
 
     inputs.files("$MDG_JAVA_DEPENDENCIES")
+    
+    // make MDG aware of whitelist.mdg and blacklist.mdg files
+    inputs.files(project.fileTree(dir: "$rootDir", include: "**/*.mdg"))
 
     def classesDir = "$buildDir/intermediates/javac"
     inputs.dir(classesDir)


### PR DESCRIPTION
Related to: https://github.com/NativeScript/android-runtime/issues/1589