### PR TITLE
(fix) Java 8 compatibility when build with Java 9+

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tns-android",
   "description": "NativeScript Runtime for Android",
-  "version": "6.6.0",
+  "version": "6.5.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/NativeScript/android-runtime.git"

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/Writer.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/Writer.java
@@ -4,6 +4,7 @@ import com.telerik.metadata.TreeNode.FieldInfo;
 import com.telerik.metadata.TreeNode.MethodInfo;
 
 import java.nio.ByteBuffer;
+import java.nio.Buffer;
 import java.nio.ByteOrder;
 import java.nio.IntBuffer;
 import java.nio.charset.StandardCharsets;
@@ -346,7 +347,7 @@ public class Writer {
             nodeData[1] = n.offsetName;
             nodeData[2] = n.offsetValue;
 
-            intBuffer.clear();
+            ((Buffer)intBuffer).clear();
             intBuffer.put(nodeData);
             outNodeStream.write(byteBuffer.array());
 


### PR DESCRIPTION
### Description
When building the metadata generator with Java 9+; Java 8 can't run it do to a breaking change in a return type of Buffer and IntBuffer.


