### PR TITLE
Fix for extra MetaData duplication and invalid rehydration with Kotlin

### DIFF
--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/Builder.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/Builder.java
@@ -98,6 +98,14 @@ public class Builder {
             }
         }
 
+        System.out.println("Added   Properties "+TreeNode.addedProperties);
+        System.out.println("Ignored Properties "+TreeNode.skippedProperties+" duplicates.");
+        System.out.println("Added   Methods "+TreeNode.addedMethods);
+        System.out.println("Ignored Methods "+TreeNode.skippedMethods+" duplicates.");
+        System.out.println("Added   Fields "+TreeNode.addedFields);
+        System.out.println("Ignored Fields "+TreeNode.skippedFields+" duplicates.");
+
+
 
         return root;
     }
@@ -161,7 +169,7 @@ public class Builder {
         node.setWentThroughSettingMembers(true);
 
         Map<String, MethodInfo> existingMethods = new HashMap<>();
-        for (MethodInfo mi : node.instanceMethods) {
+        for (MethodInfo mi : node.getInstanceMethods()) {
             existingMethods.put(mi.name + mi.sig, mi);
         }
         NativeMethodDescriptor[] extensionFunctions = ExtensionFunctionsStorage.getInstance().retrieveFunctions(clazz.getClassName()).toArray(new NativeMethodDescriptor[0]);
@@ -228,7 +236,7 @@ public class Builder {
                     if (isStatic) {
                         if (!mi.isExtensionFunction) {
                             mi.declaringType = getOrCreateNode(root, clazz, null);
-                            node.staticMethods.add(mi);
+                            node.addStaticFunction(mi);
                         } else {
                             mi.declaringType = getOrCreateNode(root, ownMethod.getDeclaringClass(), null);
                             node.addExtensionFunction(mi);
@@ -238,13 +246,13 @@ public class Builder {
                         if (existingNodeMethods.containsKey(sig)) {
                             continue;
                         }
-                        node.instanceMethods.add(mi);
+                        node.addInstanceMethod(mi);
                     }
                 }
 
-                if (mi.isResolved) {
-                    node.resolvedMethods.add(mi);
-                }
+                /* if (mi.isResolved) {
+                    node.addResolvedMethod(mi);
+                } */
             }
         }
 
@@ -301,9 +309,9 @@ public class Builder {
                     } else {
                         fi.declaringType = getOrCreateNode(root, clazz, null);
                     }
-                    node.staticFields.add(fi);
+                    node.addStaticField(fi);
                 } else {
-                    node.instanceFields.add(fi);
+                    node.addInstanceField(fi);
                 }
             }
         }

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/Builder.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/Builder.java
@@ -250,9 +250,6 @@ public class Builder {
                     }
                 }
 
-                /* if (mi.isResolved) {
-                    node.addResolvedMethod(mi);
-                } */
             }
         }
 

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/Generator.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/Generator.java
@@ -14,9 +14,12 @@ import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static java.lang.System.exit;
+
 public class Generator {
 
     private static final String VERBOSE_FLAG_NAME = "verbose";
+    private static final String SKIP_FLAG_NAME = "skip";
     private static final String ANALYTICS_ARGUMENT_BEGINNING = "analyticsFilePath=";
     private static final String MDG_OUTPUT_DIR = "mdg-output-dir.txt";
     private static final String MDG_JAVA_DEPENDENCIES = "mdg-java-dependencies.txt";
@@ -61,7 +64,7 @@ public class Generator {
         } catch (Throwable ex) {
             System.err.println(String.format("Error executing Metadata Generator: %s", ex.getMessage()));
             ex.printStackTrace(System.out);
-            System.exit(1);
+            exit(1);
         }
     }
 
