### PR TITLE
fix: apply before-plugins before checking versions

### DIFF
--- a/test-app/app/build.gradle
+++ b/test-app/app/build.gradle
@@ -186,6 +186,7 @@ def setAppIdentifier = { ->
 }
 
 android {
+    applyBeforePluginGradleConfiguration()
 
     if (enableKotlin) {
         kotlinOptions {
@@ -242,7 +243,6 @@ android {
     }
 
     setAppIdentifier()
-    applyBeforePluginGradleConfiguration()
     applyPluginGradleConfigurations()
     applyAppGradleConfiguration()
 


### PR DESCRIPTION
We need to apply before-plugins before `computeCompileSdkVersion()` and other. Otherwise user override wont be used