### PR TITLE
fix: build.gradle & kotlinVersion

### DIFF
--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -7,6 +7,13 @@ buildscript {
         apply from: "$rootDir/gradle-helpers/user_properties_reader.gradle"
         apply from: "$rootDir/gradle-helpers/paths.gradle"
         rootProject.ext.userDefinedGradleProperties = getUserProperties("${getAppResourcesPath(userDir)}/Android")
+        if (rootProject.hasProperty("userDefinedGradleProperties")) {
+            rootProject.ext.userDefinedGradleProperties.each { entry ->
+                def propertyName = entry.getKey()
+                def propertyValue = entry.getValue()
+                project.ext.set(propertyName, propertyValue)
+            }
+        }
     }
     initialize()
 


### PR DESCRIPTION
Fix for Ticket 781

---

Not sure if it was broken from a change in Gradle Versions; but the "BeforeEvaluate"  function does NOT get called before the setting of the `kotlinVersion` in the top group.  So any external properties set in `gradle.properties` are NOT set at the point we check for it.   Copying the code to the top section in the `initialize` fixes the issue, additional tests will need to be done to see if we can just remove the beforeEvaluate section without any negative side effects.   (So leaving that for now, as worst case is it re-assigns the same value to the same key).

