### PR TITLE
fix: update to jsparser

### DIFF
--- a/test-app/build-tools/jsparser/js_parser.js
+++ b/test-app/build-tools/jsparser/js_parser.js
@@ -20,8 +20,8 @@ loggingSettings = {
 };
 
 var fs = require("fs"),
-    babelParser = require("babylon"),
-    traverse = require("babel-traverse"),
+    babelParser = require("@babel/parser"),
+    traverse = require("@babel/traverse"),
     split = require('split'),
     logger = require('./helpers/logger')(loggingSettings),
     path = require("path"),
@@ -132,7 +132,7 @@ function getFileAst(tsHelpersFilePath) {
 
             var ast = babelParser.parse(fileContent, {
                 minify: false,
-                plugins: ["decorators"]
+                plugins: [["@babel/plugin-proposal-decorators", {decoratorsBeforeExport:true}]]
             });
 
 
@@ -225,7 +225,7 @@ var astFromFileContent = function (path, data, err) {
 
         var ast = babelParser.parse(data.data, {
             minify: false,
-            plugins: ["decorators", "objectRestSpread"]
+            plugins: [["@babel/plugin-proposal-decorators", {decoratorsBeforeExport:true}], "objectRestSpread"]
         });
         data.ast = ast;
         return resolve(data);

--- a/test-app/build-tools/jsparser/package.json
+++ b/test-app/build-tools/jsparser/package.json
@@ -10,9 +10,10 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "babel-traverse": "6.26.0",
-    "babel-types": "6.26.0",
-    "babylon": "6.18.0",
+    "@babel/traverse": "~7.13.17",
+    "@babel/types": "~7.13.17",
+    "@babel/parser": "7.13.16",
+    "@babel/plugin-proposal-decorators":"7.13.15",
     "split": "1.0.1"
   },
   "repository": "https://github.com/NativeScript/android-runtime",

--- a/test-app/build-tools/jsparser/visitors/es5-visitors.js
+++ b/test-app/build-tools/jsparser/visitors/es5-visitors.js
@@ -1,6 +1,6 @@
 var es5_visitors = (function() {
 
-    var types = require("babel-types"),
+    var types = require("@babel/types"),
 
         defaultExtendDecoratorName = "JavaProxy",
         columnOffset = 1,


### PR DESCRIPTION
this fixes some parsing issues with esm code (await for example)

While updating some npm deps, i realized jsparser was failing. And it was very outdated!
Now it works.
BTW could we please enable jsparser logging by default? errors are not printed without it. And then it gets really cryptic on why the app wont work at runtime.
My suggestion:
* stop build on jsparser error (not the case when jsparser ast parsing fails)
* log jsparser errors