### PR TITLE
fix: Added missing additional_gradle copy rule

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -296,6 +296,10 @@ task copyFilesToProjectTemeplate {
             into "$DIST_FRAMEWORK_PATH/app"
         }
         copy {
+            from "$TEST_APP_PATH/additional_gradle.properties"
+            into "$DIST_FRAMEWORK_PATH"
+        }
+        copy {
             from "$TEST_APP_PATH/build.gradle"
             into "$DIST_FRAMEWORK_PATH"
         }


### PR DESCRIPTION
### Description

We added `additional_gradle.properties` during 8.3.0 update but did not include it in build procedure.
This is needed in package release as `build.gradle` is trying to load it: https://github.com/NativeScript/android-runtime/blob/master/test-app/build.gradle#L21

File: https://github.com/NativeScript/android-runtime/blob/master/test-app/additional_gradle.properties