### PR TITLE
feat: expose `PerformMicrotaskCheckpoint`

### DIFF
--- a/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.cpp
@@ -677,6 +677,23 @@ void CallbackHandlers::LogMethodCallback(const v8::FunctionCallbackInfo<v8::Valu
     }
 }
 
+void CallbackHandlers::DrainMicrotaskCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
+    try {
+        auto isolate = args.GetIsolate();
+        isolate->PerformMicrotaskCheckpoint();
+    } catch (NativeScriptException& e) {
+        e.ReThrowToV8();
+    } catch (std::exception e) {
+        stringstream ss;
+        ss << "Error: c++ exception: " << e.what() << endl;
+        NativeScriptException nsEx(ss.str());
+        nsEx.ReThrowToV8();
+    } catch (...) {
+        NativeScriptException nsEx(std::string("Error: c++ exception!"));
+        nsEx.ReThrowToV8();
+    }
+}
+
 void CallbackHandlers::TimeCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
     auto nano = std::chrono::time_point_cast<std::chrono::milliseconds>(
                     std::chrono::system_clock::now());

--- a/test-app/runtime/src/main/cpp/CallbackHandlers.h
+++ b/test-app/runtime/src/main/cpp/CallbackHandlers.h
@@ -80,6 +80,8 @@ namespace tns {
         static void
         DumpReferenceTablesMethodCallback(const v8::FunctionCallbackInfo<v8::Value> &args);
 
+        static void DrainMicrotaskCallback(const v8::FunctionCallbackInfo<v8::Value>& args);
+
         static void DumpReferenceTablesMethod();
 
         static void ExitMethodCallback(const v8::FunctionCallbackInfo<v8::Value> &args);

--- a/test-app/runtime/src/main/cpp/Runtime.cpp
+++ b/test-app/runtime/src/main/cpp/Runtime.cpp
@@ -616,6 +616,7 @@ Isolate* Runtime::PrepareV8Runtime(const string& filesPath, const string& native
 
     globalTemplate->Set(ArgConverter::ConvertToV8String(isolate, "__log"), FunctionTemplate::New(isolate, CallbackHandlers::LogMethodCallback));
     globalTemplate->Set(ArgConverter::ConvertToV8String(isolate, "__dumpReferenceTables"), FunctionTemplate::New(isolate, CallbackHandlers::DumpReferenceTablesMethodCallback));
+    globalTemplate->Set(ArgConverter::ConvertToV8String(isolate, "__drainMicrotaskQueue"), FunctionTemplate::New(isolate, CallbackHandlers::DrainMicrotaskCallback));
     globalTemplate->Set(ArgConverter::ConvertToV8String(isolate, "__enableVerboseLogging"), FunctionTemplate::New(isolate, CallbackHandlers::EnableVerboseLoggingMethodCallback));
     globalTemplate->Set(ArgConverter::ConvertToV8String(isolate, "__disableVerboseLogging"), FunctionTemplate::New(isolate, CallbackHandlers::DisableVerboseLoggingMethodCallback));
     globalTemplate->Set(ArgConverter::ConvertToV8String(isolate, "__exit"), FunctionTemplate::New(isolate, CallbackHandlers::ExitMethodCallback));


### PR DESCRIPTION
Expose `PerformMicrotaskCheckpoint` as `__drainMicrotaskQueue`, which allows us to stabilize the runtime when needed (like when you need a synchronous return to a native function that is being handled in a microtask)
