### PR TITLE
fix: Set package version before preReleaseBuild

### DIFF
--- a/test-app/runtime/build.gradle
+++ b/test-app/runtime/build.gradle
@@ -147,7 +147,7 @@ dependencies {
 tasks.whenTaskAdded { task ->
     def taskName = task.getName()
     // println "\t ~ [DEBUG][runtime] build.gradle whenTaskAdded taskName = ${taskName}"
-    if (taskName.contains("externalNativeBuildRelease")) {
+    if (taskName.contains("preReleaseBuild")) {
         setRuntimeCommit.dependsOn(setPackageVersion)
         task.dependsOn(setRuntimeCommit)
     }


### PR DESCRIPTION
Fixes #1715 

⚠️ **This PR might have unintended side effects.**

It's working and has been tested on a demo project, but as I am not really familiar with Gradle files, it may have some side effects.

I invite you to test it with my demo project: https://github.com/sebj54/ns-debug-runtime-version

```
git clone https://github.com/sebj54/android-runtime.git
git clone https://github.com/sebj54/ns-debug-runtime-version.git
cd android-runtime
./gradlew
cd ../ns-debug-runtime-version
npm install ../android-runtime/dist
git checkout package.json
ns run android --release
```

If you run `./gradlew` multiple times, be sure to discard changes in `Version.h` before build:

```
git checkout test-app/runtime/src/main/cpp/Version.h
./gradlew
```

I think it is also mandatory to clean `platforms/android` directory before building the app.