@@ -72,6 +75,9 @@ public class Generator {
                 AnalyticsConfiguration.enableAnalytics(filePath);
             } else if (VERBOSE_FLAG_NAME.equals(arg)) {
                 MetadataFilterConsoleLogger.INSTANCE.setEnabled(true);
+            } else if (SKIP_FLAG_NAME.equals(arg)) {
+                System.out.println("Exiting");
+                exit(0);
             }
         }
     }

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/Generator.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/Generator.java
@@ -76,7 +76,7 @@ public class Generator {
             } else if (VERBOSE_FLAG_NAME.equals(arg)) {
                 MetadataFilterConsoleLogger.INSTANCE.setEnabled(true);
             } else if (SKIP_FLAG_NAME.equals(arg)) {
-                System.out.println("Exiting");
+                System.out.println("Skipping metadata generation: skip flag used.");
                 exit(0);
             }
         }

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/TreeNode.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/TreeNode.java
@@ -10,6 +10,13 @@ import java.util.List;
 import java.util.Optional;
 
 public class TreeNode {
+    public static int skippedMethods=0;
+    public static int skippedProperties=0;
+    public static int skippedFields=0;
+    public static int addedMethods=0;
+    public static int addedProperties=0;
+    public static int addedFields=0;
+
     public static class MethodInfo {
         public MethodInfo(NativeMethodDescriptor m) {
             this.name = m.getName();
@@ -97,7 +104,7 @@ public class TreeNode {
         staticFields = new ArrayList<>();
         properties = new ArrayList<>();
         extensionFunctions = new ArrayList<>();
-        resolvedMethods = new ArrayList<>();
+        //resolvedMethods = new ArrayList<>();
     }
 
     public static final TreeNode BYTE = getPrimitive("B", (byte) 1);
@@ -222,40 +229,155 @@ public class TreeNode {
     //
     public TreeNode arrayElement;
     //
-    public ArrayList<MethodInfo> instanceMethods;
-    public ArrayList<MethodInfo> staticMethods;
-    public ArrayList<FieldInfo> instanceFields;
-    public ArrayList<FieldInfo> staticFields;
-    ArrayList<PropertyInfo> properties;
-    ArrayList<MethodInfo> extensionFunctions;
-    ArrayList<MethodInfo> resolvedMethods;
+    private ArrayList<MethodInfo> instanceMethods;
+    private ArrayList<MethodInfo> staticMethods;
+    private ArrayList<FieldInfo> instanceFields;
+    private ArrayList<FieldInfo> staticFields;
+    private ArrayList<PropertyInfo> properties;
+    private ArrayList<MethodInfo> extensionFunctions;
+    //private ArrayList<MethodInfo> resolvedMethods;
     public TreeNode baseClassNode;
     TreeNode parentNode;
     //
 
     void addProperty(PropertyInfo propertyInfo) {
+        for (int i=0;i<properties.size();i++) {
+            PropertyInfo pi = properties.get(i);
+            if (pi.propertyName.equals(propertyInfo.propertyName)) {
+                if (pi.getterMethod != null || propertyInfo.getterMethod != null) {
+                    if (pi.getterMethod != null && propertyInfo.getterMethod != null) {
+                        if (pi.getterMethod.sig != propertyInfo.getterMethod.sig) {
+                            continue;
+                        }
+                    } else {
+                        continue;
+                    }
+                }
+                if (pi.setterMethod != null || propertyInfo.setterMethod != null) {
+                    if (pi.setterMethod != null && propertyInfo.setterMethod != null) {
+                        if (pi.setterMethod.sig != propertyInfo.setterMethod.sig) {
+                            continue;
+                        }
+                    } else {
+                        continue;
+                    }
+                }
+                skippedProperties++;
+                return;
+            }
+        }
         properties.add(propertyInfo);
+        addedProperties++;
+    }
+
+    void addStaticField(FieldInfo fieldInfo) {
+        for (int i=0;i<staticFields.size();i++) {
+            FieldInfo fi = staticFields.get(i);
+            if (fi.name.equals(fieldInfo.name) && fi.isFinalType == fieldInfo.isFinalType) {
+                if (fi.declaringType == fieldInfo.declaringType && fi.valueType == fieldInfo.valueType) {
+                    skippedFields++;
+                    return;
+                }
+            }
+        }
+        staticFields.add(fieldInfo);
+        addedFields++;
+    }
+
+
+    void addInstanceField(FieldInfo fieldInfo) {
+        for (int i=0;i<instanceFields.size();i++) {
+            FieldInfo fi = instanceFields.get(i);
+            if (fi.name.equals(fieldInfo.name) && fi.isFinalType == fieldInfo.isFinalType) {
+                if (fi.declaringType == fieldInfo.declaringType && fi.valueType == fieldInfo.valueType) {
+                    skippedFields++;
+                    return;
+                }
+            }
+        }
+        instanceFields.add(fieldInfo);
+        addedFields++;
     }
 
     void addExtensionFunction(MethodInfo methodInfo) {
+        for (int i=0;i<extensionFunctions.size();i++) {
+            MethodInfo mi = extensionFunctions.get(i);
+            if (mi.name.equals(methodInfo.name) && mi.sig.equals(methodInfo.sig)) {
+                if (mi.isResolved == methodInfo.isResolved) {
+                    if (mi.declaringType == methodInfo.declaringType) {
+                        skippedMethods++;
+                        return;
+                    }
+                }
+            }
+        }
         extensionFunctions.add(methodInfo);
+        addedMethods++;
+    }
+
+    void addStaticFunction(MethodInfo methodInfo) {
+        for (int i=0;i<staticMethods.size();i++) {
+            MethodInfo mi = staticMethods.get(i);
+            if (mi.name.equals(methodInfo.name) && mi.sig.equals(methodInfo.sig)) {
+                if (mi.isResolved == methodInfo.isResolved) {
+                    if (mi.declaringType == methodInfo.declaringType) {
+                        skippedMethods++;
+                        return;
+                    }
+                }
+            }
+        }
+        this.staticMethods.add(methodInfo);
+        addedMethods++;
+    }
+
+    void addInstanceMethod(MethodInfo methodInfo) {
+        for (int i=0;i<instanceMethods.size();i++) {
+            MethodInfo mi = instanceMethods.get(i);
+            if (mi.name.equals(methodInfo.name) && mi.sig.equals(methodInfo.sig)) {
+                if (mi.isResolved == methodInfo.isResolved) {
+                    if (mi.declaringType == methodInfo.declaringType) {
+                        skippedMethods++;
+                        return;
+                    }
+                }
+            }
+        }
+        instanceMethods.add(methodInfo);
+        addedMethods++;
     }
 
     List<PropertyInfo> getProperties() {
         return properties;
     }
 
+    List<FieldInfo> getInstanceFields() {
+        return instanceFields;
+    }
+
+    List<FieldInfo> getStaticFields() {
+        return staticFields;
+    }
+
     List<MethodInfo> getExtensionFunctions() {
         return extensionFunctions;
     }
 
-    void addResolvedMethod(MethodInfo resolvedMethod) {
+    List<MethodInfo> getInstanceMethods() {
+        return instanceMethods;
+    }
+
+    List<MethodInfo> getStaticMethods() {
+        return staticMethods;
+    }
+
+/*    void addResolvedMethod(MethodInfo resolvedMethod) {
         resolvedMethods.add(resolvedMethod);
     }
 
     List<MethodInfo> getResolvedMethods() {
         return resolvedMethods;
-    }
+    } */
 
     private boolean wentThroughSettingMembers = false;
 

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/TreeNode.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/TreeNode.java
@@ -104,7 +104,6 @@ public class TreeNode {
         staticFields = new ArrayList<>();
         properties = new ArrayList<>();
         extensionFunctions = new ArrayList<>();
-        //resolvedMethods = new ArrayList<>();
     }
 
     public static final TreeNode BYTE = getPrimitive("B", (byte) 1);
@@ -235,7 +234,6 @@ public class TreeNode {
     private ArrayList<FieldInfo> staticFields;
     private ArrayList<PropertyInfo> properties;
     private ArrayList<MethodInfo> extensionFunctions;
-    //private ArrayList<MethodInfo> resolvedMethods;
     public TreeNode baseClassNode;
     TreeNode parentNode;
     //
@@ -370,14 +368,6 @@ public class TreeNode {
     List<MethodInfo> getStaticMethods() {
         return staticMethods;
     }
-
-/*    void addResolvedMethod(MethodInfo resolvedMethod) {
-        resolvedMethods.add(resolvedMethod);
-    }
-
-    List<MethodInfo> getResolvedMethods() {
-        return resolvedMethods;
-    } */
 
     private boolean wentThroughSettingMembers = false;
 

--- a/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/Writer.java
+++ b/test-app/build-tools/android-metadata-generator/src/src/com/telerik/metadata/Writer.java
@@ -123,14 +123,16 @@ public class Writer {
             writeTreeNodeId(extensionFunction.declaringType, writer);
         }
 
-        int len = writeLength(n.instanceMethods.size(), writer);
+        List<MethodInfo> instanceMethods = n.getInstanceMethods();
+        int len = writeLength(instanceMethods.size(), writer);
         for (int i = 0; i < len; i++) {
-            writeMethodInfo(n.instanceMethods.get(i), stringsMap, writer);
+            writeMethodInfo(instanceMethods.get(i), stringsMap, writer);
         }
 
-        len = writeLength(n.instanceFields.size(), writer);
+        List<FieldInfo> instanceFields = n.getInstanceFields();
+        len = writeLength(instanceFields.size(), writer);
         for (int i = 0; i < len; i++) {
-            FieldInfo fi = n.instanceFields.get(i);
+            FieldInfo fi = instanceFields.get(i);
             int pos = stringsMap.get(fi.name).intValue(); // get start position
             // of the name
             writeInt(pos, writer); // write start position of the name of the
@@ -168,16 +170,18 @@ public class Writer {
             }
         }
 
-        len = writeLength(n.staticMethods.size(), writer);
+        List<MethodInfo> staticMethods = n.getStaticMethods();
+        len = writeLength(staticMethods.size(), writer);
         for (int i = 0; i < len; i++) {
-            MethodInfo mi = n.staticMethods.get(i);
+            MethodInfo mi = staticMethods.get(i);
             writeMethodInfo(mi, stringsMap, writer);
             writeTreeNodeId(mi.declaringType, writer);
         }
 
-        len = writeLength(n.staticFields.size(), writer);
+        List<FieldInfo> staticFields = n.getStaticFields();
+        len = writeLength(staticFields.size(), writer);
         for (int i = 0; i < len; i++) {
-            FieldInfo fi = n.staticFields.get(i);
+            FieldInfo fi = staticFields.get(i);
             int pos = stringsMap.get(fi.name).intValue();
             writeInt(pos, writer);
             writeTreeNodeId(fi.valueType, writer);
@@ -222,26 +226,30 @@ public class Writer {
 
             if (((n.nodeType & TreeNode.Interface) == TreeNode.Interface)
                     || ((n.nodeType & TreeNode.Class) == TreeNode.Class)) {
-                for (int i = 0; i < n.instanceMethods.size(); i++) {
-                    name = n.instanceMethods.get(i).name;
+                List<MethodInfo> instanceMethods = n.getInstanceMethods();
+                for (int i = 0; i < instanceMethods.size(); i++) {
+                    name = instanceMethods.get(i).name;
                     if (!uniqueStrings.containsKey(name)) {
                         writeUniqueName(name, uniqueStrings, outStringsStream);
                     }
                 }
-                for (int i = 0; i < n.staticMethods.size(); i++) {
-                    name = n.staticMethods.get(i).name;
+                List<MethodInfo> staticMethods = n.getStaticMethods();
+                for (int i = 0; i < staticMethods.size(); i++) {
+                    name = staticMethods.get(i).name;
                     if (!uniqueStrings.containsKey(name)) {
                         writeUniqueName(name, uniqueStrings, outStringsStream);
                     }
                 }
-                for (int i = 0; i < n.instanceFields.size(); i++) {
-                    name = n.instanceFields.get(i).name;
+                List<FieldInfo> instanceFields = n.getInstanceFields();
+                for (int i = 0; i < instanceFields.size(); i++) {
+                    name = instanceFields.get(i).name;
                     if (!uniqueStrings.containsKey(name)) {
                         writeUniqueName(name, uniqueStrings, outStringsStream);
                     }
                 }
-                for (int i = 0; i < n.staticFields.size(); i++) {
-                    name = n.staticFields.get(i).name;
+                List<FieldInfo> staticFields = n.getStaticFields();
+                for (int i = 0; i < staticFields.size(); i++) {
+                    name = staticFields.get(i).name;
                     if (!uniqueStrings.containsKey(name)) {
                         writeUniqueName(name, uniqueStrings, outStringsStream);
                     }


### PR DESCRIPTION
Fix for extra MetaData duplication and invalid rehydration with Kotlinn extensions if more than one method with the same name exists.

### Description
Kotlin extensions can cause issues with hiding metadata.   When upgrading to a later version of the Kotlin core this can easily be triggered.

### Commit fixes these
Closes NativeScript/NativeScript#8113
Closes NativeScript/NativeScript#8709



