### PR TITLE
feat: add class name to native objects

### DIFF
--- a/test-app/app/src/main/assets/app/tests/tests.js
+++ b/test-app/app/src/main/assets/app/tests/tests.js
@@ -1737,4 +1737,12 @@ describe("Tests ", function () {
             expect(com.tns.tests.LogcatUtil.logcatContainsString(str.slice(0, -1) + "...")).toBe(true);
         });
     }
+	it("should show the correct class name for native object", function () {
+		var obj = new java.lang.Object();
+		expect(java.lang.Object.name).toBe('java.lang.Object');
+		expect(obj.constructor.name).toBe('java.lang.Object');
+		var bool = new java.lang.Boolean(false);
+		expect(java.lang.Boolean.name).toBe('java.lang.Boolean');
+		expect(bool.constructor.name).toBe('java.lang.Boolean');
+	});
 });

--- a/test-app/runtime/src/main/cpp/MetadataNode.cpp
+++ b/test-app/runtime/src/main/cpp/MetadataNode.cpp
@@ -944,6 +944,15 @@ Local<FunctionTemplate> MetadataNode::GetConstructorFunctionTemplate(Isolate* is
     auto isInterface = s_metadataReader.IsNodeTypeInterface(treeNode->type);
     auto funcCallback = isInterface ? InterfaceConstructorCallback : ClassConstructorCallback;
     ctorFuncTemplate = FunctionTemplate::New(isolate, funcCallback, ctorCallbackData);
+    auto currentNode = treeNode;
+    std::string finalName(currentNode->name);
+    while (currentNode->parent) {
+        if (!currentNode->parent->name.empty()) {
+            finalName = currentNode->parent->name + "." + finalName;
+        }
+        currentNode = currentNode->parent;
+    }
+    ctorFuncTemplate->SetClassName(v8::String::NewFromUtf8(isolate, finalName.c_str()).ToLocalChecked());
     ctorFuncTemplate->InstanceTemplate()->SetInternalFieldCount(static_cast<int>(ObjectManager::MetadataNodeKeys::END));
 
     Local<Function> baseCtorFunc;


### PR DESCRIPTION
TODO: tests

this PR adds the class name to the object. Example:


```
const obj = new java.lang.Boolean();
console.log(obj.constructor.name); // java.lang.Boolean
```