### PR TITLE
fix: allow to pass custom ndkVersion to the runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,11 @@ import groovy.json.JsonOutput
 
 def onlyX86 = project.hasProperty("onlyX86")
 def useCCache = !project.hasProperty("noCCache")
+def hasNdkVersion = project.hasProperty("ndkVersion")
+
+if (hasNdkVersion) {
+    println "Using NDK version " + ndkVersion
+}
 
 def isWinOs = System.properties['os.name'].toLowerCase().contains('windows')
 def pVersion = "no package version was provided by build.gradle build"
@@ -184,6 +189,9 @@ def getAssembleReleaseBuildArguments = { ->
     }
     if (useCCache) {
         arguments.add("-PuseCCache")
+    }
+    if (hasNdkVersion) {
+        arguments.add("-PndkVersion="+ndkVersion)
     }
     arguments += ["--warning-mode", "all"]
     return arguments

--- a/test-app/runtime/build.gradle
+++ b/test-app/runtime/build.gradle
@@ -22,6 +22,14 @@ if (useCCache) {
 
 project.ext._buildToolsVersion = "30.0.1"
 
+
+def hasNdkVersion = project.hasProperty("ndkVersion")
+if (hasNdkVersion) {
+    println "Runtime using NDK version " + ndkVersion
+}
+
+
+
 android {
     sourceSets {
         main {
@@ -34,6 +42,10 @@ android {
     }
     compileSdkVersion 30
     buildToolsVersion project.ext._buildToolsVersion
+
+    if (hasNdkVersion) {
+        ndkVersion ndkVersion
+    }
 
     defaultConfig {
         minSdkVersion 17


### PR DESCRIPTION
@FestplattenSchnitzel This answer the need for this PR https://github.com/NativeScript/android-runtime/pull/1670

Instead of fixing the version i went for allowing to set it through command line.
You can then build the android runtime like this:
`./gradlew -PndkVersion=20.1.5948944`

@FestplattenSchnitzel why version 20.x and not 21.x ? I understand 22 might be too new but 21 should be good, right?
I just want to make sure we use a recent ndk for the runtime. I dont want any crash to appear on f-droid as we would be using an old ndk (which the dev would not know about as he builds with a newer one)