### PR TITLE
build(deps): upgrade gradle and android plugin to latest stable

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue May 12 20:24:09 CEST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-all.zip

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "**/*"
   ],
   "gradle": {
-    "version": "5.4.1",
-    "android": "3.5.3"
+    "version": "6.4",
+    "android": "3.6.3"
   },
   "android_ndk_version": "21"
 }

--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -778,6 +778,9 @@ task buildMetadata(type: BuildToolTask) {
 
     outputs.files("$METADATA_OUT_PATH/treeNodeStream.dat", "$METADATA_OUT_PATH/treeStringsStream.dat", "$METADATA_OUT_PATH/treeValueStream.dat")
 
+    workingDir "$BUILD_TOOLS_PATH"
+    main "-jar"
+
     doFirst {
         // get compiled classes to pass to metadata generator
         // these need to be called after the classes have compiled
@@ -812,9 +815,6 @@ task buildMetadata(type: BuildToolTask) {
             generatedClasses.each { out.println it }
         }
 
-        workingDir "$BUILD_TOOLS_PATH"
-        main "-jar"
-
         setOutputs outLogger
 
         def paramz = new ArrayList<String>()
@@ -840,12 +840,11 @@ task generateTypescriptDefinitions(type: BuildToolTask) {
     def paramz = new ArrayList<String>()
     def includeDirs = ["com.android.support", "/platforms/" + android.compileSdkVersion]
 
+    workingDir "$BUILD_TOOLS_PATH"
+    main "-jar"
+
     doFirst {
         delete "$TYPINGS_PATH"
-
-        workingDir "$BUILD_TOOLS_PATH"
-
-        main "-jar"
 
         paramz.add("dts-generator.jar")
         paramz.add("-input")

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }

--- a/test-app/gradle/wrapper/gradle-wrapper.properties
+++ b/test-app/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Aug 26 10:52:45 EEST 2019
+#Tue May 12 21:42:57 CEST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-all.zip


### PR DESCRIPTION
<!--Dear friend, we, the rest of the NativeScript community thank you for your
contribution! Because we want to present a really nice, readable changelog with each
release, please provide the following information: -->

### Create a meaningful title
<!-- Please, ensure your title is less than 50 characters and starts with a capital letter. We strive to follow the guidelines in the
[How to Write a Git Commit Message] (http://chris.beams.io/posts/git-commit/) article for PR titles. -->
Upgrade gradle and android plugin to latest stable

### Description
Upgraded to latest stable gradle and android plugin.

The `main` field has been moved out of the `doFirst` block because after gradle 6.3 it throws an error that the `main` field is final and cannot be modified. 

### Does your commit message include the wording below to reference a specific issue in this repo?
<!--Fixes/Implements #[Issue Number]. -->

### Related Pull Requests
<!-- List links related to this Pull Request from other repos/branches: -->

### Does your pull request have [unit tests](https://github.com/NativeScript/NativeScript/blob/master/running-tests.md)?
<!--If not, why?
If not, please tell us why tests are not included, and list all steps needed to test your pull request manually. -->
The existing tests pass locally. A test application builds fine with the changes.
